### PR TITLE
Add CSFR token input to finish-account form

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -59,7 +59,11 @@ object Checkout extends Controller with LazyLogging {
     )
   }
 
-  def thankyou = GoogleAuthenticatedStaffAction(Ok(views.html.checkout.thankyou()))
+  def thankyou = GoogleAuthenticatedStaffAction.async { implicit request =>
+    Future {
+      Ok(views.html.checkout.thankyou())
+    }
+  }
 
   def processFinishAccount = GoogleAuthenticatedStaffAction.async { implicit request =>
     FinishAccountForm().bindFromRequest.fold( formWithErrors => {

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -53,6 +53,7 @@
             <p>Some features of your subscription require you to be signed in before you can make use of them.</p>
             <p>Enter a password to finish creating your account:</p>
             <form action="@processFinishAccount" method="POST" class="form">
+                @helper.CSRF.formField
                 <fieldset class="fieldset">
                     <div class="fieldset__fields">
                         <div class="form-field js-checkout-finish-account-password">

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -4,7 +4,7 @@
 
 @import routes.Checkout.processFinishAccount
 
-@(guestAccountForm: Option[Form[GuestAccountData]] = None)
+@(guestAccountForm: Option[Form[GuestAccountData]] = None)(implicit request: RequestHeader)
 
 @main("Thank you | Subscriptions | The Guardian") {
 


### PR DESCRIPTION
Adds CSFR token as a hidden input in the Thank you page finish account form. This is now required in all forms, otherwise Play will just reject the request with an "invalid token" error.