### PR TITLE
Stop the chatty logging to the console

### DIFF
--- a/conf/logger.xml
+++ b/conf/logger.xml
@@ -1,21 +1,19 @@
 <configuration>
 
+    <contextName>subscriptions-frontend</contextName>
+
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${user.dir}/logs/subscriptions-frontend.log</file>
+        <file>logs/subscriptions-frontend.log</file>
+
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- Daily rollover with compression -->
-            <fileNamePattern>subscriptions-frontend-log-%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/subscriptions-frontend-log-%d{yyyy-MM-dd}.gz</fileNamePattern>
             <!-- keep 30 days worth of history -->
             <maxHistory>30</maxHistory>
         </rollingPolicy>
-        <encoder>
-            <pattern>%date{yyyy-MM-dd HH:mm:ss ZZZZ} [%level] from %logger in %thread - %message%n%xException</pattern>
-        </encoder>
-    </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
         </encoder>
     </appender>
 
@@ -23,7 +21,4 @@
         <appender-ref ref="FILE"/>
     </root>
 
-    <root level="ERROR">
-        <appender-ref ref="STDOUT"/>
-    </root>
 </configuration>


### PR DESCRIPTION
Some other tweaks, copying the log format pattern from Membership, etc:

https://github.com/guardian/membership-frontend/blob/4d14bc326/frontend/conf/application-logger.xml

cc @jennysivapalan @tudorraul 