### PR TITLE
Fix zxcvbn version in bower file

### DIFF
--- a/assets/javascripts/bower.json
+++ b/assets/javascripts/bower.json
@@ -9,6 +9,6 @@
         "raven-js": "~1.1.16",
         "requirejs": "~2.1.17",
         "reqwest": "~1.1.0",
-        "zxcvbn": "*"
+        "zxcvbn": "90b7d2908d1305e0ab9f0fe0d983041e546af760"
     }
 }


### PR DESCRIPTION
This fixes a regression whereby the password strength indicator failed to load. The regression was caused by a recent release of  the zxcvbn library which wouldn't play well with RequireJS.

Investigated and solved in collaboration with @davidrapson