### PR TITLE
Enable CSRF protection

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,10 +1,11 @@
 import filters.CheckCacheHeadersFilter
+import play.filters.csrf.CSRFFilter
 import monitoring.SentryLogging
 import play.api.Application
 import play.api.mvc.WithFilters
 import services.TouchpointBackend
 
-object Global extends WithFilters(CheckCacheHeadersFilter) {
+object Global extends WithFilters(CheckCacheHeadersFilter, CSRFFilter()) {
   override def onStart(app: Application) {
     SentryLogging.init()
     TouchpointBackend.All.foreach(_.start())

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -1,6 +1,7 @@
-@(form: Form[model.SubscriptionData], userIsSignedIn: Boolean)
+@(form: Form[model.SubscriptionData], userIsSignedIn: Boolean)(implicit request: RequestHeader)
 
 @import routes.Checkout.renderCheckout
+
 @import model.JsVars
 @import configuration.Config.Identity._
 
@@ -26,6 +27,7 @@
         <div class="row__item row__item--boost-2">
             <form class="form js-checkout-form" method="POST">
                 <fieldset class="fieldset js-fieldset-your-details">
+                    @helper.CSRF.formField
                     <div class="fieldset__heading">
                         <h2 class="fieldset__headline"><span class="fieldset__num">1</span> Your details</h2>
                         <a href="#" class="fieldset__edit is-hidden js-edit-your-details">Edit</a>

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "membership-common" % "0.68",
   cache,
   ws,
+  filters,
   PlayImport.specs2,
   "com.gu" %% "play-googleauth" % "0.3.0",
   "com.gu.identity" %% "identity-play-auth" % "0.5",


### PR DESCRIPTION
Enables *Cross Site Request Forgery* protection using Play's [built-in](https://www.playframework.com/documentation/2.4.x/ScalaCsrf) filter. I can verify that the CSRF token is being checked by issuing a dummy POST request to our checkout action:

```
❯ curl -XPOST -k -v -d "blah=22"  https://sub.thegulocal.com/checkout
* Adding handle: conn: 0x7f8171804000
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 0 (0x7f8171804000) send_pipe: 1, recv_pipe: 0
* About to connect() to sub.thegulocal.com port 443 (#0)
*   Trying 127.0.0.1...
* Connected to sub.thegulocal.com (127.0.0.1) port 443 (#0)
* TLS 1.0 connection using TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
* Server certificate: *.int.gnl
> POST /checkout HTTP/1.1
> User-Agent: curl/7.30.0
> Host: sub.thegulocal.com
> Accept: */*
> Content-Length: 7
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 7 out of 7 bytes
< HTTP/1.1 403 Forbidden
* Server nginx/1.8.0 is not blacklisted
< Server: nginx/1.8.0
< Date: Tue, 30 Jun 2015 15:09:09 GMT
< Content-Type: text/plain; charset=utf-8
< Transfer-Encoding: chunked
< Connection: keep-alive
< Set-Cookie: PLAY_SESSION=; Max-Age=-86400; Expires=Mon, 29 Jun 2015 15:09:09 GMT; Path=/; HTTPOnly
<
* Connection #0 to host sub.thegulocal.com left intact
No CSRF token found in headers
``` 

Also notice that Play is now including a `csrfToken` field within its session cookie:

```
curl -kI  https://sub.thegulocal.com/checkout
HTTP/1.1 303 See Other
Server: nginx/1.8.0
Date: Tue, 30 Jun 2015 15:11:41 GMT
Content-Length: 0
Connection: keep-alive
Pragma: no-cache
Location: /staff/loginAction
Set-Cookie: PLAY_SESSION=...csrfToken=6588a4e04ae991ec1334aa63addb6aa2efe2cb6d-1435677101675-37818ce10b6a4f608e1428ea...
Cache-Control: no-cache, private
```