### PR TITLE
Replace obsoleted `-mem` parameter with `-J-Xmx512m`

### DIFF
--- a/conf/upstart.conf
+++ b/conf/upstart.conf
@@ -23,5 +23,5 @@ limit nofile 65536 65536
 respawn
 
 script
-  "/subscriptions/subscriptions-frontend-1.0-SNAPSHOT/bin/subscriptions-frontend" -mem 512 -Dconfig.resource=__STAGE.conf > $LOGFILE 2>&1
+  "/subscriptions/subscriptions-frontend-1.0-SNAPSHOT/bin/subscriptions-frontend" -J-Xmx512m -Dconfig.resource=__STAGE.conf > $LOGFILE 2>&1
 end script


### PR DESCRIPTION
Apparently `sbt-native-packager` removed the `-mem` parameter with https://github.com/sbt/sbt-native-packager/commit/62362c2377 - so if you look in a subscriptions box, you see this in `/subscriptions/stdout.log`:

```
!! WARNING !! -mem option is ignored. Please use -J-Xmx and -J-Xms
```

https://github.com/sbt/sbt-native-packager/issues/82#issuecomment-76723624