### PR TITLE
Convert guest users

### DIFF
--- a/app/actions/OAuthActions.scala
+++ b/app/actions/OAuthActions.scala
@@ -4,7 +4,6 @@ import configuration.Config
 import controllers.routes
 
 object OAuthActions extends com.gu.googleauth.Actions {
-  val authConfig = Config.googleAuthConfig
-
+  val authConfig  = Config.googleAuthConfig
   val loginTarget = routes.OAuth.loginAction()
 }

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -40,7 +40,6 @@ object Config {
 
     val webAppUrl = idConfig.getString("webapp.url")
 
-
     val webAppProfileUrl = webAppUrl / "account" / "edit"
 
     def webAppSigninUrl(path: String): String =

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -15,6 +15,8 @@ object Config {
 
   val config = ConfigFactory.load()
 
+  val playSecret = config.getString("play.crypto.secret")
+
   val googleAuthConfig = {
     val con = ConfigFactory.load().getConfig("google.oauth")
     GoogleAuthConfig(
@@ -37,6 +39,9 @@ object Config {
     val keys = if (idConfig.getBoolean("production.keys")) new ProductionKeys else new PreProductionKeys
 
     val webAppUrl = idConfig.getString("webapp.url")
+
+
+    val webAppProfileUrl = webAppUrl / "account" / "edit"
 
     def webAppSigninUrl(path: String): String =
       (webAppUrl / "signin") ? ("returnUrl" -> absoluteUrl(path)) ? ("skipConfirmation" -> "true")

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -67,7 +67,7 @@ object Checkout extends Controller with LazyLogging {
         BadRequest(views.html.checkout.thankyou(Some(formWithErrors)))
       }
     }, guestAccountData => {
-      IdentityService.convertGuest(guestAccountData.guestUser, guestAccountData.password)
+      IdentityService.convertGuest(guestAccountData.password, IdentityToken(guestAccountData.token))
         .map(_ => Ok(views.html.checkout.alldone()))
     })
   }

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -25,7 +25,7 @@ object Checkout extends Controller with LazyLogging {
         } yield keyName -> field
 
       val form = SubscriptionsForm().copy(
-        data =  (
+        data = (
           idUserData("personal.first", _.firstName) ++
           idUserData("personal.last", _.secondName) ++
           idUserOpt.map("personal.emailValidation.email" -> _.primaryEmailAddress) ++
@@ -34,7 +34,7 @@ object Checkout extends Controller with LazyLogging {
           idUserData("personal.address.address2", _.address2) ++
           idUserData("personal.address.town", _.address3) ++
           idUserData("personal.address.postcode", _.postcode)
-          ).toMap
+        ).toMap
       )
 
       Ok(views.html.checkout.payment(form, userIsSignedIn = idUserOpt.isDefined))

--- a/app/forms/FinishAccountForm.scala
+++ b/app/forms/FinishAccountForm.scala
@@ -1,0 +1,15 @@
+package forms
+
+import model.GuestAccountData
+import services.{IdentityToken, UserId}
+
+object FinishAccountForm {
+  import play.api.data.Forms._
+  import play.api.data._
+
+  def apply(): Form[GuestAccountData] = Form(mapping(
+    "password" -> text(minLength = 6),
+    UserId.paramName -> text,
+    IdentityToken.paramName -> text
+  )(GuestAccountData.apply)(GuestAccountData.unapply))
+}

--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -1,0 +1,46 @@
+package forms
+
+import model.{AddressData, PaymentData, PersonalData, SubscriptionData}
+
+object SubscriptionsForm {
+  import play.api.data.Forms._
+  import play.api.data._
+
+  private val addressDataMapping = mapping(
+    "address1" -> text,
+    "address2" -> text,
+    "town" -> text,
+    "postcode" -> text
+  )(AddressData.apply)(AddressData.unapply)
+
+  private val emailMapping = tuple(
+    "email" -> email,
+    "confirm" -> email)
+    .verifying("Emails don't match", email => email._1 == email._2)
+    .transform[String](
+      email => email._1, // Transform to a single field
+      email => (email, email) // Reverse transform from a single field to multiple
+    )
+
+  private val personalDataMapping = mapping(
+    "first" -> text,
+    "last" -> text,
+    "emailValidation" -> emailMapping,
+    "address" -> addressDataMapping
+  )(PersonalData.apply)(PersonalData.unapply)
+
+  private val paymentDataMapping = mapping(
+    "account" -> text(8, 8),
+    "sortcode1" -> text(2, 2),
+    "sortcode2" -> text(2, 2),
+    "sortcode3" -> text(2, 2),
+    "holder" -> text
+  )(PaymentData.apply)(PaymentData.unapply)
+
+  private val subsForm = Form(mapping(
+    "personal" -> personalDataMapping,
+    "payment" -> paymentDataMapping
+  )(SubscriptionData.apply)(SubscriptionData.unapply))
+
+  def apply() = subsForm
+}

--- a/app/model/GuestAccountData.scala
+++ b/app/model/GuestAccountData.scala
@@ -1,0 +1,7 @@
+package model
+
+import services.{UserId, IdentityToken, GuestUser}
+
+case class GuestAccountData(password: String, id: String, token: String) {
+  def guestUser = GuestUser(UserId(id), IdentityToken(token))
+}

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -3,6 +3,8 @@ package services
 import com.gu.identity.play.IdMinimalUser
 import com.gu.membership.salesforce.MemberId
 import com.gu.membership.zuora.soap.Zuora.SubscribeResult
+import TouchpointBackend.{Normal => touchpointBackend}
+import touchpointBackend.ratePlan.{ratePlanId => ratePlan}
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import model.SubscriptionData
@@ -11,32 +13,31 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 
-case class Subscription(memberId: MemberId, zuoraSubscription: SubscribeResult)
-
 class CheckoutService(identityService: IdentityService, salesforceService: SalesforceService) extends LazyLogging {
+  import CheckoutService._
 
   lazy val paymentDelay = Some(Config.Zuora.paymentDelay)
 
   def processSubscription(subscriptionData: SubscriptionData,
-                          idUser: Option[IdMinimalUser]): Future[Subscription] = {
-    def idUserF = idUser.map(user => Future(UserId(user.id)))
-      .getOrElse {
-      logger.info(s"User does not have an Identity account, creating a Guest one.")
+                          idUserOpt: Option[IdMinimalUser]): Future[CheckoutResult] = {
 
-      identityService.registerGuest(subscriptionData.personalData)
-    }
+    val userOrElseRegisterGuest: Future[UserIdData] =
+      idUserOpt.map(user => Future {
+        MinimalIdUser(user)
+      }).getOrElse {
+        logger.info(s"User does not have an Identity account. Creating a guest account")
+        identityService.registerGuest(subscriptionData.personalData)
+      }
 
     //TODO when implementing test-users this requires updating to supply data to correct location
-    val touchpointBackend = TouchpointBackend.Normal
-    val ratePlan = touchpointBackend.ratePlan.ratePlanId
-
     for {
-      idUser <- idUserF
-      memberId <- salesforceService.createOrUpdateUser(subscriptionData.personalData, idUser)
-      subscription <- touchpointBackend.zuoraService.createSubscription(memberId, subscriptionData, ratePlan, paymentDelay)
-    } yield Subscription(memberId, subscription)
-
+      userData <- userOrElseRegisterGuest
+      memberId <- salesforceService.createOrUpdateUser(subscriptionData.personalData, userData.id)
+      subscribeResult <- touchpointBackend.zuoraService.createSubscription(memberId, subscriptionData, ratePlan, paymentDelay)
+    } yield CheckoutResult(memberId, userData, subscribeResult)
   }
 }
 
-object CheckoutService extends CheckoutService(IdentityService, SalesforceService)
+object CheckoutService extends CheckoutService(IdentityService, SalesforceService) {
+  case class CheckoutResult(salesforceMember: MemberId, userIdData: UserIdData, zuoraResult: SubscribeResult)
+}

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -142,11 +142,10 @@ object IdentityApiClient extends IdentityApiClient with LazyLogging {
   override def convertGuest: (JsValue, GuestUser) => Future[WSResponse] = (json, gu) => {
     val endpoint = authoriseCall(WS.url(s"$identityEndpoint/guest/${gu.id}"))
 
-    val ep = endpoint
+    endpoint
       .withHeaders("X-Guest-Registration-Token" -> gu.token.toString)
       .put(json)
-
-    ep.withWSFailureLogging(endpoint)
+      .withWSFailureLogging(endpoint)
       .withCloudwatchMonitoringOfPut
   }
 }

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -31,7 +31,9 @@ class IdentityService(identityApiClient: IdentityApiClient) extends LazyLogging 
  def registerGuest(personalData: PersonalData): Future[GuestUser] = {
     val json = JsObject(Map(
       "primaryEmailAddress" -> JsString(personalData.email),
-      "statusFields" -> JsObject(Map("receiveGnmMarketing" -> JsBoolean(true))),
+      "publicFields" -> JsObject(Map(
+        "displayName" -> JsString(s"${personalData.firstName} ${personalData.lastName}")
+      )),
       "privateFields" -> JsObject(Map(
         "firstName" ->  JsString(personalData.firstName),
         "secondName" -> JsString(personalData.lastName),
@@ -40,7 +42,8 @@ class IdentityService(identityApiClient: IdentityApiClient) extends LazyLogging 
         "billingAddress3" -> JsString(personalData.address.town),
         "billingPostcode" -> JsString(personalData.address.postcode),
         "billingCountry" -> JsString("United Kingdom")
-    ))))
+      )),
+      "statusFields" -> JsObject(Map("receiveGnmMarketing" -> JsBoolean(true)))))
 
     identityApiClient.createGuest(json).map(response => response.json.as[GuestUser])
   }

--- a/app/services/package.scala
+++ b/app/services/package.scala
@@ -1,0 +1,59 @@
+import com.gu.identity.play.IdMinimalUser
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+package object services {
+
+  case class UserId(id:String) {
+    override def toString = id
+  }
+
+  object UserId {
+    val paramName = "user-id"
+
+    implicit val jsonReader = new Reads[UserId] {
+      override def reads(json: JsValue): JsResult[UserId] = json match {
+        case JsString(id) => JsSuccess(UserId(id))
+        case _            => JsError("Cannot parse UserId")
+      }
+    }
+  }
+
+  case class IdentityToken(token: String) {
+    override def toString = token
+  }
+
+  object IdentityToken {
+    val paramName = "identity-token"
+
+    implicit val jsonReader = new Reads[IdentityToken] {
+      override def reads(json: JsValue): JsResult[IdentityToken] = json match {
+        case JsString(id) => JsSuccess(IdentityToken(id))
+        case _            => JsError("Cannot parse IdentityToken")
+      }
+    }
+  }
+
+  sealed trait UserIdData {
+    def id: UserId
+  }
+
+  case class MinimalIdUser(user: IdMinimalUser) extends UserIdData {
+    override def id = UserId(user.id)
+  }
+
+  case class GuestUser(id: UserId, token: IdentityToken) extends UserIdData {
+    def toFormParams = Map(
+      UserId.paramName -> id.toString,
+      IdentityToken.paramName -> token.toString
+    )
+  }
+
+  object GuestUser {
+    implicit val guestUserTokenReads: Reads[GuestUser] = (
+      (JsPath \  "guestRegistrationRequest" \ "userId").read[UserId] and
+      (JsPath \  "guestRegistrationRequest" \ "token").read[IdentityToken]
+      )(GuestUser.apply _)
+    class UnparsableGuestUserError extends RuntimeException("Cannot de-serialise GuestUser data from session")
+  }
+}

--- a/app/services/package.scala
+++ b/app/services/package.scala
@@ -53,7 +53,7 @@ package object services {
     implicit val guestUserTokenReads: Reads[GuestUser] = (
       (JsPath \  "guestRegistrationRequest" \ "userId").read[UserId] and
       (JsPath \  "guestRegistrationRequest" \ "token").read[IdentityToken]
-      )(GuestUser.apply _)
+    )(GuestUser.apply _)
     class UnparsableGuestUserError extends RuntimeException("Cannot de-serialise GuestUser data from session")
   }
 }

--- a/app/views/checkout/alldone.scala.html
+++ b/app/views/checkout/alldone.scala.html
@@ -1,0 +1,17 @@
+@import configuration.Config.Identity.webAppProfileUrl
+@()
+
+@main("Finish creating your account | Subscriptions | The Guardian") {
+  <div class="gs-container">
+    <h2 class="page-heading page-heading--border">Finish creating your account</h2>
+    <div class="row row--items-1">
+      <div class="row__item">
+        <p>All done!</p>
+        <p>You can edit your details as well as manage your subscription in your Profile area</p>
+        <div class="actions">
+          <a href="@webAppProfileUrl" class="button button--primary button--large">My profile</a>
+        </div>
+      </div>
+    </div>
+  </div>
+}

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -4,7 +4,7 @@
 
 @import routes.Checkout.processFinishAccount
 
-@(formOpt: Option[Form[GuestAccountData]] = None)
+@(guestAccountForm: Option[Form[GuestAccountData]] = None)
 
 @main("Thank you | Subscriptions | The Guardian") {
 
@@ -48,7 +48,7 @@
                 <li>Enter your subscription code (shown above and also in your confirmation email) and your postcode</li>
             </ol>
 
-        @formOpt.map { form =>
+        @guestAccountForm.map { form =>
             <h3 class="section-header">Register for an account</h3>
             <p>Some features of your subscription require you to be signed in before you can make use of them.</p>
             <p>Enter a password to finish creating your account:</p>

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -1,4 +1,10 @@
-@()
+@import model.GuestAccountData
+@import services.UserId.{paramName => userIdParam}
+@import services.IdentityToken.{paramName => identityTokenParam}
+
+@import routes.Checkout.processFinishAccount
+
+@(formOpt: Option[Form[GuestAccountData]] = None)
 
 @main("Thank you | Subscriptions | The Guardian") {
 
@@ -41,9 +47,29 @@
                 <li>Open the app and tap the 'Settings' icon</li>
                 <li>Enter your subscription code (shown above and also in your confirmation email) and your postcode</li>
             </ol>
+
+        @formOpt.map { form =>
             <h3 class="section-header">Register for an account</h3>
             <p>Some features of your subscription require you to be signed in before you can make use of them.</p>
-            <a href="#" class="button button--primary button--large">Register now</a>
+            <p>Enter a password to finish creating your account:</p>
+            <form action="@processFinishAccount" method="POST" class="form">
+                <fieldset class="fieldset">
+                    <div class="fieldset__fields">
+                        <div class="form-field js-checkout-finish-account-password">
+                            <label class="label" for="last">Password</label>
+                            <input name="@userIdParam" type="hidden" value="@form.data.get(userIdParam)">
+                            <input name="@identityTokenParam" type="hidden" value="@form.data.get(identityTokenParam)">
+                            <input name="password" type="password" class="input-text js-input">
+                            @checkout.errorMessage("Password is too short")
+                        </div>
+                        <div class="actions">
+                            <button class="button button--primary button--large js-checkout-finish-account-submit">Confirm</button>
+                        </div>
+                    </div>
+                </fieldset>
+            </form>
+        }
+
         </div>
         <div class="row__item">
         </div>

--- a/assets/javascripts/modules/checkout/checkout.js
+++ b/assets/javascripts/modules/checkout/checkout.js
@@ -136,7 +136,6 @@ define(['$',
 
     var finishAccount = function () {
         if ($FINISH_ACCOUNT_SUBMIT.length) {
-            console.info("finishAccount()", $FINISH_ACCOUNT_SUBMIT);
             bean.on($FINISH_ACCOUNT_SUBMIT[0], 'click', function (e) {
                 e.preventDefault();
 

--- a/assets/javascripts/modules/checkout/checkout.js
+++ b/assets/javascripts/modules/checkout/checkout.js
@@ -39,7 +39,7 @@ define(['$',
         $FIELDSET_REVIEW = form.$FIELDSET_REVIEW,
         $EDIT_YOUR_DETAILS = form.$EDIT_YOUR_DETAILS,
         $EDIT_PAYMENT_DETAILS = form.$EDIT_PAYMENT_DETAILS,
-
+        $FINISH_ACCOUNT_SUBMIT = form.$FINISH_ACCOUNT_SUBMIT,
         FIELDSET_COLLAPSED = 'fieldset--collapsed',
         FIELDSET_COMPLETE = 'data-fieldset-complete',
         IS_HIDDEN = 'is-hidden';
@@ -134,10 +134,26 @@ define(['$',
         }
     };
 
+    var finishAccount = function () {
+        if ($FINISH_ACCOUNT_SUBMIT.length) {
+            console.info("finishAccount()", $FINISH_ACCOUNT_SUBMIT);
+            bean.on($FINISH_ACCOUNT_SUBMIT[0], 'click', function (e) {
+                e.preventDefault();
+
+                if (validations.validateFinishAccount()) {
+                    bean.off($FINISH_ACCOUNT_SUBMIT[0], 'click');
+                    bean.fire($FINISH_ACCOUNT_SUBMIT[0], 'click');
+                }
+            });
+
+        }
+    };
+
     function init() {
         manualAddress();
         toggleFieldsets();
         reviewDetails();
+        finishAccount();
     }
 
     return {

--- a/assets/javascripts/modules/checkout/form-elements.js
+++ b/assets/javascripts/modules/checkout/form-elements.js
@@ -19,6 +19,7 @@ define(['$'], function ($) {
         $MANUAL_ADDRESS: $('.js-checkout-manual-address .js-input'),
         $FULL_ADDRESS: $('.js-checkout-full-address .js-input'),
         $CONFIRM_PAYMENT: $('.js-checkout-confirm-payment .js-input'),
+        $FINISH_ACCOUNT_PASSWORD: $('.js-checkout-finish-account-password .js-input'),
 
         $FIRST_NAME_CONTAINER: $('.js-checkout-first'),
         $LAST_NAME_CONTAINER: $('.js-checkout-last'),
@@ -34,6 +35,7 @@ define(['$'], function ($) {
         $MANUAL_ADDRESS_CONTAINER: $('.js-checkout-manual-address'),
         $FULL_ADDRESS_CONTAINER: $('.js-checkout-full-address'),
         $CONFIRM_PAYMENT_CONTAINER: $('.js-checkout-confirm-payment'),
+        $FINISH_ACCOUNT_PASSWORD_CONTAINER: $('.js-checkout-finish-account-password'),
 
         $YOUR_DETAILS_SUBMIT: $('.js-checkout-your-details-submit'),
         $PAYMENT_DETAILS_SUBMIT: $('.js-checkout-payment-details-submit'),
@@ -44,6 +46,7 @@ define(['$'], function ($) {
         $REVIEW_SORTCODE: $('.js-checkout-review-sortcode'),
         $REVIEW_HOLDER: $('.js-checkout-review-holder'),
         $SMALLPRINT: $('.js-checkout-smallprint'),
+        $FINISH_ACCOUNT_SUBMIT: $('.js-checkout-finish-account-submit'),
         $FIELDSET_YOUR_DETAILS: $('.js-fieldset-your-details'),
         $FIELDSET_PAYMENT_DETAILS: $('.js-fieldset-payment-details'),
         $FIELDSET_REVIEW: $('.js-fieldset-review'),

--- a/assets/javascripts/modules/checkout/validations.js
+++ b/assets/javascripts/modules/checkout/validations.js
@@ -23,10 +23,6 @@ define([
         {input: form.$POSTCODE, container: form.$POSTCODE_CONTAINER}
     ];
 
-    function isNumber (n) {
-        return !isNaN(parseFloat(n)) && isFinite(n);
-    }
-
     function toggleError(container, condition) {
         if (condition) {
             container.addClass(ERROR_CLASS);

--- a/assets/javascripts/modules/checkout/validations.js
+++ b/assets/javascripts/modules/checkout/validations.js
@@ -23,6 +23,10 @@ define([
         {input: form.$POSTCODE, container: form.$POSTCODE_CONTAINER}
     ];
 
+    function isNumber (n) {
+        return !isNaN(parseFloat(n)) && isFinite(n);
+    }
+
     function toggleError(container, condition) {
         if (condition) {
             container.addClass(ERROR_CLASS);
@@ -108,7 +112,14 @@ define([
         return accountNumberValid && sortCodeValid && holderNameValid && detailsConfirmed;
     };
 
+    var validateFinishAccount = function () {
+        var passwordValid = form.$FINISH_ACCOUNT_PASSWORD.val().length >= 6;
+        toggleError(form.$FINISH_ACCOUNT_PASSWORD_CONTAINER, !passwordValid);
+        return passwordValid;
+    };
+
     return {
+        validateFinishAccount: validateFinishAccount,
         validatePersonalDetails: validatePersonalDetails,
         validatePaymentDetails: validatePaymentDetails
     };

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -26,7 +26,6 @@ google.oauth {
 
 identity {
   baseUri = ""
-  apiToken = ""
   webapp.url="https://profile.theguardian.com"
 }
 subscriptions.url="https://subscribe.theguardian.com"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,11 +8,14 @@
 # This must be changed for production, but we recommend not changing it in this file.
 #
 # See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
-application.secret="Is]F;gOuRS]X[eTv4j9k;_jC3Tc>2Xv<D_On/CRr/MBoJAM5yBB_w2Fp]1c7xDpX"
+play.crypto.secret="Is]F;gOuRS]X[eTv4j9k;_jC3Tc>2Xv<D_On/CRr/MBoJAM5yBB_w2Fp]1c7xDpX"
 
 # The application languages
 # ~~~~~
 application.langs="en"
+
+# Enable cookie-based session for HTTPS only
+application.session.secure=true
 
 google.oauth {
   // https://console.developers.google.com/project/guardian-subscriptions/apiui/credential?authuser=1

--- a/conf/routes
+++ b/conf/routes
@@ -22,6 +22,7 @@ GET         /checkout                        controllers.Checkout.renderCheckout
 POST        /checkout                        controllers.Checkout.handleCheckout
 GET         /checkout/thankyou               controllers.Checkout.thankyou
 GET         /checkout/check-identity         controllers.Checkout.checkIdentity(email: String)
+POST        /checkout/finish-account         controllers.Checkout.processFinishAccount
 
 # collection and delivery
 GET         /collection/paper-digital        controllers.Shipping.viewCollectionPaperDigital

--- a/conf/routes
+++ b/conf/routes
@@ -22,7 +22,7 @@ GET         /checkout                        controllers.Checkout.renderCheckout
 POST        /checkout                        controllers.Checkout.handleCheckout
 GET         /checkout/thankyou               controllers.Checkout.thankyou
 GET         /checkout/check-identity         controllers.Checkout.checkIdentity(email: String)
-POST        /checkout/finish-account         controllers.Checkout.processFinishAccount
+POST        /checkout/register-guest-user    controllers.Checkout.processFinishAccount
 
 # collection and delivery
 GET         /collection/paper-digital        controllers.Shipping.viewCollectionPaperDigital


### PR DESCRIPTION
When a guest user subscribes, display a form in the thank you page inviting her to complete her account by setting password. This PR implements only a basic password validation, I plan on adding the same password strength widget used in Identity-frontend and Membership in a separate one.

**Note:** In order to be able to set a password for an Identity guest user account the subscription-frontend token needs to have the `user.password.c` permission enabled (I have [updated](https://github.com/guardian/identity/pull/283) the corresponding PR on identity).

![screen shot 2015-06-30 at 14 05 56](https://cloud.githubusercontent.com/assets/63361/8431562/503dc952-1f32-11e5-9ec3-084250afb501.png)

On successful submission of the password form the user gets redirected to another page
linking to the Identity frontend website.

![screen shot 2015-06-30 at 14 02 05](https://cloud.githubusercontent.com/assets/63361/8431586/6c9b0e02-1f32-11e5-8dff-b8f7e07d8421.png)

@rtyley @jennysivapalan @tudorraul 
 
