### PR TITLE
Add git commit hooks for CSS/JS linting

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# Pre-commit hooks
+
+# Validate CSS
+CSS_SRC_PATTERN="\.scss"
+git diff --cached --name-only | if grep "$CSS_SRC_PATTERN"
+then
+    grunt compile:css
+fi
+cssValidateResult=$?
+
+# Validate JS
+JS_SRC_PATTERN="\.js$"
+git diff --cached --name-only | if grep "$JS_SRC_PATTERN"
+then
+    grunt validate
+fi
+jsValidateResult=$?
+
+# Test JS
+git diff --cached --name-only | if grep "[^/]\+/\(test/js/spec\).*$JS_SRC_PATTERN"
+then
+    grunt test:unit
+fi
+jsTestResult=$?
+
+# Exit code 1 means don't commit and 0 means do commit
+[ $cssValidateResult -ne 0 ] || [ $jsValidateResult -ne 0 ] || [ $jsTestResult -ne 0 ] && exit 1
+exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -150,6 +150,10 @@ install_chromedriver() {
   fi
 }
 
+copy_githooks() {
+    cp git-hooks/pre-commit .git/hooks/
+}
+
 compile() {
   grunt compile
 }
@@ -175,6 +179,7 @@ main() {
   install_dependencies
   install_nginx
   install_chromedriver
+  copy_githooks
   compile
   report
 }


### PR DESCRIPTION
Add git commit hooks for CSS/JS linting, helps catch syntax errors early rather than in a build. Will need to run `setup.sh` again to copy the hooks over.

@tudorraul @rtyley 