### PR TITLE
Add Prout, so we can see when our pull requests go out

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,0 +1,5 @@
+{
+  "checkpoints": {
+    "PROD": { "url": "https://subscribe.theguardian.com.origin.membership.guardianapis.com/", "overdue": "14M", "disableSSLVerification": true }
+  }
+}

--- a/app/views/fragments/footer.scala.html
+++ b/app/views/fragments/footer.scala.html
@@ -8,6 +8,7 @@
 </div>
 <div class="global-footer">
     <div class="gs-container">
-        <div class="really-serious-copyright">© @{new DateTime().year.getAsText} Guardian News and Media Limited or its affiliated companies. All rights reserved.</div>
+        <div class="really-serious-copyright">© @{new DateTime().year.getAsText} Guardian News and Media Limited or its affiliated companies. All rights reserved. Build #@app.BuildInfo.buildNumber</div>
+        <!-- build-commit-id: @app.BuildInfo.gitCommitId -->
     </div>
 </div>

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,9 @@ lazy val root = (project in file(".")).enablePlugins(
   magentaPackageName := name.value,
   buildInfoKeys := Seq[BuildInfoKey](
     name,
+    BuildInfoKey.constant("gitCommitId", Option(System.getenv("BUILD_VCS_NUMBER")) getOrElse(try {
+      "git rev-parse HEAD".!!.trim
+    } catch { case e: Exception => "unknown" })),
     BuildInfoKey.constant("buildNumber", Option(System.getenv("BUILD_NUMBER")) getOrElse "DEV"),
     BuildInfoKey.constant("buildTime", System.currentTimeMillis)
   ),


### PR DESCRIPTION
http://www.theguardian.com/info/developer-blog/2015/feb/03/prout-is-your-pull-request-out
https://github.com/guardian/prout

cc @jennysivapalan 