### PR TITLE
Reinstate edit links on checkout page

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -70,8 +70,8 @@
                                 <a href="@webAppSigninUrl(renderCheckout().toString())">Sign in</a>
                             }
                         </div>
-                        <div class="fieldset__edit is-hidden">
-                            <button class="u-button-reset js-edit-your-details">Edit</button>
+                        <div class="fieldset__edit">
+                            <button class="text-button u-button-reset js-edit-your-details is-hidden">Edit</button>
                         </div>
                     </div>
                     <div class="fieldset__fields">
@@ -148,8 +148,8 @@
                         </h2>
                         <p class="fieldset__note"><i class="icon-secure"></i> This site is secure</p>
                         <div class="fieldset__note">Payment will be taken by Direct Debit</div>
-                        <div class="fieldset__edit is-hidden">
-                            <button class="u-button-reset js-edit-payment-details">Edit</button>
+                        <div class="fieldset__edit">
+                            <button class="text-button u-button-reset js-edit-payment-details is-hidden">Edit</button>
                         </div>
                     </div>
                     <div class="fieldset__fields">

--- a/assets/stylesheets/modules/_buttons.scss
+++ b/assets/stylesheets/modules/_buttons.scss
@@ -80,3 +80,13 @@
         display: none;
     }
 }
+
+.text-button {
+    @include fs-data(3);
+    line-height: 1;
+    cursor: pointer;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}


### PR DESCRIPTION
Should probably still show edit links...

![screen shot 2015-07-09 at 11 55 00](https://cloud.githubusercontent.com/assets/123386/8593645/75ad4ef0-2631-11e5-99c4-be97a708aefa.png)

@jennysivapalan 