### PR TITLE
Display address line 2 as optional

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -101,24 +101,24 @@
                         </div>
                         <div class="js-checkout-full-address">
                             <div class="form-field js-checkout-house">
-                                <label class="label" for="house">Address line 1</label>
-                                <input type="text" class="input-text js-input" name="personal.address.address1" value="@form.data.get("personal.address.address1")">
+                                <label class="label" for="address-line-1">Address line 1</label>
+                                <input type="text" class="input-text js-input" id="address-line-1" name="personal.address.address1" value="@form.data.get("personal.address.address1")">
                                 @checkout.errorMessage("This field is required")
                             </div>
                             <div class="form-field js-checkout-street">
-                                <label class="label" for="street">Address line 2</label>
-                                <input type="text" class="input-text js-input" name="personal.address.address2" value="@form.data.get("personal.address.address2")">
+                                <label class="label optional-marker" for="address-line-2">Address line 2</label>
+                                <input type="text" class="input-text js-input" id="address-line-2" name="personal.address.address2" value="@form.data.get("personal.address.address2")">
                                 @checkout.errorMessage("This field is required")
                             </div>
                             <div class="form-field js-checkout-town">
-                                <label class="label" for="town">Town/City</label>
-                                <input type="text" class="input-text js-input" name="personal.address.town" value="@form.data.get("personal.address.town")">
+                                <label class="label" for="address-town">Town/City</label>
+                                <input type="text" class="input-text js-input" id="address-town" name="personal.address.town" value="@form.data.get("personal.address.town")">
                                 @checkout.errorMessage("This field is required")
                             </div>
                         </div>
                         <div class="form-field js-checkout-postcode">
-                            <label class="label" for="postcode">Postcode</label>
-                            <input type="text" class="input-text js-input input-text input-text--small" name="personal.address.postcode" value="@form.data.get("personal.address.postcode")">
+                            <label class="label" for="address-postcode">Postcode</label>
+                            <input type="text" class="input-text js-input input-text input-text--small" id="address-postcode" name="personal.address.postcode" value="@form.data.get("personal.address.postcode")">
                             @checkout.errorMessage("Please enter a valid postal code")
                         </div>
                         <div class="form-field">

--- a/assets/javascripts/modules/checkout/validations.js
+++ b/assets/javascripts/modules/checkout/validations.js
@@ -18,7 +18,6 @@ define([
         {input: form.$FIRST_NAME, container: form.$FIRST_NAME_CONTAINER},
         {input: form.$LAST_NAME, container: form.$LAST_NAME_CONTAINER},
         {input: form.$ADDRESS1, container: form.$ADDRESS1_CONTAINER},
-        {input: form.$ADDRESS2, container: form.$ADDRESS2_CONTAINER},
         {input: form.$ADDRESS3, container: form.$ADDRESS3_CONTAINER},
         {input: form.$POSTCODE, container: form.$POSTCODE_CONTAINER}
     ];

--- a/assets/stylesheets/modules/_forms.scss
+++ b/assets/stylesheets/modules/_forms.scss
@@ -227,6 +227,17 @@
     margin-top: ($gs-baseline / 2);
 }
 
+/* Form Extras
+   ========================================================================== */
+
+.optional-marker:after {
+    @include fs-textSans(1);
+    color: $c-neutral2;
+    vertical-align: middle;
+    margin-left: .25em;
+    content: '(optional)';
+}
+
 /* ==========================================================================
    Password Strength indicator
    ========================================================================== */


### PR DESCRIPTION
This displays address line 2 as optional and fixes some missing label associations originally highlighted in https://github.com/guardian/subscriptions-frontend/pull/73

![screen shot 2015-07-08 at 14 13 18](https://cloud.githubusercontent.com/assets/123386/8570935/b4576c1e-257b-11e5-8f65-098ab2d12005.png)

**Note:** This assumes that an empty value is posted to the service as an empty string. Membership does this the same way i.e., address2 not an Option. Current assumption is that this passes through to the service OK.