### PR TITLE
Set delay in payment request by Zuora upon creating a subscription

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -6,6 +6,7 @@ import com.gu.membership.salesforce.SalesforceConfig
 import com.netaporter.uri.dsl._
 import com.typesafe.config.ConfigFactory
 import net.kencochrane.raven.dsn.Dsn
+import com.github.nscala_time.time.Imports._
 
 import scala.util.Try
 
@@ -44,6 +45,11 @@ object Config {
       (webAppUrl / "signout") ? ("returnUrl" -> absoluteUrl(path)) ? ("skipConfirmation" -> "true")
 
     private def absoluteUrl(path: String): String = (subscriptionsUrl / path).toString()
+  }
+
+  object Zuora {
+    val paymentDelay = config.getConfig("touchpoint.backend.environments").getConfig(stage)
+      .getInt("zuora.paymentDelayInDays").days
   }
 
   val subscriptionsUrl = config.getString("subscriptions.url")

--- a/app/services/ZuoraService.scala
+++ b/app/services/ZuoraService.scala
@@ -8,6 +8,7 @@ import com.gu.membership.zuora.soap.{Login, ZuoraApi}
 import com.gu.monitoring.ZuoraMetrics
 import configuration.Config
 import model.SubscriptionData
+import org.joda.time.Period
 import services.zuora.Subscribe
 import utils.ScheduledTask
 
@@ -26,8 +27,8 @@ class ZuoraService(zuoraApiConfig: ZuoraApiConfig) extends ZuoraApi {
   override val metrics = new ZuoraMetrics(stage, application)
   val authTask = ScheduledTask(s"Zuora ${apiConfig.envName} auth", Authentication("", ""), 0.seconds, 30.minutes)(request(Login(apiConfig)))
 
-  def createSubscription(memberId: MemberId, data: SubscriptionData, ratePlanId: String): Future[SubscribeResult] = {
-    request(Subscribe(memberId, data, ratePlanId))
+  def createSubscription(memberId: MemberId, data: SubscriptionData, ratePlanId: String, paymentDelay: Option[Period]): Future[SubscribeResult] = {
+    request(Subscribe(memberId, data, ratePlanId, paymentDelay))
   }
 }
 

--- a/app/services/zuora/Subscribe.scala
+++ b/app/services/zuora/Subscribe.scala
@@ -5,18 +5,18 @@ import com.gu.membership.zuora.Countries
 import com.gu.membership.zuora.soap.Zuora.SubscribeResult
 import com.gu.membership.zuora.soap.ZuoraAction
 import model.SubscriptionData
-import org.joda.time.DateTime
+import org.joda.time.{Period, DateTime}
 
 import com.gu.membership.zuora.soap.ZuoraServiceHelpers._
 import scala.xml.Elem
 
-case class Subscribe(memberId: MemberId, data: SubscriptionData, productRatePlanId: String) extends ZuoraAction[SubscribeResult] {
+case class Subscribe(memberId: MemberId, data: SubscriptionData, productRatePlanId: String, paymentDelay: Option[Period]) extends ZuoraAction[SubscribeResult] {
 
   override protected val body: Elem = {
 
     val now = DateTime.now
     val effectiveDate = formatDateTime(now)
-    val contractAcceptanceDate = formatDateTime(now)
+    val contractAcceptanceDate = paymentDelay.map(delay => formatDateTime(now.plus(delay))).getOrElse(effectiveDate)
 
     val payment =
       <ns1:PaymentMethod xsi:type="ns2:PaymentMethod">

--- a/conf/touchpoint.DEV.conf
+++ b/conf/touchpoint.DEV.conf
@@ -14,6 +14,7 @@ touchpoint.backend.environments {
       }
     }
     zuora {
+      paymentDelayInDays = 1
       api {
         url = "https://apisandbox.zuora.com/apps/services/a/58.0"
         username = ""

--- a/conf/touchpoint.PROD.conf
+++ b/conf/touchpoint.PROD.conf
@@ -14,6 +14,7 @@ touchpoint.backend.environments {
       }
     }
     zuora {
+      paymentDelayInDays = 16
       api {
         url = "https://apisandbox.zuora.com/apps/services/a/58.0"
         username = ""


### PR DESCRIPTION
A delay is achieved by setting a future date in the `ContractAcceptanceDate` field when a subscription is created in Zuora

This is how a next day (dev configuration) payment request is set in Zuora
![screen shot 2015-07-02 at 15 55 09](https://cloud.githubusercontent.com/assets/1492162/8480043/5561319c-20d3-11e5-88ff-90750db5c055.png)

:sparkles: 