### PR TITLE
Improve JavaScript fallbacks

### DIFF
--- a/app/views/fragments/global/warnings.scala.html
+++ b/app/views/fragments/global/warnings.scala.html
@@ -1,0 +1,10 @@
+<noscript>
+    <div class="warning-message warning-message--javascript">
+        <strong>Please enable JavaScript</strong>&ndash;we use it to enhance behaviour for Guardian Subscriptions.
+        <a href="http://www.enable-javascript.com/">See instructions to do so in your browser</a>.
+    </div>
+</noscript>
+<div class="warning-message warning-message--browser">
+    You are using an <strong>outdated</strong> browser.
+    If possible <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.
+</div>

--- a/app/views/fragments/head.scala.html
+++ b/app/views/fragments/head.scala.html
@@ -1,15 +1,18 @@
-@(title: String)
+@(title: String, jsVars: model.JsVars)
 
 @import play.api.Play
 @import controllers.CachedAssets.hashedPathFor
 
-<meta charset="utf-8"/>
+<meta charset="utf-8">
+
 <title>@title</title>
 
-<meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
-<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<meta name="format-detection" content="telephone=no"/>
-<meta name="HandheldFriendly" content="True"/>
+<meta http-equiv="X-UA-Compatible" content="IE=Edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="format-detection" content="telephone=no">
+<meta name="HandheldFriendly" content="True">
+
+@fragments.javascriptFirstSteps(jsVars)
 
 <link rel="stylesheet" href="@hashedPathFor("stylesheets/main.min.css")"/>
 <!--[if (IE 9)]>
@@ -24,3 +27,5 @@
 } else {
     <link rel="shortcut icon" type="image/png" href="@hashedPathFor("images/favicons/32x32.ico")"/>
 }
+
+@fragments.javascriptLaterSteps()

--- a/app/views/fragments/javascriptFirstSteps.scala.html
+++ b/app/views/fragments/javascriptFirstSteps.scala.html
@@ -15,30 +15,21 @@
     var guardian = JSON.parse('@Html(Json.stringify(Json.toJson(jsVars)))');
     guardian.buildNumber = '@app.BuildInfo.buildNumber';
     guardian.isModernBrowser =  (
-            'querySelector' in document
-            && 'addEventListener' in window
-            && 'localStorage' in window
-            && 'sessionStorage' in window
-            && 'bind' in Function
-            && (('XMLHttpRequest' in window && 'withCredentials' in new XMLHttpRequest())
-              || 'XDomainRequest' in window));
+        'querySelector' in document
+        && 'addEventListener' in window
+        && 'localStorage' in window
+        && 'sessionStorage' in window
+        && 'bind' in Function
+        && (('XMLHttpRequest' in window && 'withCredentials' in new XMLHttpRequest()) || 'XDomainRequest' in window)
+    );
 
     (function(isModern) {
-        if (isModern) {
-            // only load JS if the browser cuts the mustard
-            var newElm = document.createElement('script');
-            newElm.src = '@hashedPathFor("javascripts/main.min.js")';
-            document.getElementsByTagName("head")[0].appendChild(newElm);
+        // We want to add/remove classes to HTML ASAP to avoid FOUC
+        var htmlClassNames = ['js-on'];
+        document.documentElement.className = document.documentElement.className.replace(/\bjs-off\b/g, '') + ' ' + htmlClassNames.join(' ');
+
+        if (!isModern) {
+            document.documentElement.className += ' js-ancient-browser';
         }
     })(guardian.isModernBrowser);
-
-    // Initialise requireJS loader module Curl
-    var curl = {
-        apiName: "require",
-        paths: {
-            zxcvbn: '@hashedPathFor("javascripts/vendor/zxcvbn.js")'
-        }
-    };
 </script>
-
-<script src='@hashedPathFor("javascripts/vendor/curl.js")'></script>

--- a/app/views/fragments/javascriptLaterSteps.scala.html
+++ b/app/views/fragments/javascriptLaterSteps.scala.html
@@ -9,7 +9,7 @@
         }
     };
 </script>
-<script src="@hashedPathFor("javascripts/vendor/zxcvbn.js")"></script>
+<script src="@hashedPathFor("javascripts/vendor/curl.js")"></script>
 <script id="script-main">
     // Only load JS if the browser cuts the mustard
     function loadJS(a,b){"use strict";var c=window.document.getElementsByTagName("script")[0],d=window.document.createElement("script");return d.src=a,d.async=!0,c.parentNode.insertBefore(d,c),b&&"function"==typeof b&&(d.onload=b),d}

--- a/app/views/fragments/javascriptLaterSteps.scala.html
+++ b/app/views/fragments/javascriptLaterSteps.scala.html
@@ -1,0 +1,21 @@
+@import controllers.CachedAssets.hashedPathFor
+
+@* Scripts that should be executed after CSS is loaded *@
+<script id="script-curl">
+    var curl = {
+        apiName: "require",
+        paths: {
+            zxcvbn: '@hashedPathFor("javascripts/vendor/zxcvbn.js")'
+        }
+    };
+</script>
+<script src="@hashedPathFor("javascripts/vendor/zxcvbn.js")"></script>
+<script id="script-main">
+    // Only load JS if the browser cuts the mustard
+    function loadJS(a,b){"use strict";var c=window.document.getElementsByTagName("script")[0],d=window.document.createElement("script");return d.src=a,d.async=!0,c.parentNode.insertBefore(d,c),b&&"function"==typeof b&&(d.onload=b),d}
+    (function(isModern) {
+        if (isModern) {
+            loadJS('@hashedPathFor("javascripts/main.min.js")');
+        }
+    })(guardian.isModernBrowser);
+</script>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -10,7 +10,9 @@
 <head>
     @fragments.head(title, jsVars)
 </head>
-    <body class="@bodyClasses.mkString(" ")">
+    <body class="js-off @bodyClasses.mkString(" ")">
+
+        @fragments.global.warnings()
         @fragments.global.header()
         @fragments.global.navigation()
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,14 +1,6 @@
-@import model.JsVars
-
-@*
-    TODO:
-    bodyClasses should be avoided and is deprecated.
-    Currently being used for digital pack page and to help transition to a consistent
-    body width throughout the site. The extra classes will be removed when this is the case.
-*@
 @(
     title: String,
-    jsVars: JsVars = JsVars.default,
+    jsVars: model.JsVars = model.JsVars.default,
     isInternational: Boolean = false,
     bodyClasses: Seq[String] = Nil
 )(content: Html)
@@ -16,8 +8,7 @@
 <!DOCTYPE html>
 <html lang="en-GB">
 <head>
-    @fragments.head(title)
-    @fragments.javascriptFirstSteps(jsVars)
+    @fragments.head(title, jsVars)
 </head>
     <body class="@bodyClasses.mkString(" ")">
         @fragments.global.header()

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -48,3 +48,4 @@
 @import 'modules/checkout';
 @import 'modules/checkout-basket';
 @import 'modules/membership';
+@import 'modules/warnings';

--- a/assets/stylesheets/modules/_warnings.scss
+++ b/assets/stylesheets/modules/_warnings.scss
@@ -1,0 +1,25 @@
+/* ==========================================================================
+   Warnings
+   ========================================================================== */
+
+.warning-message {
+    @include fs-bodyCopy(1);
+    padding: $gs-baseline;
+    color: $c-white;
+    background-color: guss-colour(error);
+    text-align: center;
+
+    a {
+        color: inherit;
+    }
+    a:hover {
+        border-color: $c-white;
+    }
+}
+
+.warning-message--browser {
+    display: none;
+}
+.js-ancient-browser .warning-message--browser {
+    display: block;
+}


### PR DESCRIPTION
Improves how JavaScript loading is handled and adds unsupported messages

- Splits `<head`> JavaScript into firstSteps and laterSteps, we want to be loading `main.js` later than CSS, so this introduces that separation between the two stages of scripts.
- Adds no-js and browser unsupported messages.

![screen shot 2015-07-10 at 15 33 21](https://cloud.githubusercontent.com/assets/123386/8621030/44098054-271b-11e5-9def-f17bbc027dec.png)
![screen shot 2015-07-10 at 15 33 42](https://cloud.githubusercontent.com/assets/123386/8621031/44202b38-271b-11e5-8967-424c70c0b221.png)

@rtyley 
