### PR TITLE
Load in rate plan from Configuration. 

### DIFF
--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -22,10 +22,14 @@ class CheckoutService(identityService: IdentityService, salesforceService: Sales
       identityService.registerGuest(subscriptionData.personalData)
     }
 
+    //TODO when implementing test-users this requires updating to supply data to correct location
+    val touchpointBackend = TouchpointBackend.Normal
+    val ratePlan = touchpointBackend.ratePlan.ratePlanId
+
     for {
       idUser <- idUserF
       memberId <- salesforceService.createOrUpdateUser(subscriptionData.personalData, idUser)
-      subscription <- TouchpointBackend.Normal.zuoraService.createSubscription(memberId, subscriptionData)   //TODO when implementing test-users this requires updating to supply data to correct location
+      subscription <- touchpointBackend.zuoraService.createSubscription(memberId, subscriptionData, ratePlan)
     } yield Subscription(memberId, subscription)
 
   }

--- a/app/services/TouchpointBackend.scala
+++ b/app/services/TouchpointBackend.scala
@@ -2,7 +2,7 @@ package services
 
 import com.gu.identity.play.IdMinimalUser
 import configuration.Config
-import touchpoint.TouchpointBackendConfig
+import touchpoint.{ProductRatePlan, TouchpointBackendConfig}
 
 object TouchpointBackend {
   import TouchpointBackendConfig.BackendType
@@ -16,7 +16,9 @@ object TouchpointBackend {
     
     val salesforceRepo = new SalesforceRepo(touchpointBackendConfig.salesforce)
 
-    TouchpointBackend(salesforceRepo, zuoraService)
+    val ratePlan = touchpointBackendConfig.productRatePlan
+
+    TouchpointBackend(salesforceRepo, zuoraService, ratePlan)
   }
 
   val Normal = TouchpointBackend(BackendType.Default)
@@ -26,7 +28,8 @@ object TouchpointBackend {
 
 case class TouchpointBackend(
   salesforceRepo: SalesforceRepo,
-  zuoraService : ZuoraService) {
+  zuoraService : ZuoraService,
+  ratePlan: ProductRatePlan) {
 
   def start() = {
     salesforceRepo.salesforce.authTask.start()

--- a/app/services/ZuoraService.scala
+++ b/app/services/ZuoraService.scala
@@ -26,8 +26,8 @@ class ZuoraService(zuoraApiConfig: ZuoraApiConfig) extends ZuoraApi {
   override val metrics = new ZuoraMetrics(stage, application)
   val authTask = ScheduledTask(s"Zuora ${apiConfig.envName} auth", Authentication("", ""), 0.seconds, 30.minutes)(request(Login(apiConfig)))
 
-  def createSubscription(memberId: MemberId, data: SubscriptionData): Future[SubscribeResult] = {
-    request(Subscribe(memberId, data))
+  def createSubscription(memberId: MemberId, data: SubscriptionData, ratePlanId: String): Future[SubscribeResult] = {
+    request(Subscribe(memberId, data, ratePlanId))
   }
 }
 

--- a/app/services/zuora/Subscribe.scala
+++ b/app/services/zuora/Subscribe.scala
@@ -10,7 +10,7 @@ import org.joda.time.DateTime
 import com.gu.membership.zuora.soap.ZuoraServiceHelpers._
 import scala.xml.Elem
 
-case class Subscribe(memberId: MemberId, data: SubscriptionData) extends ZuoraAction[SubscribeResult] {
+case class Subscribe(memberId: MemberId, data: SubscriptionData, productRatePlanId: String) extends ZuoraAction[SubscribeResult] {
 
   override protected val body: Elem = {
 
@@ -73,7 +73,7 @@ case class Subscribe(memberId: MemberId, data: SubscriptionData) extends ZuoraAc
           </ns1:Subscription>
           <ns1:RatePlanData>
             <ns1:RatePlan xsi:type="ns2:RatePlan">
-              <ns2:ProductRatePlanId>2c92c0f84bbfec8b014bc655f4852d9d</ns2:ProductRatePlanId>
+              <ns2:ProductRatePlanId>{productRatePlanId}</ns2:ProductRatePlanId>
             </ns1:RatePlan>
           </ns1:RatePlanData>
         </ns1:SubscriptionData>

--- a/app/touchpoint/TouchpointBackendConfig.scala
+++ b/app/touchpoint/TouchpointBackendConfig.scala
@@ -3,8 +3,9 @@ package touchpoint
 import com.gu.membership.salesforce.SalesforceConfig
 import com.gu.membership.zuora.ZuoraApiConfig
 import com.typesafe.scalalogging.LazyLogging
+import touchpoint.Product.Digital
 
-case class TouchpointBackendConfig(salesforce: SalesforceConfig, zuora: ZuoraApiConfig)
+case class TouchpointBackendConfig(salesforce: SalesforceConfig, zuora: ZuoraApiConfig, productRatePlan: ProductRatePlan)
 
 object TouchpointBackendConfig extends LazyLogging {
 
@@ -34,7 +35,23 @@ object TouchpointBackendConfig extends LazyLogging {
 
     TouchpointBackendConfig(
       SalesforceConfig.from(envBackendConf, environmentName),
-      ZuoraApiConfig.forSubscriptions(envBackendConf, environmentName)
+      ZuoraApiConfig.from(envBackendConf, environmentName),
+      ProductRatePlan(envBackendConf)
     )
+  }
+}
+
+object Product {
+  case object Digital
+}
+
+case class ProductRatePlan(
+  product: Product,
+  ratePlanId: String
+)
+
+object ProductRatePlan {
+  def apply(config: com.typesafe.config.Config): ProductRatePlan = {
+    ProductRatePlan(Digital , config.getString("zuora.digital.monthly"))
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val root = (project in file(".")).enablePlugins(
 scalaVersion := "2.11.6"
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "membership-common" % "0.69",
+  "com.gu" %% "membership-common" % "0.70-SNAPSHOT",
   cache,
   ws,
   PlayImport.specs2,

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val root = (project in file(".")).enablePlugins(
 scalaVersion := "2.11.6"
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "membership-common" % "0.70-SNAPSHOT",
+  "com.gu" %% "membership-common" % "0.70",
   cache,
   ws,
   PlayImport.specs2,

--- a/conf/touchpoint.DEV.conf
+++ b/conf/touchpoint.DEV.conf
@@ -19,6 +19,9 @@ touchpoint.backend.environments {
         username = ""
         password = ""
       }
+      digital {
+        monthly = "2c92c0f84bbfec8b014bc655f4852d9d"
+      }
     }
   }
 }

--- a/conf/touchpoint.PROD.conf
+++ b/conf/touchpoint.PROD.conf
@@ -19,6 +19,9 @@ touchpoint.backend.environments {
         username = ""
         password = ""
       }
+      digital {
+        monthly = "2c92c0f84bbfec8b014bc655f4852d9d"
+      }
     }
   }
 }


### PR DESCRIPTION
This relies on https://github.com/guardian/membership-common/pull/72

Currently this loads in just one ProductRatePlan but we should be able to extend this to a list when we bring in the other billing frequencies and products.