### PR TITLE
Remove thankyou panel

### DIFF
--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -54,35 +54,27 @@
             <p>Enter a password to finish creating your account:</p>
             <form action="@processFinishAccount" method="POST" class="form">
                 @helper.CSRF.formField
-                <fieldset class="fieldset">
-                    <div class="fieldset__fields">
-                        <div class="form-field js-checkout-finish-account-password">
-                            <input name="@userIdParam" type="hidden" value="@form.data.get(userIdParam)">
-                            <input name="@identityTokenParam" type="hidden" value="@form.data.get(identityTokenParam)">
-                            <label class="label" for="last">Password</label>
-                            <input class="input-text js-input js-password-strength"
-                                   name="password"
-                                   type="password"
-                                   autocapitalize="off"
-                                   autocorrect="off"
-                                   spellcheck="false"
-                                   minlength="6"
-                                   maxlength="20"
-                                   value=""
-                                   required />
+                <div class="form-field js-checkout-finish-account-password">
+                    <input name="@userIdParam" type="hidden" value="@form.data.get(userIdParam)">
+                    <input name="@identityTokenParam" type="hidden" value="@form.data.get(identityTokenParam)">
+                    <label class="label" for="last">Password</label>
+                    <input class="input-text js-input js-password-strength"
+                           name="password"
+                           type="password"
+                           autocapitalize="off"
+                           autocorrect="off"
+                           spellcheck="false"
+                           minlength="6"
+                           maxlength="20"
+                           value=""
+                           required />
 
-                            @checkout.errorMessage("Password too short")
-                        </div>
-                        <div class="password-strength-indicator score-null is-off is-hidden js-on js-password-strength-indicator">
-                            <div class="form-note form-note--right form-note--underneath js-password-strength-label">
-                                Password strength
-                            </div>
-                        </div>
-                        <div class="actions">
-                            <button class="button button--primary button--large js-checkout-finish-account-submit">Confirm</button>
-                        </div>
-                    </div>
-                </fieldset>
+                    @checkout.errorMessage("Password too short")
+                </div>
+                @fragments.forms.passwordStrengthIndicator()
+                <div class="actions">
+                    <button class="button button--primary button--large js-checkout-finish-account-submit">Confirm</button>
+                </div>
             </form>
         }
 

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -92,19 +92,5 @@
     </div>
 </div>
 
-<div class="membership-promo">
-    <div class="gs-container">
-        <div class="block">
-            <h2 class="block__title">Get even closer to the Guardian <span class="break">by becoming a member</span></h2>
-            <div class="block__footer">
-                <div class="block__info">
-                    <div>We're bringing the Guardian to life <span class="break">through live events and meet-ups</span></div>
-                    <div class="action">Join and be part of the <span class="break">conversations that matter</span></div>
-                </div>
-                <a class="button button--secondary button--large" href="https://membership.theguardian.com/join?INTCMP=GU_SUBSCRIPTIONS_UK_PROMO" data-test-id="subscriptions-uk-membership">Join now</a>
-            </div>
-        </div>
-    </div>
-</div>
 
 }

--- a/app/views/fragments/forms/passwordStrengthIndicator.scala.html
+++ b/app/views/fragments/forms/passwordStrengthIndicator.scala.html
@@ -1,0 +1,6 @@
+<div class="password-strength">
+    <div class="password-strength__indicator score-null is-off is-hidden js-on js-password-strength-indicator"></div>
+    <div class="password-strength__note js-password-strength-label">
+        Password strength
+    </div>
+</div>

--- a/assets/stylesheets/modules/_forms.scss
+++ b/assets/stylesheets/modules/_forms.scss
@@ -237,12 +237,13 @@ $password-strength-score-2: #ffbb00;
 $password-strength-score-3: #aad801;
 $password-strength-score-4: #33a22b;
 
-.password-strength-indicator {
-    background-color: $c-neutral5;
+.password-strength {
+    margin-bottom: $gs-baseline / 2;
+}
+.password-strength__indicator {
     height: 8px;
-    margin-top: 4px;
-    margin-bottom: ($gs-baseline * 2);
     position: relative;
+    background-color: $c-neutral5;
 
     &:after {
         bottom: 0;
@@ -271,5 +272,14 @@ $password-strength-score-4: #33a22b;
     &.score-4:after {
         width: 100%;
         background-color: $password-strength-score-4;
+    }
+}
+.password-strength__note {
+    @include fs-textSans(1);
+    color: $c-neutral2;
+    margin: ($gs-baseline / 2) 0;
+
+    @include mq(mobile) {
+        text-align: right;
     }
 }


### PR DESCRIPTION
Removes the Membership panel on thankyou page, going to actually implement it in another PR. Resolves this:

![screen shot 2015-07-08 at 12 22 50](https://cloud.githubusercontent.com/assets/123386/8569134/1e62ef76-256c-11e5-84d4-7bc330de89d6.png)

The panel will look like this:

![screen shot 2015-07-08 at 12 05 04](https://cloud.githubusercontent.com/assets/123386/8569136/254d58e4-256c-11e5-9a33-9c2fe8d0f870.png)

Also refactors the password strength meter to fix a couple of display bugs (Membership implementation already had this issue so I'll port this back).

![screen shot 2015-07-08 at 12 21 44](https://cloud.githubusercontent.com/assets/123386/8569152/4aacafa4-256c-11e5-83e7-1cdf3e9c4bca.png)

@afiore 
