### PR TITLE
Fix global line-height

### DIFF
--- a/assets/stylesheets/base/_base.scss
+++ b/assets/stylesheets/base/_base.scss
@@ -18,6 +18,7 @@ html {
 body {
     margin: 0;
     color: $c-body;
+    line-height: 1.5;
 }
 
 h1, h2, h3 {


### PR DESCRIPTION
PR https://github.com/guardian/subscriptions-frontend/pull/74 caused the line-height a little cramped on Digital Pack landing page, other pages are largely fine. This corrects that by setting the preferred default line-height.

![screen shot 2015-07-08 at 12 48 21](https://cloud.githubusercontent.com/assets/123386/8569443/a4c93c52-256f-11e5-9e82-2fab77a6d416.png)

![screen shot 2015-07-08 at 12 48 24](https://cloud.githubusercontent.com/assets/123386/8569442/a4c8f094-256f-11e5-8ae2-cfea5a580f3f.png)
