### PR TITLE
Fix Direct Debit copy, clean up notices

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -23,49 +23,8 @@
 
             <div class="u-display-from-tablet" data-set="checkout-notices">
                 <div class="js-append">
-                    @fragments.checkout.notice("Advanced Notice") {
-                        <p>The details of your Direct Debit instruction including payment schedule, due date, frequency and amount will be sent to you within three working days. All the normal Direct Debit safeguards and guarantees apply.</p>
-                    }
-                    @fragments.checkout.notice("Money Back Guarantee") {
-                        <p>If you wish to cancel your subscription, we will send you a refund of the unexpired part of your subscription.</p>
-                    }
-                    @fragments.checkout.notice("Direct Debit") {
-                        <address>
-                            The Guardian, Perrymount Road, Perrymount Road,
-                            Haywards Heath, West Sussex, RH16 3DH,
-                            United Kingdom
-                        </address>
-                        <ul class="u-unstyled-list">
-                            <li>Tel: 0808 168 5088</li>
-                            <li><a href="mailto:gnmsubs@@quadrantsubs.com">gnmsubs@@quadrantsubs.com</a></li>
-                        </ul>
-                        <aside class="direct-debit">
-                            <div class="direct-debit__logo">
-                                <img src="@controllers.CachedAssets.hashedPathFor("images/direct-debit.png")" alt="Direct Debit">
-                            </div>
-                            <div class="direct-debit__disclaimer prose">
-                                Your payments are protected by the
-                                <a href="#direct-debit-guarantee" class="js-toggle" data-toggle="direct-debit-guarantee">
-                                    Direct Debit guarantee.
-                                </a>
-                            </div>
-                            <div id="direct-debit-guarantee" class="prose" data-toggle-hidden>
-                                <ul>
-                                    <li>The Guarantee is offered by all banks and building societies that accept instructions to pay Direct Debits</li>
-                                    <li>If there are any changes to the amount, date or frequency of your Direct Debit Guardian Subscriptions will notify you (normally 3 working days) in advance of your account being debited or as otherwise agreed. If you request Guardian Subscriptions to collect a payment, confirmation of the amount and date will be given to you at the time of the request</li>
-                                    <li>
-                                        If an error is made in the payment of your Direct Debit, by Guardian Subscriptions or your bank or building society, you are entitled to a full and immediate refund of the amount paid from your bank or building society
-                                        <ul>
-                                            <li>If an error is made in the payment of your Direct Debit, by Guardian Subscriptions or your bank or building society, you are entitled to a full and immediate refund of the amount paid from your bank or building society</li>
-                                        </ul>
-                                    </li>
-                                    <li>If you receive a refund you are not entitled to, you must pay it back when Guardian Subscriptions asks you to You can cancel a Direct Debit at any time by simply contacting your bank or building society. Written confirmation may be required. Please also notify Guardian Subscriptions.</li>
-                                </ol>
-                            </div>
-                        </aside>
-                    }
+                    @fragments.checkout.notices()
                 </div>
-
             </div>
         </div>
 

--- a/app/views/fragments/checkout/notice.scala.html
+++ b/app/views/fragments/checkout/notice.scala.html
@@ -1,6 +1,0 @@
-@(title: String)(content: Html)
-
-<div class="notice">
-    <h4 class="notice__header">@title</h4>
-    <div class="notice__content">@content</div>
-</div>

--- a/app/views/fragments/checkout/notices.scala.html
+++ b/app/views/fragments/checkout/notices.scala.html
@@ -1,0 +1,72 @@
+@()
+
+@import controllers.CachedAssets.hashedPathFor
+
+@notice(title: String)(content: Html) = {
+    <div class="notice">
+        <h4 class="notice__header">@title</h4>
+        <div class="notice__content">@content</div>
+    </div>
+}
+
+@notice("Advanced Notice") {
+    <p>
+        The details of your Direct Debit instruction including payment schedule,
+        due date, frequency and amount will be sent to you within three working days.
+        All the normal Direct Debit safeguards and guarantees apply.
+    </p>
+}
+@notice("Money Back Guarantee") {
+    <p>
+        If you wish to cancel your subscription, we will send
+        you a refund of the unexpired part of your subscription.
+    </p>
+}
+@notice("Direct Debit") {
+
+    <address>
+        The Guardian, Perrymount Road, Perrymount Road,
+        Haywards Heath, West Sussex, RH16 3DH,
+        United Kingdom
+    </address>
+
+    <ul class="u-unstyled-list">
+        <li>Tel: 0808 168 5088</li>
+        <li><a href="mailto:gnmsubs@@quadrantsubs.com">gnmsubs@@quadrantsubs.com</a></li>
+    </ul>
+
+    <aside class="direct-debit">
+        <div class="direct-debit__logo">
+            <img src="@hashedPathFor("images/direct-debit.png")" alt="Direct Debit">
+        </div>
+        <div class="direct-debit__disclaimer prose">
+            Your payments are protected by the
+            <a href="#direct-debit-guarantee" class="js-toggle" data-toggle="direct-debit-guarantee">
+                Direct Debit guarantee.
+            </a>
+        </div>
+        <div id="direct-debit-guarantee" class="prose" data-toggle-hidden>
+            <ul>
+                <li>
+                    The Guarantee is offered by all banks and building societies that accept instructions to pay Direct Debits
+                </li>
+                <li>
+                    If there are any changes to the amount, date or frequency of your Direct Debit Guardian Subscriptions
+                    will notify you (normally 3 working days) in advance of your account being debited or as otherwise agreed.
+                    If you request Guardian Subscriptions to collect a payment, confirmation of the amount and date will be
+                    given to you at the time of the request
+                </li>
+                <li>
+                    If an error is made in the payment of your Direct Debit, by Guardian Subscriptions or your bank or building society,
+                    you are entitled to a full and immediate refund of the amount paid from your bank or building society
+                </li>
+                <li>
+                    If you receive a refund you are not entitled to, you must pay it back when Guardian Subscriptions asks you to.
+                    You can cancel a Direct Debit at any time by simply contacting your bank or building society.
+                    Written confirmation may be required. Please also notify Guardian Subscriptions.
+                </li>
+            </ol>
+        </div>
+    </aside>
+
+}

--- a/assets/stylesheets/modules/_checkout-basket.scss
+++ b/assets/stylesheets/modules/_checkout-basket.scss
@@ -20,10 +20,10 @@
         // Magic number
         min-height: 100px;
     }
-}
-.basket-preview__title,
-.basket-preview__product {
-    display: inline-block;
+
+    @include mq(tablet) {
+        margin-bottom: $gs-gutter;
+    }
 }
 .basket-preview__image {
     display: none;
@@ -49,6 +49,7 @@
 .basket-preview__title {
     font-weight: normal;
     font-family: inherit;
+    display: inline-block;
 
     @include mq(tablet) {
         @include fs-header(2);
@@ -56,9 +57,11 @@
         border-top: 1px solid $c-neutral5;
         padding-top: $gs-baseline / 2;
         margin-bottom: $gs-gutter;
+        display: block;
     }
 }
 .basket-preview__product {
+    display: inline-block;
     margin-bottom: $gs-baseline / 4;
 }
 .basket-preview__product__title {


### PR DESCRIPTION
Direct Debit copy supplied had a duplicated item it, this PR removes that and cleans up the notice markup a bit to make the template more readable.

![screen shot 2015-07-14 at 11 55 27](https://cloud.githubusercontent.com/assets/123386/8671737/926350de-2a1f-11e5-9837-63d39cda29fb.png)

![screen shot 2015-07-14 at 11 59 11](https://cloud.githubusercontent.com/assets/123386/8671759/c4105708-2a1f-11e5-9cc6-920218365973.png)


@afiore @tudorraul 