### PR TITLE
Updated savings percentages on paper and paper plus digital pages

### DIFF
--- a/app/views/shipping/index.scala.html
+++ b/app/views/shipping/index.scala.html
@@ -65,7 +65,7 @@
                                 <input class="package__select" type="radio" name="package" id="everyday" value="collection-paper-digital-everyday" checked>
                                 <label class="package__info" for="everyday">
                                     <span class="package__title">EVERYDAY+</span> <strong class="package__price">
-                                    &pound;10.99 per week &mdash; save 52%</strong>
+                                    &pound;10.99 per week &mdash; save 54%</strong>
                                     <span class="package__description">
                                         Guardian and Observer papers, plus tablet editions and Premium mobile access</span>
                                     <span class="package__monthly">Monthly price <strong>&pound;47.62</strong></span>
@@ -75,7 +75,7 @@
                                 <input class="package__select" type="radio" name="package" id="sixday" value="collection-paper-digital-sixday">
                                 <label class="package__info" for="sixday">
                                     <span class="package__title">SIXDAY+</span> <strong class="package__price">
-                                    &pound;9.99 per week &mdash; save 50%</strong>
+                                    &pound;9.99 per week &mdash; save 53%</strong>
                                     <span class="package__description">
                                         Guardian papers, plus tablet editions and Premium mobile access</span>
                                     <span class="package__monthly">Monthly price <strong>&pound;43.29</strong></span>
@@ -106,7 +106,7 @@
                                 <input class="package__select" type="radio" name="package" id="everyday" value="collection-paper-everyday" checked>
                                 <label class="package__info" for="everyday">
                                     <span class="package__title">EVERYDAY</span> <strong class="package__price">
-                                    &pound;9.99 per week &mdash; save 25%</strong>
+                                    &pound;9.99 per week &mdash; save 32%</strong>
                                     <span class="package__description">Guardian and Observer papers</span>
                                     <span class="package__monthly">Monthly price <strong>&pound;43.29</strong></span>
                                 </label>
@@ -115,7 +115,7 @@
                                 <input class="package__select" type="radio" name="package" id="sixday" value="collection-paper-sixday">
                                 <label class="package__info" for="sixday">
                                     <span class="package__title">SIXDAY</span> <strong class="package__price">
-                                    &pound;8.49 per week &mdash; save 19%</strong>
+                                    &pound;8.49 per week &mdash; save 27%</strong>
                                     <span class="package__description">Guardian papers</span>
                                     <span class="package__monthly">Monthly price <strong>&pound;36.79</strong></span>
                                 </label>
@@ -124,7 +124,7 @@
                                 <input class="package__select" type="radio" name="package" id="weekend" value="collection-paper-weekend">
                                 <label class="package__info" for="weekend">
                                     <span class="package__title">WEEKEND</span> <strong class="package__price">
-                                    &pound;4.49 per week &mdash; save 17%</strong>
+                                    &pound;4.49 per week &mdash; save 20%</strong>
                                     <span class="package__description">Saturday Guardian and Observer papers</span>
                                     <span class="package__monthly">Monthly price <strong>&pound;19.46</strong></span>
                                 </label>


### PR DESCRIPTION
 The savings percentages required updating (since price rise) on the the Paper + digital and Paper pages.
:newspaper: :computer:   