### PR TITLE
Basic regression tests for Print, and Print + Digital subscriptions

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -12,8 +12,8 @@ import scala.util.Try
 
 object Config {
   val appName = "subscriptions-frontend"
-
   val config = ConfigFactory.load()
+  val appUrl = config.getString("subscriptions.url")
 
   val playSecret = config.getString("play.crypto.secret")
 

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -13,7 +13,6 @@ import scala.util.Try
 object Config {
   val appName = "subscriptions-frontend"
   val config = ConfigFactory.load()
-  val appUrl = config.getString("subscriptions.url")
 
   val playSecret = config.getString("play.crypto.secret")
 

--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"))
 
 addCommandAlias("devrun", "run -Dconfig.resource=DEV.conf 9200")
-addCommandAlias("run-tests", "testOnly -- -l Acceptance")
+addCommandAlias("fast-test", "testOnly -- -l Acceptance")
+addCommandAlias("acceptance-test", "testOnly -- -r Acceptance")
 
 playArtifactDistSettings

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,9 @@ libraryDependencies ++= Seq(
   "org.seleniumhq.selenium" % "selenium-java" % "2.44.0" % "test"
 )
 
-testOptions in Test += Tests.Argument("-oF")
+testOptions in Test ++= Seq(
+  Tests.Argument("-oFD") // display full stack errors and execution times in Scalatest output
+)
 
 javaOptions in Test += "-Dconfig.file=test/conf/application.conf"
 
@@ -48,5 +50,6 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"))
 
 addCommandAlias("devrun", "run -Dconfig.resource=DEV.conf 9200")
+addCommandAlias("run-tests", "testOnly -- -l Acceptance")
 
 playArtifactDistSettings

--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,11 @@ libraryDependencies ++= Seq(
   "com.github.nscala-time" %% "nscala-time" % "2.0.0",
   "net.kencochrane.raven" % "raven-logback" % "6.0.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+  "org.seleniumhq.selenium" % "selenium-java" % "2.44.0" % "test"
 )
+
+testOptions in Test += Tests.Argument("-oF")
 
 javaOptions in Test += "-Dconfig.file=test/conf/application.conf"
 

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,6 @@ resolvers ++= Seq(
 
 addCommandAlias("devrun", "run -Dconfig.resource=DEV.conf 9200")
 addCommandAlias("fast-test", "testOnly -- -l Acceptance")
-addCommandAlias("acceptance-test", "testOnly -- -r Acceptance")
+addCommandAlias("acceptance-test", "testOnly -- -n Acceptance")
 
 playArtifactDistSettings

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <property name="application-name" value="subscription-frontend" />
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>%d [%thread] %level %logger - %m%n</Pattern>
+        </layout>
+    </appender>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <File>logs/${application-name}-functional-test.log</File>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>%d %p %t %c - %m%n</Pattern>
+        </layout>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -6,6 +6,7 @@
             <Pattern>%d [%thread] %level %logger - %m%n</Pattern>
         </layout>
     </appender>
+
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <File>logs/${application-name}-functional-test.log</File>
         <layout class="ch.qos.logback.classic.PatternLayout">
@@ -17,4 +18,5 @@
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="FILE"/>
     </root>
+    
 </configuration>

--- a/test/conf/application.conf
+++ b/test/conf/application.conf
@@ -6,7 +6,7 @@ include file("/etc/gu/subscriptions-frontend.conf")
 
 // Set to "https://subscriptions.guardian.com" in order to run acceptance tests
 // against the actual site
-subscriptions.url="https://sub.thegulocal.com"
+subscriptions.url="https://subscribe.theguardian.com"
 
 // Set in order to use Sauce Labs as remote Selenium driver (intended for CI use)
-//webDriverRemoteUrl = "http://USERNAME:APIKEY@ondemand.saucelabs.com:80/wd/hub"
+webDriverRemoteUrl = ${WEBDRIVER_REMOTE_URL}

--- a/test/conf/application.conf
+++ b/test/conf/application.conf
@@ -1,0 +1,12 @@
+stage = "TEST"
+
+include file("../conf/application.conf")
+
+include file("/etc/gu/subscriptions-frontend.conf")
+
+// Set to "https://subscriptions.guardian.com" in order to run acceptance tests
+// against the actual site
+subscriptions.url="https://sub.thegulocal.com"
+
+// Set in order to use Sauce Labs as remote Selenium driver (intended for CI use)
+//webDriverRemoteUrl = "http://USERNAME:APIKEY@ondemand.saucelabs.com:80/wd/hub"

--- a/test/functional/Config.scala
+++ b/test/functional/Config.scala
@@ -10,9 +10,11 @@ import org.openqa.selenium.{Platform, WebDriver}
 import scala.util.Try
 
 
-object Driver {
-  def fromConfig: WebDriver = {
-    val conf = ConfigFactory.load()
+object Config {
+  private val conf = ConfigFactory.load()
+  val appUrl = conf.getString("subscriptions.url")
+
+  lazy val driver: WebDriver = {
     Try { conf.getString("webDriverRemoteUrl") }.toOption.map { urlS =>
       new RemoteWebDriver(new URL(urlS), defaultCapabilities)
     }.getOrElse {

--- a/test/functional/Config.scala
+++ b/test/functional/Config.scala
@@ -15,8 +15,8 @@ object Config {
   val appUrl = conf.getString("subscriptions.url")
 
   lazy val driver: WebDriver = {
-    Try { conf.getString("webDriverRemoteUrl") }.toOption.map { urlS =>
-      new RemoteWebDriver(new URL(urlS), defaultCapabilities)
+    Try { new URL(conf.getString("webDriverRemoteUrl")) }.toOption.map { url =>
+      new RemoteWebDriver(url, defaultCapabilities)
     }.getOrElse {
       new ChromeDriver()
     }

--- a/test/functional/Driver.scala
+++ b/test/functional/Driver.scala
@@ -1,0 +1,30 @@
+package functional
+
+import java.net.URL
+
+import com.typesafe.config.ConfigFactory
+import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.remote.{DesiredCapabilities, RemoteWebDriver}
+import org.openqa.selenium.{Platform, WebDriver}
+
+import scala.util.Try
+
+
+object Driver {
+  def fromConfig: WebDriver = {
+    val conf = ConfigFactory.load()
+    Try { conf.getString("webDriverRemoteUrl") }.toOption.map { urlS =>
+      val url = new URL(urlS)
+      new RemoteWebDriver(url, defaultCapabilities)
+    }.getOrElse {
+      new ChromeDriver()
+    }
+  }
+
+  val defaultCapabilities = {
+    val capabilities = DesiredCapabilities.chrome()
+    capabilities.setCapability("platform", Platform.WIN8)
+    capabilities.setCapability("name", "Subscriptions frontend Acceptance test: https://github.com/guardian/subscriptions-frontend")
+    capabilities
+  }
+}

--- a/test/functional/Driver.scala
+++ b/test/functional/Driver.scala
@@ -14,8 +14,7 @@ object Driver {
   def fromConfig: WebDriver = {
     val conf = ConfigFactory.load()
     Try { conf.getString("webDriverRemoteUrl") }.toOption.map { urlS =>
-      val url = new URL(urlS)
-      new RemoteWebDriver(url, defaultCapabilities)
+      new RemoteWebDriver(new URL(urlS), defaultCapabilities)
     }.getOrElse {
       new ChromeDriver()
     }

--- a/test/functional/PrintSubscriptionsSpec.scala
+++ b/test/functional/PrintSubscriptionsSpec.scala
@@ -1,25 +1,66 @@
 package functional
 
+import java.net.URL
+
+import controllers.routes.Shipping.{viewCollectionPaper, viewCollectionPaperDigital, viewDeliveryPaperDigital, viewDeliveryPaper}
+import configuration.Config.appUrl
 import functional.pages.{Home, SubscriptionPlan}
 import org.openqa.selenium.WebDriver
 import org.scalatest._
 import org.scalatest.selenium.WebBrowser
 
-class PrintSubscriptionsSpec extends FreeSpec with ShouldMatchers with WebBrowser with BeforeAndAfterAll {
-  implicit val driver: WebDriver = Driver.fromConfig
+case class Subscription(name: String, landingHost: String)
 
-  "selecting a subscription managed through guardiansubscriptions.co.uk" - {
-    "Paper + Digital subscription" taggedAs(Core, Acceptance) in {
+class PrintSubscriptionsSpec extends FreeSpec with ShouldMatchers with WebBrowser with BeforeAndAfterAll {
+  implicit lazy val driver: WebDriver = Driver.fromConfig
+
+  "selecting a subscription managed through " - {
+    "Paper + Digital subscription" taggedAs Acceptance in {
       Home.selectPaperPlusDigital()
       SubscriptionPlan.selectSixdayPackage()
-      assert(SubscriptionPlan.pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
+      assert(pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
+      assertResult("www.guardiansubscriptions.co.uk")(currentHost)
     }
 
-    "Paper only subscription" taggedAs(Core, Acceptance) in {
+    "Paper voucher subscription" taggedAs Acceptance in {
+      goTo(s"$appUrl/${viewCollectionPaper.toString}")
+      SubscriptionPlan.selectSixdayPackage()
+      assert(pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
+      assertResult("www.guardiansubscriptions.co.uk")(currentHost)
+    }
+
+    "Paper voucher + digital subscription" taggedAs Acceptance in {
+      goTo(s"$appUrl/${viewCollectionPaperDigital.toString}")
+      SubscriptionPlan.selectSixdayPackage()
+      assert(pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
+      assertResult("www.guardiansubscriptions.co.uk")(currentHost)
+    }
+
+    "Paper only subscription" taggedAs Acceptance in {
       Home.selectPaper()
       SubscriptionPlan.selectWeekendPackage()
-      assert(SubscriptionPlan.pageHasText("You have chosen\nWEEKEND"), "document contains selected plan")
+      assert(pageHasText("You have chosen\nWEEKEND"), "document contains selected plan")
+      assertResult("www.guardiansubscriptions.co.uk")(currentHost)
     }
+
+    "Paper home delivery + digital subscription" taggedAs Acceptance in {
+      goTo(s"$appUrl/${viewDeliveryPaperDigital.toString}")
+      SubscriptionPlan.selectWeekendPackage()
+      assert(pageHasText("You have chosen\nWEEKEND"), "document contains selected plan")
+      assertResult("www.guardiandirectsubs.co.uk")(currentHost)
+    }
+
+    "Paper home delivery subscription" taggedAs Acceptance in {
+      goTo(s"$appUrl/${viewDeliveryPaper.toString}")
+      SubscriptionPlan.selectSixdayPackage()
+      assert(pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
+      assertResult("www.guardiandirectsubs.co.uk")(currentHost)
+    }
+  }
+
+  private def currentHost: String = new URL(currentUrl).getHost
+  private def pageHasText(text: String): Boolean = {
+    find(tagName("body")).get.text.contains(text)
   }
 
   override def afterAll() {

--- a/test/functional/PrintSubscriptionsSpec.scala
+++ b/test/functional/PrintSubscriptionsSpec.scala
@@ -2,11 +2,12 @@ package functional
 
 import java.net.URL
 
-import configuration.Config.appUrl
+import controllers.routes.Shipping.{viewCollectionPaper, viewCollectionPaperDigital, viewDeliveryPaperDigital, viewDeliveryPaper}
 import functional.pages.{Home, SubscriptionPlan}
 import org.openqa.selenium.WebDriver
 import org.scalatest._
 import org.scalatest.selenium.WebBrowser
+import Config.appUrl
 
 case class SubscriptionTest(url: String, name: String, landingHost: String)
 
@@ -18,7 +19,7 @@ object SubscriptionTest {
 }
 
 class PrintSubscriptionsSpec extends FreeSpec with ShouldMatchers with WebBrowser with BeforeAndAfterAll {
-  implicit lazy val driver: WebDriver = Driver.fromConfig
+  implicit lazy val driver: WebDriver = Config.driver
 
   val testData = Seq(
     SubscriptionTest.collection(viewCollectionPaper.toString, "Paper voucher subscription"),

--- a/test/functional/PrintSubscriptionsSpec.scala
+++ b/test/functional/PrintSubscriptionsSpec.scala
@@ -2,7 +2,6 @@ package functional
 
 import java.net.URL
 
-import controllers.routes.Shipping.{viewCollectionPaper, viewCollectionPaperDigital, viewDeliveryPaperDigital, viewDeliveryPaper}
 import functional.pages.{Home, SubscriptionPlan}
 import org.openqa.selenium.WebDriver
 import org.scalatest._
@@ -22,10 +21,10 @@ class PrintSubscriptionsSpec extends FreeSpec with ShouldMatchers with WebBrowse
   implicit lazy val driver: WebDriver = Config.driver
 
   val testData = Seq(
-    SubscriptionTest.collection(viewCollectionPaper.toString, "Paper voucher subscription"),
-    SubscriptionTest.collection(viewCollectionPaperDigital.toString, "Paper + digital voucher subscription"),
-    SubscriptionTest.delivery(viewDeliveryPaper.toString, "Paper home delivery subscription"),
-    SubscriptionTest.delivery(viewDeliveryPaperDigital.toString, "Paper + digital home delivery subscription")
+    SubscriptionTest.collection("/collection/paper", "Paper voucher subscription"),
+    SubscriptionTest.collection("/collection/paper-digital", "Paper + digital voucher subscription"),
+    SubscriptionTest.delivery("/delivery/paper", "Paper home delivery subscription"),
+    SubscriptionTest.delivery("/delivery/paper-digital", "Paper + digital home delivery subscription")
   )
 
   "Lucrative subscriptions" - {

--- a/test/functional/PrintSubscriptionsSpec.scala
+++ b/test/functional/PrintSubscriptionsSpec.scala
@@ -2,7 +2,7 @@ package functional
 
 import java.net.URL
 
-import functional.pages.{Home, SubscriptionPlan}
+import functional.pages.{DigitalPack, Home, SubscriptionPlan}
 import org.openqa.selenium.WebDriver
 import org.scalatest._
 import org.scalatest.selenium.WebBrowser
@@ -48,6 +48,21 @@ class PrintSubscriptionsSpec extends FreeSpec with ShouldMatchers with WebBrowse
       assert(pageHasText("You have chosen\nWEEKEND"), "document contains selected plan")
       assertResult("www.guardiansubscriptions.co.uk")(currentHost)
     }
+  }
+
+  "Digital Pack" - {
+    "selecting UK" taggedAs Acceptance in {
+      pending
+      DigitalPack.selectUK
+      assert(pageHasText("You have chosen:\nDigital pack"))
+    }
+
+    "selecting not UK" taggedAs Acceptance in {
+      pending
+      DigitalPack.selectNonUK
+      assertResult("www.guardiansubscriptions.co.uk")(currentHost)
+    }
+
   }
 
   private def currentHost: String = new URL(currentUrl).getHost

--- a/test/functional/PrintSubscriptionsSpec.scala
+++ b/test/functional/PrintSubscriptionsSpec.scala
@@ -2,35 +2,41 @@ package functional
 
 import java.net.URL
 
-import controllers.routes.Shipping.{viewCollectionPaper, viewCollectionPaperDigital, viewDeliveryPaperDigital, viewDeliveryPaper}
 import configuration.Config.appUrl
 import functional.pages.{Home, SubscriptionPlan}
 import org.openqa.selenium.WebDriver
 import org.scalatest._
 import org.scalatest.selenium.WebBrowser
 
-case class Subscription(name: String, landingHost: String)
+case class SubscriptionTest(url: String, name: String, landingHost: String)
+
+object SubscriptionTest {
+  def collection(url: String, name: String) =
+    SubscriptionTest(url, name, "www.guardiansubscriptions.co.uk")
+  def delivery(url: String, name: String) =
+    SubscriptionTest(url, name, "www.guardiandirectsubs.co.uk")
+}
 
 class PrintSubscriptionsSpec extends FreeSpec with ShouldMatchers with WebBrowser with BeforeAndAfterAll {
   implicit lazy val driver: WebDriver = Driver.fromConfig
 
-  "selecting a subscription managed through " - {
+  val testData = Seq(
+    SubscriptionTest.collection(viewCollectionPaper.toString, "Paper voucher subscription"),
+    SubscriptionTest.collection(viewCollectionPaperDigital.toString, "Paper + digital voucher subscription"),
+    SubscriptionTest.delivery(viewDeliveryPaper.toString, "Paper home delivery subscription"),
+    SubscriptionTest.delivery(viewDeliveryPaperDigital.toString, "Paper + digital home delivery subscription")
+  )
+
+  "Lucrative subscriptions" - {
+    for (test <- testData) yield test.name.taggedAs(Acceptance) in {
+      goTo(s"$appUrl/${test.url}")
+      SubscriptionPlan.selectSixdayPackage()
+      assert(pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
+      assertResult(test.landingHost)(currentHost)
+    }
+
     "Paper + Digital subscription" taggedAs Acceptance in {
       Home.selectPaperPlusDigital()
-      SubscriptionPlan.selectSixdayPackage()
-      assert(pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
-      assertResult("www.guardiansubscriptions.co.uk")(currentHost)
-    }
-
-    "Paper voucher subscription" taggedAs Acceptance in {
-      goTo(s"$appUrl/${viewCollectionPaper.toString}")
-      SubscriptionPlan.selectSixdayPackage()
-      assert(pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
-      assertResult("www.guardiansubscriptions.co.uk")(currentHost)
-    }
-
-    "Paper voucher + digital subscription" taggedAs Acceptance in {
-      goTo(s"$appUrl/${viewCollectionPaperDigital.toString}")
       SubscriptionPlan.selectSixdayPackage()
       assert(pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
       assertResult("www.guardiansubscriptions.co.uk")(currentHost)
@@ -41,20 +47,6 @@ class PrintSubscriptionsSpec extends FreeSpec with ShouldMatchers with WebBrowse
       SubscriptionPlan.selectWeekendPackage()
       assert(pageHasText("You have chosen\nWEEKEND"), "document contains selected plan")
       assertResult("www.guardiansubscriptions.co.uk")(currentHost)
-    }
-
-    "Paper home delivery + digital subscription" taggedAs Acceptance in {
-      goTo(s"$appUrl/${viewDeliveryPaperDigital.toString}")
-      SubscriptionPlan.selectWeekendPackage()
-      assert(pageHasText("You have chosen\nWEEKEND"), "document contains selected plan")
-      assertResult("www.guardiandirectsubs.co.uk")(currentHost)
-    }
-
-    "Paper home delivery subscription" taggedAs Acceptance in {
-      goTo(s"$appUrl/${viewDeliveryPaper.toString}")
-      SubscriptionPlan.selectSixdayPackage()
-      assert(pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
-      assertResult("www.guardiandirectsubs.co.uk")(currentHost)
     }
   }
 

--- a/test/functional/PrintSubscriptionsSpec.scala
+++ b/test/functional/PrintSubscriptionsSpec.scala
@@ -1,0 +1,28 @@
+package functional
+
+import functional.pages.{Home, SubscriptionPlan}
+import org.openqa.selenium.WebDriver
+import org.scalatest._
+import org.scalatest.selenium.WebBrowser
+
+class PrintSubscriptionsSpec extends FreeSpec with ShouldMatchers with WebBrowser with BeforeAndAfterAll {
+  implicit val driver: WebDriver = Driver.fromConfig
+
+  "selecting a subscription managed through guardiansubscriptions.co.uk" - {
+    "Paper + Digital subscription" taggedAs(Core, Acceptance) in {
+      Home.selectPaperPlusDigital()
+      SubscriptionPlan.selectSixdayPackage()
+      assert(SubscriptionPlan.pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
+    }
+
+    "Paper only subscription" taggedAs(Core, Acceptance) in {
+      Home.selectPaper()
+      SubscriptionPlan.selectWeekendPackage()
+      assert(SubscriptionPlan.pageHasText("You have chosen\nWEEKEND"), "document contains selected plan")
+    }
+  }
+
+  override def afterAll() {
+    quit()
+  }
+}

--- a/test/functional/Tags.scala
+++ b/test/functional/Tags.scala
@@ -1,0 +1,8 @@
+package functional
+
+import org.scalatest.Tag
+
+object Core extends Tag("core")
+object Acceptance extends Tag("functional")
+object Optional extends Tag("optional")
+object Unstable extends Tag("unsatable")

--- a/test/functional/Tags.scala
+++ b/test/functional/Tags.scala
@@ -2,7 +2,7 @@ package functional
 
 import org.scalatest.Tag
 
-object Core extends Tag("core")
-object Acceptance extends Tag("functional")
-object Optional extends Tag("optional")
-object Unstable extends Tag("unsatable")
+object Core extends Tag("Core")
+object Acceptance extends Tag("Acceptance")
+object Optional extends Tag("Optional")
+object Unstable extends Tag("Unsatable")

--- a/test/functional/pages/DigitalPack.scala
+++ b/test/functional/pages/DigitalPack.scala
@@ -1,0 +1,23 @@
+package functional.pages
+
+import org.openqa.selenium.WebDriver
+import org.scalatest.selenium.{WebBrowser, Page}
+import functional.Config.appUrl
+
+object DigitalPack extends Page with WebBrowser {
+  override val url = s"$appUrl/digital/country"
+
+  def selectUK(implicit d: WebDriver) = {
+    selectCountry("uk")
+  }
+
+  def selectNonUK(implicit d: WebDriver) = {
+    selectCountry("Not the United Kingdom")
+  }
+
+  private def selectCountry(value: String)(implicit d: WebDriver):Unit = {
+    go.to(this)
+    singleSel("country").value = value
+    click on cssSelector("""button[type="submit"]""")
+  }
+}

--- a/test/functional/pages/Home.scala
+++ b/test/functional/pages/Home.scala
@@ -1,13 +1,11 @@
 package functional.pages
 
-import configuration.Config.appUrl
+import functional.Config.appUrl
 import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.{Page, WebBrowser}
 
 object Home extends Page with WebBrowser {
   val url = appUrl
-
-  def selectDigital = ???
 
   def selectPaperPlusDigital()(implicit d: WebDriver) =
     selectPlan("""*[data-test-id="subscriptions-uk-paper-digital"]""")

--- a/test/functional/pages/Home.scala
+++ b/test/functional/pages/Home.scala
@@ -1,0 +1,22 @@
+package functional.pages
+
+import configuration.Config.appUrl
+import org.openqa.selenium.WebDriver
+import org.scalatest.selenium.{Page, WebBrowser}
+
+object Home extends Page with WebBrowser {
+  val url = appUrl
+
+  def selectDigital = ???
+
+  def selectPaperPlusDigital()(implicit d: WebDriver) =
+    selectPlan("""*[data-test-id="subscriptions-uk-paper-digital"]""")
+
+  def selectPaper()(implicit d: WebDriver) =
+    selectPlan( """*[data-test-id="subscriptions-uk-paper"]""")
+
+  private def selectPlan(selector: String)(implicit d: WebDriver) = {
+    go.to(this)
+    clickOn(cssSelector(selector))
+  }
+}

--- a/test/functional/pages/Home.scala
+++ b/test/functional/pages/Home.scala
@@ -14,7 +14,7 @@ object Home extends Page with WebBrowser {
     selectPlan( """*[data-test-id="subscriptions-uk-paper"]""")
 
   private def selectPlan(selector: String)(implicit d: WebDriver) = {
-    go.to(this)
+    if (currentUrl != url) go.to(this)
     clickOn(cssSelector(selector))
   }
 }

--- a/test/functional/pages/SubscriptionPlan.scala
+++ b/test/functional/pages/SubscriptionPlan.scala
@@ -8,10 +8,6 @@ object SubscriptionPlan extends  WebBrowser {
   def selectSixdayPackage()(implicit d: WebDriver) = selectPackage("sixday")
   def selectWeekendPackage()(implicit d: WebDriver) = selectPackage("weekend")
 
-  def pageHasText(text: String)(implicit d: WebDriver): Boolean = {
-    find(tagName("body")).get.text.contains(text)
-  }
-
   private def selectPackage(id: String)(implicit d: WebDriver) = {
     clickOn(cssSelector(s"""label[for="$id"]"""))
     clickOn(cssSelector("""*[data-test-id="choose-package-select"]"""))

--- a/test/functional/pages/SubscriptionPlan.scala
+++ b/test/functional/pages/SubscriptionPlan.scala
@@ -1,0 +1,19 @@
+package functional.pages
+
+import org.openqa.selenium.WebDriver
+import org.scalatest.selenium.WebBrowser
+
+object SubscriptionPlan extends  WebBrowser {
+  def selectEverydayPackage()(implicit d: WebDriver) = selectPackage("everyday")
+  def selectSixdayPackage()(implicit d: WebDriver) = selectPackage("sixday")
+  def selectWeekendPackage()(implicit d: WebDriver) = selectPackage("weekend")
+
+  def pageHasText(text: String)(implicit d: WebDriver): Boolean = {
+    find(tagName("body")).get.text.contains(text)
+  }
+
+  private def selectPackage(id: String)(implicit d: WebDriver) = {
+    clickOn(cssSelector(s"""label[for="$id"]"""))
+    clickOn(cssSelector("""*[data-test-id="choose-package-select"]"""))
+  }
+}


### PR DESCRIPTION
Implements a small regression test covering the Print-only and Print + Digital subscriptions workflow. This can be run locally (against `https://sub.thegulocal.com`), or against the production site. 

@TesterSpike @rtyley 