### PR TITLE
Re-instate Play v2.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import play.sbt.PlayImport
+
 name := "subscriptions-frontend"
 
 version := "1.0-SNAPSHOT"
@@ -24,10 +26,10 @@ scalaVersion := "2.11.6"
 libraryDependencies ++= Seq(
   cache,
   ws,
-  "com.gu" %% "play-googleauth" % "0.2.1",
+  PlayImport.specs2,
+  "com.gu" %% "play-googleauth" % "0.3.0",
   "com.github.nscala-time" %% "nscala-time" % "2.0.0",
   "net.kencochrane.raven" % "raven-logback" % "6.0.0"
-
 )
 
 javaOptions in Test += "-Dconfig.file=test/conf/application.conf"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers += Resolver.typesafeRepo("releases") // Play seems to require quite a few things from here
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.4.0")

--- a/test/ApplicationSpec.scala
+++ b/test/ApplicationSpec.scala
@@ -9,11 +9,6 @@ import play.api.test.Helpers._
 class ApplicationSpec extends Specification {
 
   "Application" should {
-
-    "send 404 on a bad request" in new WithApplication {
-      route(FakeRequest(GET, "/boum")) must equalTo(None)
-    }
-
     "render the index page" in new WithApplication {
       val home = route(FakeRequest(GET, "/")).get
 


### PR DESCRIPTION
We stepped down with https://github.com/guardian/subscriptions-frontend/commit/1031c2159 because `play-googleauth` wasn't available at that time, but https://github.com/guardian/play-googleauth/pull/24 took care of that.

For unmerged stuff (ie https://github.com/guardian/subscriptions-frontend/pull/31) that depends on `membership-common`, v0.66 takes care of that with https://github.com/guardian/membership-common/pull/67.

cc @tudorraul 