### PR TITLE
Update production to point to UAT

### DIFF
--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -1,4 +1,3 @@
-include "touchpoint.DEV.conf"
 include "application"
 
 stage = "DEV"

--- a/conf/PROD.conf
+++ b/conf/PROD.conf
@@ -1,4 +1,3 @@
-include "touchpoint.PROD.conf"
 include "application"
 
 stage="PROD"
@@ -11,4 +10,4 @@ identity {
 
 subscriptions.url="https://subscribe.theguardian.com"
 
-touchpoint.backend.default=PROD
+touchpoint.backend.default=UAT

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,6 +17,10 @@ application.langs="en"
 # Enable cookie-based session for HTTPS only
 application.session.secure=true
 
+# Touchpoint-backend environment-specific config - ***NO PRIVATE CREDENTIALS in these files***
+include "touchpoint.DEV.conf"
+include "touchpoint.UAT.conf"
+
 google.oauth {
   // https://console.developers.google.com/project/guardian-subscriptions/apiui/credential?authuser=1
   client.id=""

--- a/conf/touchpoint.UAT.conf
+++ b/conf/touchpoint.UAT.conf
@@ -1,6 +1,6 @@
 # ***NO PRIVATE CREDENTIALS IN THIS FILE *** - use subscriptions-frontend in S3 for private data
 touchpoint.backend.environments {
-  PROD {
+  UAT {
     salesforce {
       consumer {
         key = ""
@@ -21,7 +21,7 @@ touchpoint.backend.environments {
         password = ""
       }
       digital {
-        monthly = "2c92c0f84bbfec8b014bc655f4852d9d"
+        monthly = "2c92c0f84e2efd07014e440647377727"
       }
     }
   }


### PR DESCRIPTION
This requires an update to the private config file in S3 before merging.

I've renamed `touchpoint.PROD.conf` to `touchpoint.UAT.conf`. Once we have the production credentials we can create the relevant file.