### PR TITLE
Add 404 and 500 error pages

### DIFF
--- a/app/monitoring/ErrorHandler.scala
+++ b/app/monitoring/ErrorHandler.scala
@@ -1,0 +1,32 @@
+package monitoring
+
+import javax.inject._
+
+import controllers.{Cached, NoCache}
+import play.api._
+import play.api.http.DefaultHttpErrorHandler
+import play.api.mvc.Results._
+import play.api.mvc._
+import play.api.routing.Router
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent._
+
+class ErrorHandler @Inject() (
+                               env: Environment,
+                               config: Configuration,
+                               sourceMapper: OptionalSourceMapper,
+                               router: Provider[Router]
+                               ) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) {
+
+  override def onClientError(request: RequestHeader, statusCode: Int, message: String = ""): Future[Result] = {
+    super.onClientError(request, statusCode, message).map(Cached(_))
+  }
+
+  override protected def onNotFound(request: RequestHeader, message: String): Future[Result] = {
+    Future.successful(Cached(NotFound(views.html.error404())))
+  }
+
+  override protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] =
+    Future.successful(NoCache(InternalServerError(views.html.error500(exception))))
+}

--- a/app/views/error404.scala.html
+++ b/app/views/error404.scala.html
@@ -1,0 +1,9 @@
+@main(title = "Page not found") {
+    <div class="gs-container">
+        @fragments.page.header("Error 404", Some("Page not found"))
+
+        <div class="row">
+            <p>Sorry, this page does not exist.</p>
+        </div>
+    </div>
+}

--- a/app/views/error500.scala.html
+++ b/app/views/error500.scala.html
@@ -1,0 +1,17 @@
+@(ex: Throwable)
+@main("Internal Server Error") {
+    <div class="gs-container">
+        @fragments.page.header("Error 500", Some("There was an error on this page"))
+
+        <div class="row">
+            <p>
+              Sorry, there was an error on this page. We're aware of the problem. If this error persists, please contact
+              support on <a href="mailto:subscriptions.dev@@theguardian.com">subscriptions.dev@@theguardian.com</a>.
+            </p>
+            @ex match { case err: play.api.UsefulException =>
+            <p>Please provide the following error code to help identify the issue.</p>
+            <pre>Error code: @err.id</pre>
+            }
+        </div>
+    </div>
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -21,4 +21,6 @@ google.oauth {
   callback=""
 }
 
+play.http.errorHandler = "monitoring.ErrorHandler"
+
 include file("/etc/gu/subscriptions-frontend.conf")


### PR DESCRIPTION
Implement 404 and 500 error pages by reusing the ErrorHandler object from  Membershops.
I have verified the 404 page works fine (see screenshot), however I haven't managed to reproduce the 500 error locally. Is there a way to run Play locally in production mode?

![screen shot 2015-06-18 at 11 25 11](https://cloud.githubusercontent.com/assets/63361/8229287/4470ccc0-15ad-11e5-8dad-aa2ca9e3a6dc.png)
