### PR TITLE
Revise Membership promo / Add pattern library

### DIFF
--- a/app/controllers/PatternLibrary.scala
+++ b/app/controllers/PatternLibrary.scala
@@ -1,0 +1,12 @@
+package controllers
+
+import play.api.mvc.Controller
+import actions.CommonActions.NoCacheAction
+
+object PatternLibrary extends Controller {
+
+  def patterns = NoCacheAction { implicit request =>
+    Ok(views.html.patterns.patterns())
+  }
+
+}

--- a/app/model/ResponsiveImage.scala
+++ b/app/model/ResponsiveImage.scala
@@ -1,0 +1,28 @@
+package model
+
+case class ResponsiveImage(path: String, width: Int)
+
+case class ResponsiveImageGroup(
+  name: Option[String] = None,
+  altText: Option[String],
+  availableImages: Seq[ResponsiveImage]
+) {
+
+  private val sortedImages = availableImages.sortBy(_.width)
+
+  val smallestImage = sortedImages.head.path
+  val defaultImage = sortedImages.find(_.width > 300).map(_.path).getOrElse(smallestImage)
+
+  val srcset = sortedImages.map { img =>
+    img.path + " " + img.width.toString + "w"
+  }.mkString(", ")
+
+}
+
+object ResponsiveImageGenerator {
+  def apply(id: String, sizes: Seq[Int]): Seq[ResponsiveImage] = {
+    sizes.map { size =>
+      ResponsiveImage(s"https://media.guim.co.uk/$id/$size.jpg", size)
+    }
+  }
+}

--- a/app/views/fragments/promos/membershipPromo.scala.html
+++ b/app/views/fragments/promos/membershipPromo.scala.html
@@ -1,4 +1,20 @@
+@()
+
+@import model.{ResponsiveImageGroup, ResponsiveImageGenerator}
+
+@promoImage = @{
+    ResponsiveImageGroup(
+        name=Some("intro"),
+        altText=Some("About Membership"),
+        availableImages=ResponsiveImageGenerator(
+            id="bb922fe62efbe24af2df336dd2b621c5799246b4/0_0_1140_683",
+            sizes=List(1000,500)
+        )
+    )
+}
+
 <div class="membership-promo">
+    <img class="membership-promo__image" src="@promoImage.defaultImage" srcset="@promoImage.srcset" sizes="100vw" alt="@promoImage.altText">
     <div class="membership-promo__content">
         <h3 class="membership-promo__title">
             Get even closer to the Guardian by becoming a member

--- a/app/views/patterns/patterns.scala.html
+++ b/app/views/patterns/patterns.scala.html
@@ -1,0 +1,53 @@
+@()
+
+@pattern(title: String, description: Option[String] = None)(content: Html) = {
+    <div class="pattern js-pattern-item u-cf" data-pattern-label="@title">
+        <div class="pattern__header">
+            <h2 class="pattern__title">@title</h2>
+            @if(description) {
+                <p class="pattern__description">@description</p>
+            }
+        </div>
+        <div class="pattern__body">
+            @content
+        </div>
+    </div>
+}
+
+@main("Pattern Library") {
+
+    <main class="gs-container">
+
+        <div class="pattern-nav js-pattern-nav"></div>
+        <h1>Pattern Library</h1>
+
+        @pattern("Base - Inline Text Elements") {
+            <div class="prose">
+                <p><a href="#">This is a text link</a></p>
+                <p><strong>Strong is used to indicate strong importance</strong></p>
+                <p><em>This text has added emphasis</em></p>
+                <p><del>This text is deleted</del> and <ins>This text is inserted</ins></p>
+                <p><s>This text has a strikethrough</s></p>
+                <p>Superscript<sup>®</sup></p>
+                <p>Subscript for things like H<sub>2</sub>O</p>
+                <p><small>This small text is small for for fine print, etc.</small></p>
+                <p>Abbreviation: <abbr title="HyperText Markup Language">HTML</abbr></p>
+                <p>Keybord input: <kbd>Cmd</kbd></p>
+                <p><q cite="https://developer.mozilla.org/en-US/docs/HTML/Element/q">This text is a short inline quotation</q></p>
+                <p><cite>This is a citation</cite>
+                </p><p>The <dfn>dfn element</dfn> indicates a definition.</p>
+                <p>The <mark>mark element</mark> indicates a highlight</p>
+            </div>
+        }
+
+        @pattern("Page Header") {
+            @fragments.page.header("This a page header", None)
+        }
+
+        @pattern("Membership Promo") {
+            @fragments.promos.membershipPromo()
+        }
+
+    </main>
+
+}

--- a/assets/javascripts/main.js
+++ b/assets/javascripts/main.js
@@ -4,6 +4,7 @@ require([
     'modules/appendAround',
     'modules/checkout/checkout',
     'modules/components/password',
+    'modules/patterns',
     // Add new dependencies ABOVE this
     'raven'
 ], function(
@@ -11,7 +12,8 @@ require([
     toggle,
     appendAround,
     checkout,
-    password
+    password,
+    patterns
 ) {
     'use strict';
 
@@ -30,4 +32,8 @@ require([
     appendAround.init();
     checkout.init();
     password.init();
+
+    // Pattern library
+    patterns.init();
+
 });

--- a/assets/javascripts/modules/patterns.js
+++ b/assets/javascripts/modules/patterns.js
@@ -1,0 +1,61 @@
+define(function() {
+
+    'use strict';
+
+    function buildItems(selector) {
+        var items = [];
+        [].forEach.call(document.querySelectorAll(selector), function(el, index) {
+            el.id = 'pattern-' + index;
+            var option = [
+                '<option value="#pattern-' + index + '">',
+                    el.getAttribute('data-pattern-label'),
+                '</option>'
+            ].join('');
+            items.push( option );
+        }, false);
+        return items;
+    }
+
+    function buildSelect(items) {
+        return [
+            '<select class="js-pattern-selector">',
+                '<option value="">Select a pattern</option>',
+                items.join(''),
+            '</select>'
+        ].join('');
+    }
+
+    function renderPatternNav(selector, select) {
+        document.querySelector(selector).innerHTML = select;
+    }
+
+    function bindNavEvents(selector) {
+        var nav = document.querySelector(selector);
+        if (nav) {
+            nav.onchange = function() {
+              var val = this.value;
+              if (val) {
+                window.location = val;
+              }
+            };
+        }
+    }
+
+    function init() {
+
+        var patterns = buildItems('.js-pattern-item'),
+            select;
+
+        if (patterns.length) {
+            select = buildSelect(patterns);
+            renderPatternNav('.js-pattern-nav', select);
+            bindNavEvents('.js-pattern-selector');
+        }
+
+    }
+
+    return {
+        init: init
+    };
+
+});

--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -8,8 +8,11 @@
 @import 'bower_components/guss-layout/_row';
 @import 'bower_components/guss-layout/_columns';
 @import 'bower_components/guss-typography/_typography';
- // TODO: Deprecated in favour of autoprefixer
+ // Deprecated in favour of autoprefixer
 @import 'bower_components/guss-css3/_css3';
+
+/* Project Mixins
+   ========================================================================== */
 
 // Hide content visually, still readable by screen readers
 @mixin u-h {
@@ -48,4 +51,11 @@
         padding-left: $gs-gutter;
         padding-right: $gs-gutter;
     }
+}
+
+@mixin vertically-offset($offset: 50%) {
+    transform: translateY(-($offset));
+    top: $offset;
+    margin: 0 auto;
+    display: block;
 }

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -52,6 +52,10 @@
 @import 'modules/membership';
 @import 'modules/warnings';
 
+// Dev modules:
+// - Pattern library
+@import 'modules/patterns';
+
 /* ==========================================================================
    STATE
    ========================================================================== */

--- a/assets/stylesheets/modules/_membership.scss
+++ b/assets/stylesheets/modules/_membership.scss
@@ -5,42 +5,62 @@
 
 .membership-promo {
     color: $c-white;
-    background: $c-neutral1 url(/assets/images/backgrounds/bg-membership-cards.png) 0 center no-repeat;
-    background-size: cover;
+    background-color: $c-membership;
     margin-bottom: $gs-baseline * 2;
-}
-.membership-promo__content {
-    padding: $gs-gutter ($gs-gutter / 2);
-    background-color: rgba(0,0,0,0.5);
+
+    @include mq(phablet) {
+        position: relative;
+    }
 
     @include mq(tablet) {
+        max-height: 300px; // Magic number
+        overflow: hidden;
+    }
+}
+.membership-promo__image {
+    @include mq(tablet) {
+        @include vertically-offset(25%);
+        position: relative;
+    }
+}
+.membership-promo__content {
+    padding: ($gs-gutter / 2);
+    background-color: rgba(0,0,0,0.5);
+
+    @include mq(phablet) {
+        position: absolute;
+        top: 0; bottom: 0;
+        width: 100%;
         padding: $gs-gutter;
         background-color: transparent;
         background-image: linear-gradient(90deg, rgba(0, 0, 0, .9) 0%, transparent 100%);
     }
 }
 .membership-promo__title {
-    @include fs-headline(5);
-    font-weight: guss-font-weight('bold');
-    margin-bottom: $gs-baseline * 3;
+    @include fs-headline(3);
+    font-weight: guss-font-weight(bold);
+    margin-bottom: $gs-baseline;
 
-    @include mq(tablet) {
+    @include mq(phablet) {
         @include fs-headline(6, $size-only: true);
+        margin-bottom: $gs-baseline * 3;
         max-width: gs-span(6);
     }
 }
 .membership-promo__info {
-    @include fs-header(3);
+    @include fs-header(1);
+    font-weight: guss-font-weight(regular);
     margin-bottom: $gs-baseline;
 
-    @include mq(tablet) {
+    @include mq(phablet) {
+        @include fs-header(3, $size-only: true);
         max-width: 16em; // Magic-number
     }
 }
 .membership-promo__info__highlight {
     color: $c-membership-higlight;
 
-    @include mq(tablet) {
+    @include mq(phablet) {
         display: block;
     }
 }

--- a/assets/stylesheets/modules/_patterns.scss
+++ b/assets/stylesheets/modules/_patterns.scss
@@ -1,0 +1,30 @@
+/* ==========================================================================
+   Patterns
+   ========================================================================== */
+
+.pattern {
+    @include clearfix();
+    margin-top: ($gs-gutter * 2);
+}
+.pattern__header {
+    margin-bottom: ($gs-gutter);
+    border-top: 1px solid $c-border;
+    padding-top: ($gs-baseline / 2);
+}
+.pattern__title {
+    @include fs-data(6);
+}
+.pattern__description {
+    @include fs-data(4);
+    color: $c-neutral2;
+}
+
+.pattern-nav {
+    position: fixed;
+    bottom: 0; right: 0;
+    width: 100%;
+    z-index: 10000;
+    padding: .3em 1em;
+    background: transparentize($c-white, .3);
+    text-align: center;
+}

--- a/conf/routes
+++ b/conf/routes
@@ -38,6 +38,10 @@ GET         /staff/login                     controllers.OAuth.login
 GET         /staff/loginAction               controllers.OAuth.loginAction
 GET         /oauth2callback                  controllers.OAuth.oauth2Callback
 
+# Pattern Library
+GET         /patterns                        controllers.PatternLibrary.patterns
+
 # Map static resources from the /public folder to the /assets URL path
 GET         /assets/*file                    controllers.CachedAssets.at(path="/public", file)
+GET         /robots.txt                      controllers.CachedAssets.at(path="/public", file="robots.txt")
 GET         /favicon.ico                     controllers.CacheBustedAssets.at(path="images/favicons/32x32.ico")

--- a/conf/routes
+++ b/conf/routes
@@ -2,6 +2,9 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
+GET         /robots.txt                      controllers.CachedAssets.at(path="/public", file="robots.txt")
+GET         /favicon.ico                     controllers.CacheBustedAssets.at(path="images/favicons/32x32.ico")
+
 # Editions homepage
 GET         /                                controllers.Homepage.index
 GET         /au                              controllers.Homepage.indexAu
@@ -43,5 +46,3 @@ GET         /patterns                        controllers.PatternLibrary.patterns
 
 # Map static resources from the /public folder to the /assets URL path
 GET         /assets/*file                    controllers.CachedAssets.at(path="/public", file)
-GET         /robots.txt                      controllers.CachedAssets.at(path="/public", file="robots.txt")
-GET         /favicon.ico                     controllers.CacheBustedAssets.at(path="images/favicons/32x32.ico")

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+
+Disallow: /patterns
+
+Allow: /

--- a/test/model/ResponsiveImageTest.scala
+++ b/test/model/ResponsiveImageTest.scala
@@ -1,0 +1,70 @@
+package model
+
+import play.api.test.PlaySpecification
+
+class ResponsiveImageTest extends PlaySpecification {
+
+  val largeImage = "https://media.guim.co.uk/bb922fe62efbe24af2df336dd2b621c5799246b4/0_0_1140_683/1000.jpg"
+  val mediumImage = "https://media.guim.co.uk/bb922fe62efbe24af2df336dd2b621c5799246b4/0_0_1140_683/500.jpg"
+  val smallImage = "https://media.guim.co.uk/bb922fe62efbe24af2df336dd2b621c5799246b4/0_0_1140_683/140.jpg"
+
+  "ResponsiveImageGroup" should {
+
+    "generate a src and srcset information for a sequence of images" in {
+
+      val imageGroup = ResponsiveImageGroup(
+        altText=None,
+        availableImages = Seq(
+          ResponsiveImage(
+            path=largeImage,
+            width=1000
+          ),
+          ResponsiveImage(
+            path=mediumImage,
+            width=500
+          ),
+          ResponsiveImage(
+            path=smallImage,
+            width=140
+          )
+        )
+      )
+
+      imageGroup.smallestImage mustEqual smallImage
+      imageGroup.defaultImage mustEqual mediumImage
+      imageGroup.srcset mustEqual List(
+        smallImage + " 140w",
+        mediumImage + " 500w",
+        largeImage + " 1000w"
+      ).mkString(", ")
+
+    }
+
+  }
+
+  "ResponsiveImageGenerator" should {
+
+    "generate a src and srcset information for a generated image group" in {
+
+      val imageGroup = ResponsiveImageGroup(
+        name=None,
+        altText=None,
+        availableImages=ResponsiveImageGenerator(
+          id="bb922fe62efbe24af2df336dd2b621c5799246b4/0_0_1140_683",
+          sizes=List(1000,500,140)
+        )
+      )
+
+      imageGroup.smallestImage mustEqual smallImage
+      imageGroup.defaultImage mustEqual mediumImage
+      imageGroup.srcset mustEqual List(
+        smallImage + " 140w",
+        mediumImage + " 500w",
+        largeImage + " 1000w"
+      ).mkString(", ")
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
This PR revises the styling for the Membership promo. As this component is on the thank-you page and so requires a number of steps to test I thought this would be an opportunity to add a basic pattern library as **a)** It has been very useful on Membership and **b)** it allows me to style components in a standalone context.

- Revise Membership promo styling
- Port ResponsiveImage model Memberhship
- Add basic PatternLibrary routes and templates

Will be available at https://subscribe.theguardian.com/patterns

![screen shot 2015-07-14 at 17 53 25](https://cloud.githubusercontent.com/assets/123386/8679560/404d165c-2a53-11e5-96ca-bbc18efa9ea6.png)
![screen shot 2015-07-14 at 17 58 10](https://cloud.githubusercontent.com/assets/123386/8679561/4067392e-2a53-11e5-8bf8-272814cee186.png)


I've made some (reasonable) assumptions about the small screen styling for this component pending discussion with design.

@jennysivapalan 