### PR TITLE
Added Sentry configuration.

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,4 +1,10 @@
 import filters.CheckCacheHeadersFilter
+import monitoring.SentryLogging
+import play.api.Application
 import play.api.mvc.WithFilters
 
-object Global extends WithFilters(CheckCacheHeadersFilter)
+object Global extends WithFilters(CheckCacheHeadersFilter) {
+  override def onStart(app: Application) {
+    SentryLogging.init()
+  }
+}

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -2,6 +2,9 @@ package configuration
 
 import com.gu.googleauth.GoogleAuthConfig
 import com.typesafe.config.ConfigFactory
+import net.kencochrane.raven.dsn.Dsn
+
+import scala.util.Try
 
 object Config {
   val googleAuthConfig = {
@@ -19,4 +22,7 @@ object Config {
 
   val stage = config.getString("stage")
   val stageProd: Boolean = stage == "PROD"
+
+  lazy val sentryDsn = Try(new Dsn(config.getString("sentry.dsn")))
+
 }

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -23,6 +23,6 @@ object Config {
   val stage = config.getString("stage")
   val stageProd: Boolean = stage == "PROD"
 
-  lazy val sentryDsn = Try(new Dsn(config.getString("sentry.dsn")))
+  val sentryDsn = Try(new Dsn(config.getString("sentry.dsn")))
 
 }

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -1,0 +1,37 @@
+package monitoring
+
+import ch.qos.logback.classic.filter.ThresholdFilter
+import ch.qos.logback.classic.{Logger, LoggerContext}
+import configuration.Config
+import net.kencochrane.raven.RavenFactory
+import net.kencochrane.raven.logback.SentryAppender
+import org.slf4j.Logger.ROOT_LOGGER_NAME
+import org.slf4j.LoggerFactory
+
+import scala.util.{Failure, Success}
+
+object SentryLogging {
+
+  def init() {
+    Config.sentryDsn match {
+      case Failure(ex) =>
+        play.api.Logger.warn("No Sentry logging configured (OK for dev)", ex)
+      case Success(dsn) =>
+        play.api.Logger.info(s"Initialising Sentry logging for ${dsn.getHost}")
+        val buildInfo: Map[String, Any] = app.BuildInfo.toMap
+        val tags = Map("stage" -> Config.stage) ++ buildInfo
+        val tagsString = tags.map { case (key, value) => s"$key:$value"}.mkString(",")
+
+        val filter = new ThresholdFilter { setLevel("ERROR") }
+        filter.start() // OMG WHY IS THIS NECESSARY LOGBACK?
+
+        val sentryAppender = new SentryAppender(RavenFactory.ravenInstance(dsn)) {
+          addFilter(filter)
+          setTags(tagsString)
+          setContext(LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext])
+        }
+        sentryAppender.start()
+        LoggerFactory.getLogger(ROOT_LOGGER_NAME).asInstanceOf[Logger].addAppender(sentryAppender)
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,9 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   "com.gu" %% "play-googleauth" % "0.2.1",
-  "com.github.nscala-time" %% "nscala-time" % "2.0.0"
+  "com.github.nscala-time" %% "nscala-time" % "2.0.0",
+  "net.kencochrane.raven" % "raven-logback" % "6.0.0"
+
 )
 
 javaOptions in Test += "-Dconfig.file=test/conf/application.conf"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ lazy val root = (project in file(".")).enablePlugins(
     BuildInfoKey.constant("buildNumber", Option(System.getenv("BUILD_NUMBER")) getOrElse "DEV"),
     BuildInfoKey.constant("buildTime", System.currentTimeMillis)
   ),
-  buildInfoPackage := "app"
+  buildInfoPackage := "app",
+  buildInfoOptions += BuildInfoOption.ToMap
 )
 
 scalaVersion := "2.11.6"


### PR DESCRIPTION
Based on implementation from Membership: https://github.com/guardian/membership-old/pull/876/files (N.B. note this a reference to the old repo).

There is new project / team in Sentry. @rtyley you should have access straight away but @tudorraul you'll need to become a member. I don't have powers to invite you but @rtyley might be.

I've updated the prod configuration with the sentry.dsn value.

:tanabata_tree: :page_with_curl: 