### PR TITLE
Setup client-side Sentry

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,12 +5,14 @@
   },
 
   "globals"   : {
+    "Raven": false,
     "require": false,
     "define": false,
     "guardian": false
   },
 
   "rules": {
+    "camelcase": 0,
     "curly": [2, "all"],
     "no-unused-vars": 2,
     "quotes": [2, "single"],

--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,8 @@
 /.settings
 /RUNNING_PID
 /out
-dist
 logs
 tmp
-conf/assets.map
 
 # Scala-IDE specific
 .worksheet
@@ -31,9 +29,13 @@ project/target
 project/boot/
 project/plugins/project/
 
-# frontend
+# Frontend
 .sass-cache
 bower_components
 node_modules
+conf/assets.map
+
+public/dist
+public/images
 public/javascripts
 public/stylesheets

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -118,7 +118,8 @@ module.exports = function(grunt) {
                         'qwery': 'bower_components/qwery/qwery',
                         'requireLib': 'bower_components/requirejs/require',
                         'reqwest': 'bower_components/reqwest/reqwest',
-                        Promise: 'bower_components/native-promise-only/lib/npo.src'
+                        'Promise': 'bower_components/native-promise-only/lib/npo.src',
+                        'raven': 'bower_components/raven-js/dist/raven'
                     },
                     optimize: isDev ? 'none' : 'uglify2',
                     generateSourceMaps: isDev ? 'true' : 'false',

--- a/app/views/fragments/head.scala.html
+++ b/app/views/fragments/head.scala.html
@@ -23,5 +23,3 @@
 } else {
     <link rel="shortcut icon" type="image/png" href="@controllers.CachedAssets.hashedPathFor("images/favicons/32x32.ico")"/>
 }
-
-<script src="//cdn.optimizely.com/js/293455139.js"></script>

--- a/app/views/fragments/javascriptFirstSteps.scala.html
+++ b/app/views/fragments/javascriptFirstSteps.scala.html
@@ -5,7 +5,7 @@
 
 <script id="gu">
     var guardian = JSON.parse('@Html(Json.stringify(Json.toJson(jsVars)))');
-
+    guardian.buildNumber = '@app.BuildInfo.buildNumber';
     guardian.isModernBrowser =  (
             'querySelector' in document
             && 'addEventListener' in window
@@ -23,5 +23,4 @@
             document.getElementsByTagName("head")[0].appendChild(newElm);
         }
     })(guardian.isModernBrowser);
-
 </script>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -7,7 +7,6 @@
 <head>
     @fragments.head(title)
     @fragments.javascriptFirstSteps(jsVars)
-    <script src="//cdn.optimizely.com/js/293455139.js"></script>
 </head>
     <body class="@bodyClassName">
         @fragments.header()

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -6,6 +6,8 @@
 <html lang="en-GB">
 <head>
     @fragments.head(title)
+    @fragments.javascriptFirstSteps(jsVars)
+    <script src="//cdn.optimizely.com/js/293455139.js"></script>
 </head>
     <body class="@bodyClassName">
         @fragments.header()
@@ -13,8 +15,6 @@
         @content
 
         @fragments.footer.footer(footer)
-
-        @fragments.javascript(jsVars)
 
         @fragments.analytics.google()
         @fragments.analytics.omniture()

--- a/assets/javascripts/bower.json
+++ b/assets/javascripts/bower.json
@@ -1,10 +1,10 @@
 {
-  "name": "subscriptions javascripts",
-  "version": "0.1",
+  "name": "Subscriptions JavaScripts",
   "dependencies": {
     "bean": "~1.0.6",
     "bonzo": "~2.0.0",
     "qwery": "~4.0.0",
+    "raven-js": "~1.1.16",
     "requirejs": "~2.1.17",
     "reqwest": "~1.1.0",
     "native-promise-only": "guardian/native-promise-only#master"

--- a/assets/javascripts/main.js
+++ b/assets/javascripts/main.js
@@ -1,17 +1,28 @@
 require([
+    'utils/ajax',
     'modules/checkout/checkout',
     'modules/digitalpack',
-    'utils/ajax'
+    // Add new dependencies ABOVE this
+    'raven'
 ], function(
+    ajax,
     checkout,
-    digitalpack,
-    ajax
+    digitalpack
 ) {
     'use strict';
 
-    // Global
+    /**
+     * Set up Raven, which speaks to Sentry to track errors
+     */
+    /*global Raven */
+    Raven.config('https://6dd79da86ec54339b403277d8baac7c8@app.getsentry.com/47380', {
+        whitelistUrls: ['subscribe.theguardian.com/assets/'],
+        tags: { build_number: guardian.buildNumber }
+    }).install();
 
     ajax.init({page: {ajaxUrl: ''}});
+
     checkout.init();
     digitalpack.init();
+
 });


### PR DESCRIPTION
- Setup raven-js for Sentry
- Add build version to guardian global object
- Move javascript -> javascriptFirstSteps, as the `isModernBrowser` / global vars should be in the `<head>`

As well as generally tracking client-side errors, this also helps validate if the pattern [`onFailure(new Error('Personal details incorrect.')); `](https://github.com/guardian/subscriptions-frontend/blob/95909983e925a73aa3e50b41c0051a0478b6a01c/assets/javascripts/modules/checkout/validations.js#L61) results in Sentry noise and console errors.

Fairly confident it will as the current pattern does this in the console:

![screen shot 2015-07-02 at 12 48 33](https://cloud.githubusercontent.com/assets/123386/8476393/cecafbdc-20b8-11e5-8a43-e86a60a43bc7.png)

// @rtyley @tudorraul 