### PR TITLE
Rewire checkout service

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -5,7 +5,7 @@ import com.gu.identity.play.{IdUser, PrivateFields}
 import model.{AddressData, PaymentData, PersonalData, SubscriptionData}
 import play.api.libs.json._
 import play.api.mvc._
-import services.IdentityService
+import services.{AuthenticationService, CheckoutService, IdentityService}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -45,6 +45,7 @@ object Checkout extends Controller {
           yield BadRequest(views.html.checkout.payment(formWithErrors, userIsSignedIn = idUserOpt.isDefined))
       },
       userData => {
+        CheckoutService.processSubscription(userData, AuthenticationService.authenticatedUserFor(request))
         Future.successful(Redirect(routes.Checkout.thankyou()))
       }
     )

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -4,7 +4,7 @@
 @import model.JsVars
 @import configuration.Config.Identity._
 
-@disabled = @{ if (userIsSignedIn) "disabled" else "" }
+@readonly = @{ if (userIsSignedIn) "readonly" else "" }
 
 @main(title = "Checkout | Subscriptions | The Guardian",
       jsVars = JsVars.default.copy(userIsSignedIn = userIsSignedIn)) {
@@ -33,19 +33,19 @@
                     <div class="fieldset__fields">
                         <div class="form-field">
                             <label class="label" for="first">First name</label>
-                            <input type="text" class="input-text js-checkout-first" name="personal.first" id="first" value="@form.data.get("personal.first")" @disabled>
+                            <input type="text" class="input-text js-checkout-first" name="personal.first" id="first" value="@form.data.get("personal.first")" @readonly>
                         </div>
                         <div class="form-field">
                             <label class="label" for="last">Last name</label>
-                            <input type="text" class="input-text js-checkout-last" name="personal.last" id="last" value="@form.data.get("personal.last")" @disabled>
+                            <input type="text" class="input-text js-checkout-last" name="personal.last" id="last" value="@form.data.get("personal.last")" @readonly>
                         </div>
                         <div class="form-field">
                             <label class="label" for="email">Email address</label>
-                            <input type="email" class="input-text js-checkout-email" name="personal.emailValidation.email" id="email" value ="@form.data.get("personal.emailValidation.email")" @disabled>
+                            <input type="email" class="input-text js-checkout-email" name="personal.emailValidation.email" id="email" value ="@form.data.get("personal.emailValidation.email")" @readonly>
                         </div>
                         <div class="form-field">
                             <label class="label" for="confirm">Confirm email address</label>
-                            <input type="email" class="input-text" name="personal.emailValidation.confirm" id="confirm" value ="@form.data.get("personal.emailValidation.confirm")" @disabled>
+                            <input type="email" class="input-text" name="personal.emailValidation.confirm" id="confirm" value ="@form.data.get("personal.emailValidation.confirm")" @readonly>
                         </div>
                         <div class="js-checkout-full-address">
                             <div class="form-field">


### PR DESCRIPTION
I had introduced two regressions in my previous PR: @tudorraul @jennysivapalan 

- `CheckoutService` had been accidentally unwired from the controller
- I was using the `disabled` attribute for form inputs, which has the undesirable effect of prevent the field value from being submitted. Replacing it with 'readonly', which seems to work fine. 