### PR TITLE
Remove ID dev token

### DIFF
--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -7,7 +7,6 @@ identity {
   baseUri = "https://idapi.code.dev-theguardian.com"
   production.keys=false
   webapp.url="https://profile.thegulocal.com"
-  apiToken = "subscriptions-dev-client-token"
 }
 
 subscriptions.url="https://sub.thegulocal.com"


### PR DESCRIPTION
The token for Identity API CODE environment should be placed in local configuration file, `/etc/gu/subscription-frontend.conf`