### PR TITLE
Country select page design

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -12,13 +12,11 @@
     bodyClasses = List("is-wide")
 ) {
 
-<div class="gs-container">
+<main class="gs-container">
 
-    <div class="checkout-container">
+    <section class="checkout-container">
 
-        <div class="checkout-header">
-            <h1 class="checkout-header__title">Checkout</h1>
-        </div>
+        @fragments.checkout.checkoutHeader("Checkout")
 
         <div class="checkout-container__sidebar">
             @fragments.checkout.basketPreview()
@@ -234,7 +232,7 @@
 
         </div>
 
-    </div>
+    </section>
 
-</div>
+</main>
 }

--- a/app/views/digitalpack/country.scala.html
+++ b/app/views/digitalpack/country.scala.html
@@ -1,34 +1,43 @@
 @()(implicit rh: RequestHeader)
 
-@main("Select your country | Digital | Subscriptions | The Guardian") {
+@main("Select your country | Digital | Subscriptions | The Guardian", bodyClasses = List("is-wide")) {
 
-<div class="gs-container">
-    @fragments.page.header("Digital Pack", Some("Digital access to our Daily Edition and Guardian App Premium Tier"))
+<main class="gs-container">
 
-    <div class="row row--items-1">
-        <div class="row__item">
-            <form class="form" method="POST">
-                @helper.CSRF.formField
-                <fieldset class="fieldset fieldset--single">
-                    <div class="fieldset__heading">
-                        <h2 class="fieldset__headline">The Digital Pack is available throughout the world</h2>
-                    </div>
-                    <div class="fieldset__fields">
+    <section class="checkout-container">
+
+        @fragments.checkout.checkoutHeader("Checkout")
+
+        <div class="checkout-container__sidebar">
+            @fragments.checkout.basketPreview()
+        </div>
+
+        <div class="checkout-container__form">
+
+            <div class="country-select">
+                <h2 class="country-select__title">The Digital Pack is available throughout the world</h2>
+                <div class="country-select__content">
+                    <form class="form-panel" method="POST">
+                        @helper.CSRF.formField
                         <div class="form-field">
                             <label class="label" for="country">Please select your country</label>
-                            <select class="select select--wide" name="country" id="country">
-                                <option selected="selected" value="uk">United Kingdom</option>
-                                <option value="row">Not the United Kingdom</option>
-                            </select>
+                            <div class="custom-select">
+                                <select name="country" id="country">
+                                    <option selected="selected" value="uk">United Kingdom</option>
+                                    <option value="row">Not the United Kingdom</option>
+                                </select>
+                            </div>
                         </div>
                         <div class="actions">
                             <button type="submit" class="button button--primary button--large">Continue</button>
                         </div>
-                    </div>
-                </fieldset>
-            </form>
+                    </form>
+                </div>
+            </div>
+
         </div>
-    </div>
-</div>
+
+    </section>
+</main>
 
 }

--- a/app/views/fragments/checkout/checkoutHeader.scala.html
+++ b/app/views/fragments/checkout/checkoutHeader.scala.html
@@ -1,0 +1,5 @@
+@(title: String)
+
+<div class="checkout-header">
+    <h1 class="checkout-header__title">@title</h1>
+</div>

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -40,6 +40,8 @@
 @import 'modules/sections';
 @import 'modules/icons';
 @import 'modules/forms';
+@import 'modules/forms-select';
+@import 'modules/forms-password';
 @import 'modules/buttons';
 @import 'modules/packages';
 @import 'modules/digital';

--- a/assets/stylesheets/modules/_checkout.scss
+++ b/assets/stylesheets/modules/_checkout.scss
@@ -39,6 +39,37 @@
     }
 }
 
+/* Country Select
+   ========================================================================== */
+
+.country-select {
+    border-top: 1px solid $c-border;
+    padding-top: $gs-baseline / 2;
+    margin-bottom: $gs-baseline;
+
+    @include mq(desktop) {
+        display: table;
+        width: 100%
+    }
+}
+.country-select__title,
+.country-select__content {
+    @include mq(desktop) {
+        display: table-cell;
+        vertical-align: top;
+    }
+}
+.country-select__title {
+    @include fs-header(3);
+    color: $c-brand;
+    margin-bottom: $gs-gutter;
+
+    @include mq(desktop) {
+        width: 35%;
+        padding-right: ($gs-gutter * 2);
+    }
+}
+
 /* Basket Preview
    ========================================================================== */
 

--- a/assets/stylesheets/modules/_forms-password.scss
+++ b/assets/stylesheets/modules/_forms-password.scss
@@ -1,0 +1,56 @@
+/* ==========================================================================
+   Forms - Password Strength indicator
+   ========================================================================== */
+
+$password-strength-score-0: #e31f26;
+$password-strength-score-1: #e6711b;
+$password-strength-score-2: #ffbb00;
+$password-strength-score-3: #aad801;
+$password-strength-score-4: #33a22b;
+
+.password-strength {
+    margin-bottom: $gs-baseline / 2;
+}
+.password-strength__indicator {
+    height: 8px;
+    position: relative;
+    background-color: $c-neutral5;
+
+    &:after {
+        bottom: 0;
+        content: '';
+        display: block;
+        left: 0;
+        position: absolute;
+        top: 0;
+    }
+    &.score-0:after {
+        width: 20%;
+        background-color: $password-strength-score-0;
+    }
+    &.score-1:after {
+        width: 40%;
+        background-color: $password-strength-score-1;
+    }
+    &.score-2:after {
+        width: 60%;
+        background-color: $password-strength-score-2;
+    }
+    &.score-3:after {
+        width: 80%;
+        background-color: $password-strength-score-3;
+    }
+    &.score-4:after {
+        width: 100%;
+        background-color: $password-strength-score-4;
+    }
+}
+.password-strength__note {
+    @include fs-textSans(1);
+    color: $c-neutral2;
+    margin: ($gs-baseline / 2) 0;
+
+    @include mq(mobile) {
+        text-align: right;
+    }
+}

--- a/assets/stylesheets/modules/_forms-select.scss
+++ b/assets/stylesheets/modules/_forms-select.scss
@@ -91,7 +91,7 @@
  * Targeted via this hack http://browserhacks.com/#hack-a3f166304aafed524566bc6814e1d5c7
  */
 x:-o-prefocus, .custom-select::after {
-    display:none;
+    display: none;
 }
 
 /**
@@ -105,33 +105,12 @@ x:-o-prefocus, .custom-select::after {
  * http://stackoverflow.com/questions/17553300/change-ie-background-color-on-unopened-focused-select-box
  */
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .custom-select select::-ms-expand {
-    display: none;
-  }
-  .custom-select select:focus::-ms-value {
-    background: transparent;
-    color: $c-neutral1;
-  }
-}
-
-/**
- * FIREFOX won't let us hide the native select arrow, so we have to make it wider than needed and clip it via overflow on the parent container.
- * The percentage width is a fallback since FF 4+ supports calc() so we can just add a fixed amount of extra width to push the native arrow out of view.
- * We're applying this hack across all FF versions because all the previous hacks were too fragile and complex.
- * You might want to consider not using this hack and using the native select arrow in FF.
- * Note this makes the menus wider than the select button because they display at the specified width and aren't clipped.
- * Targeting hack via http://browserhacks.com/#hack-758bff81c5c32351b02e10480b5ed48e
- *
- * Show only the native arrow
- */
-@-moz-document url-prefix() {
-    .custom-select {
-        overflow: hidden;
+    .custom-select select::-ms-expand {
+        display: none;
     }
-    .custom-select select {
-        width: 120%;
-        width: -moz-calc(100% + 3em);
-        width: calc(100% + em);
+    .custom-select select:focus::-ms-value {
+        background: transparent;
+        color: $c-neutral1;
     }
 }
 

--- a/assets/stylesheets/modules/_forms-select.scss
+++ b/assets/stylesheets/modules/_forms-select.scss
@@ -1,0 +1,149 @@
+/* ==========================================================================
+   Forms - Custom Select
+   @see https://github.com/filamentgroup/select-css
+   ========================================================================== */
+
+/**
+ * Container used for styling the custom select,
+ */
+.custom-select {
+    position: relative;
+    display: block;
+    padding: 0;
+    margin-bottom: $gs-baseline * 2;
+}
+
+/**
+ * This is the native select,
+ * we're making everything but the text invisible
+ * so we can see the button styles in the wrapper
+ *
+ * [1] Font size must be 16px or larger to prevent iOS page zoom on focus
+ */
+.custom-select select {
+    @include f-textSans();
+    font-size: 1em; // [1]
+    line-height: inherit;
+    color: inherit;
+    margin: 0;
+    width: 100%;
+    outline: none;
+    box-sizing: border-box;
+    -webkit-appearance: none;
+    appearance: none;
+    padding: ($gs-baseline / 2) $gs-baseline;
+    border: 1px solid $c-border;
+    border-radius: 20px;
+    background-color: $c-white;
+
+}
+
+/**
+ * Custom select arrow
+ * [1] Offset by 1/2 of the icon height to center
+ * [2] This hack make the select behind the arrow clickable in some browsers
+ */
+.custom-select::after {
+    content: "";
+    position: absolute;
+    z-index: 2;
+    top: 50%;
+    right: $gs-gutter;
+    height: 14px;
+    width: 7px;
+    margin-top: -7px; // [1]
+    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxNi4wLjEsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB3aWR0aD0iN3B4IiBoZWlnaHQ9IjE0LjAyN3B4IiB2aWV3Qm94PSIwIDAgNyAxNC4wMjciIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDcgMTQuMDI3IiB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxwYXRoIGZpbGw9IiMzMDMwMzAiIGQ9Ik02LjQ1MSwxMC4xODRMNC4xNDUsMTEuOTRWOC4yOWgtMS4yOXYzLjY1bC0yLjMwNi0xLjc1N0wwLDEwLjc2MWwzLjI3NiwzLjI2N2gwLjQ0OEw3LDEwLjc2MUw2LjQ1MSwxMC4xODR6DQoJIE0yLjg1NSwyLjA1OXYzLjY3OGgxLjI5VjIuMDU5bDIuMzA3LDEuNzU3TDcsMy4yNjdMMy43MjQsMEgzLjI3NkwwLDMuMjY3bDAuNTQ5LDAuNTQ5TDIuODU1LDIuMDU5eiIvPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPC9zdmc+DQo=);
+    background-repeat: no-repeat;
+    background-size: 100%;
+    pointer-events: none; // [2]
+}
+
+/**
+ * Hover styles
+ */
+.custom-select:hover select {
+    border: 1px solid $c-neutral3;
+}
+
+/**
+ * Focus styles
+ */
+.custom-select select:focus {
+    outline: none;
+    box-shadow: 0 0 1px 2px rgba(180, 222, 250, 1);
+    color: $c-neutral1;
+    border: 1px solid $c-neutral3;
+}
+
+/**
+ * Set options to normal weight
+ */
+.custom-select option {
+    font-weight: normal;
+}
+
+/* ------------------------------------  */
+/* START OF UGLY BROWSER-SPECIFIC HACKS */
+/* ----------------------------------  */
+
+/**
+ * OPERA - Pre-Blink nix the custom arrow, go with a native select button to keep it simple.
+ * Targeted via this hack http://browserhacks.com/#hack-a3f166304aafed524566bc6814e1d5c7
+ */
+x:-o-prefocus, .custom-select::after {
+    display:none;
+}
+
+/**
+ * IE 10/11+
+ * This hides native dropdown button arrow so it will have the custom appearance,
+ * IE 9 and earlier get a native select - targeting media query hack via
+ * http://browserhacks.com/#hack-28f493d247a12ab654f6c3637f6978d5
+ *
+ * The second rule removes the odd blue bg color behind the text in the select button in
+ * IE 10/11 and sets the text color to match the focus style's fix via
+ * http://stackoverflow.com/questions/17553300/change-ie-background-color-on-unopened-focused-select-box
+ */
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  .custom-select select::-ms-expand {
+    display: none;
+  }
+  .custom-select select:focus::-ms-value {
+    background: transparent;
+    color: $c-neutral1;
+  }
+}
+
+/**
+ * FIREFOX won't let us hide the native select arrow, so we have to make it wider than needed and clip it via overflow on the parent container.
+ * The percentage width is a fallback since FF 4+ supports calc() so we can just add a fixed amount of extra width to push the native arrow out of view.
+ * We're applying this hack across all FF versions because all the previous hacks were too fragile and complex.
+ * You might want to consider not using this hack and using the native select arrow in FF.
+ * Note this makes the menus wider than the select button because they display at the specified width and aren't clipped.
+ * Targeting hack via http://browserhacks.com/#hack-758bff81c5c32351b02e10480b5ed48e
+ *
+ * Show only the native arrow
+ */
+@-moz-document url-prefix() {
+    .custom-select {
+        overflow: hidden;
+    }
+    .custom-select select {
+        width: 120%;
+        width: -moz-calc(100% + 3em);
+        width: calc(100% + em);
+    }
+}
+
+/**
+ * Firefox focus has odd artifacts around the text, this kills that.
+ * See https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-focusring
+ */
+.custom-select select:-moz-focusring {
+    color: transparent;
+    text-shadow: 0 0 0 #000;
+}
+
+/* ------------------------------------  */
+/*  END OF UGLY BROWSER-SPECIFIC HACKS  */
+/* ------------------------------------  */

--- a/assets/stylesheets/modules/_forms.scss
+++ b/assets/stylesheets/modules/_forms.scss
@@ -27,6 +27,12 @@ input[type=number] {
     margin-bottom: 0;
 }
 
+.form-panel {
+    background-color: $c-neutral7;
+    padding: ($gs-gutter / 2);
+    padding-bottom: $gs-baseline * 2;
+}
+
 // Form Fieldset
 // ============================================================================
 
@@ -144,6 +150,7 @@ input[type=number] {
     outline: none;
     width: 100%;
     -webkit-appearance: none;
+    appearance: none;
     border-radius: 20px;
 
     &:focus {
@@ -265,61 +272,4 @@ input[type=number] {
     vertical-align: middle;
     margin-left: .25em;
     content: '(optional)';
-}
-
-/* ==========================================================================
-   Password Strength indicator
-   ========================================================================== */
-
-$password-strength-score-0: #e31f26;
-$password-strength-score-1: #e6711b;
-$password-strength-score-2: #ffbb00;
-$password-strength-score-3: #aad801;
-$password-strength-score-4: #33a22b;
-
-.password-strength {
-    margin-bottom: $gs-baseline / 2;
-}
-.password-strength__indicator {
-    height: 8px;
-    position: relative;
-    background-color: $c-neutral5;
-
-    &:after {
-        bottom: 0;
-        content: '';
-        display: block;
-        left: 0;
-        position: absolute;
-        top: 0;
-    }
-    &.score-0:after {
-        width: 20%;
-        background-color: $password-strength-score-0;
-    }
-    &.score-1:after {
-        width: 40%;
-        background-color: $password-strength-score-1;
-    }
-    &.score-2:after {
-        width: 60%;
-        background-color: $password-strength-score-2;
-    }
-    &.score-3:after {
-        width: 80%;
-        background-color: $password-strength-score-3;
-    }
-    &.score-4:after {
-        width: 100%;
-        background-color: $password-strength-score-4;
-    }
-}
-.password-strength__note {
-    @include fs-textSans(1);
-    color: $c-neutral2;
-    margin: ($gs-baseline / 2) 0;
-
-    @include mq(mobile) {
-        text-align: right;
-    }
 }


### PR DESCRIPTION
Update country select to match latest designs. There is still some work to do around responsive styling for the current selection panel, but I want to pick this up with Ben W on Monday.

![screen shot 2015-07-09 at 16 49 14](https://cloud.githubusercontent.com/assets/123386/8599807/6b2ed560-265a-11e5-9958-8d40e17e432a.png)

![screen shot 2015-07-09 at 16 41 50](https://cloud.githubusercontent.com/assets/123386/8599802/66c3a258-265a-11e5-8db5-48aae8bf6eea.png)
![screen shot 2015-07-09 at 16 42 33](https://cloud.githubusercontent.com/assets/123386/8599804/66d8dc90-265a-11e5-84f5-49ff197478c7.png)

From a technical point of view, the most controversial part is the custom select styling. I typically don't recommend custom select styling but Filament group [have a solution](https://github.com/filamentgroup/select-css) which looks pretty solid across browsers and fallsback to default selects on unsupported browsers so it feels OK to use. Does rely on complex CSS browser hacks but they are well documented and tests so it's worth considering if it's worth the complexity.

@tudorraul @afiore 