### PR TITLE
Implement test users endpoint

### DIFF
--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -1,7 +1,7 @@
 package actions
 
 import com.typesafe.scalalogging.LazyLogging
-import configuration.QA.{passthroughCookie => qaCookie}
+import configuration.QA.passthroughCookie
 import controllers.{Cached, NoCache}
 import play.api.mvc._
 
@@ -22,12 +22,11 @@ object CommonActions {
 
   object PreReleaseFeature extends ActionBuilder[Request] with LazyLogging {
     override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {
-      val cookie = request.cookies.get(qaCookie.name)
-
-      if (cookie.exists(_.value == qaCookie.value)) {
+      val qaCookie = request.cookies.get(passthroughCookie.name)
+      if (qaCookie.exists(_.value == passthroughCookie.value)) {
         block(request)
       } else {
-        cookie.foreach(_ => logger.warn("Invalid QA Cookie supplied"))
+        qaCookie.foreach(_ => logger.warn("Invalid QA Cookie supplied"))
         OAuthActions.AuthAction.authenticate(request, block)
       }
     }

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -40,7 +40,7 @@ object Config {
     val keys = if (idConfig.getBoolean("production.keys")) new ProductionKeys else new PreProductionKeys
 
     val testUsersSecret = idConfig.getString("test.users.secret")
-    
+
     val webAppUrl = idConfig.getString("webapp.url")
 
     val webAppProfileUrl = webAppUrl / "account" / "edit"

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -39,6 +39,8 @@ object Config {
 
     val keys = if (idConfig.getBoolean("production.keys")) new ProductionKeys else new PreProductionKeys
 
+    val testUsersSecret = idConfig.getString("test.users.secret")
+    
     val webAppUrl = idConfig.getString("webapp.url")
 
     val webAppProfileUrl = webAppUrl / "account" / "edit"
@@ -48,6 +50,10 @@ object Config {
 
     def idWebAppSignOutUrl(path: String): String =
       (webAppUrl / "signout") ? ("returnUrl" -> absoluteUrl(path)) ? ("skipConfirmation" -> "true")
+
+    def idWebAppRegisterUrl(path : String): String =
+      (webAppUrl / "register") ? ("returnUrl" -> absoluteUrl(path)) ? ("skipConfirmation" -> "true")
+
 
     private def absoluteUrl(path: String): String = (subscriptionsUrl / path).toString()
   }

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -8,55 +8,59 @@ import forms.{FinishAccountForm, SubscriptionsForm}
 import model.SubscriptionData
 import play.api.data.Form
 import play.api.libs.json._
+import play.api.mvc
 import play.api.mvc._
 import services.CheckoutService.CheckoutResult
-import services.{CheckoutService, _}
+import services._
+import utils.TestUsers
 import views.html.{checkout => view}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import AuthenticationService.authenticatedUserFor
 
 object Checkout extends Controller with LazyLogging {
-  private val zuoraService = TouchpointBackend.Normal.zuoraService
-  private lazy val checkoutService = new CheckoutService(IdentityService, SalesforceService, zuoraService)
+
   private val goCardlessService = GoCardlessService
 
-  def identityCookieOpt(implicit request: Request[_]): Option[Cookie] =
-    request.cookies.find(_.name == "SC_GU_U")
-
   def renderCheckout = GoogleAuthenticatedStaffAction.async { implicit request =>
-    getIdentityUserByCookie.map { idUserOpt =>
-      val form = idUserOpt.map { idUser =>
-        val data = SubscriptionData.fromIdUser(idUser)
-        SubscriptionsForm().fill(data)
-      } getOrElse {
-        SubscriptionsForm()
+
+    val authUserOpt = authenticatedUserFor(request)
+    val touchpointBackend =
+      TouchpointBackend.forRequest(request.cookies.get(Testing.UnauthenticatedTestUserCookieName).map(_.value))
+
+    def fillForm(): Future[Form[SubscriptionData]] = for {
+      fullUserOpt <-authUserOpt.fold[Future[Option[IdUser]]](Future.successful(None))(au => IdentityService.userLookupByScGuU(AuthCookie(au.authCookie)))
+    } yield {
+        fullUserOpt.map { idUser =>
+          SubscriptionsForm().fill(SubscriptionData.fromIdUser(idUser))
+        } getOrElse {
+          SubscriptionsForm()
+        }
       }
-      //TODO when implementing test-users this requires updating to supply data to correct location
-      val touchpointBackend = TouchpointBackend.Normal
-      Ok(views.html.checkout.payment(form, userIsSignedIn = idUserOpt.isDefined, zuoraService.products))
+
+    for {
+      filledForm <- fillForm()
+    } yield {
+      Ok(views.html.checkout.payment(filledForm, userIsSignedIn = authUserOpt.isDefined, touchpointBackend.zuoraService.products))
     }
   }
 
-  def handleCheckout = GoogleAuthenticatedStaffAction.async { implicit request =>
-    SubscriptionsForm().bindFromRequest.fold(
-      formWithErrors =>
-        getIdentityUserByCookie.map { idUserOpt =>
-          logger.error(s"Backend form validation failed. Please make sure that the front-end and the backend validations are in sync (validation errors: ${formWithErrors.errors}})")
-          //TODO when implementing test-users this requires updating to supply data to correct location
-          val touchpointBackend = TouchpointBackend.Normal
-          BadRequest(view.payment(formWithErrors, userIsSignedIn = idUserOpt.isDefined, zuoraService.products))
-        },
-      formData => {
-        val idUserOpt = AuthenticationService.authenticatedUserFor(request)
-        val authCookie = identityCookieOpt.map(cookie => AuthCookie(cookie.value))
+  val parseCheckoutForm = parse.form[SubscriptionData](SubscriptionsForm.subsForm, onErrors = formWithErrors => {
+    logger.error(s"Backend form validation failed. Please make sure that the front-end and the backend validations are in sync (validation errors: ${formWithErrors.errors}})")
+    BadRequest
+  })
 
-        checkoutService.processSubscription(formData, idUserOpt, authCookie).map { case CheckoutResult(_, userIdData, subscription) =>
-          val passwordForm = userIdData.toGuestAccountForm
-          Ok(view.thankyou(subscription.name, formData.personalData, passwordForm))
-        }
-      }
-    )
+  def handleCheckout = GoogleAuthenticatedStaffAction.async(parseCheckoutForm) { implicit request =>
+    val formData = request.body
+    val idUserOpt = authenticatedUserFor(request)
+
+    val touchpointBackend = TouchpointBackend.forRequest(Some(formData.personalData.firstName))
+
+    touchpointBackend.checkoutService.processSubscription(formData, idUserOpt).map { case CheckoutResult(_, userIdData, subscription) =>
+      val passwordForm = userIdData.toGuestAccountForm
+      Ok(view.thankyou(subscription.name, formData.personalData, passwordForm))
+    }
   }
 
   def mandatePDF = GoogleAuthenticatedStaffAction.async { implicit request =>
@@ -85,11 +89,6 @@ object Checkout extends Controller with LazyLogging {
       doesUserExist <- IdentityService.doesUserExist(email)
     } yield Ok(Json.obj("emailInUse" -> doesUserExist))
   }
-
-  private def getIdentityUserByCookie(implicit request: Request[_]): Future[Option[IdUser]] =
-    identityCookieOpt.fold(Future.successful(None: Option[IdUser])) { cookie =>
-      IdentityService.userLookupByScGuU(AuthCookie(cookie.value))
-    }
 
   private def handleWithBadRequest[A](formWithErrors: Form[A]): Future[Result] =
     Future {

--- a/app/controllers/Testing.scala
+++ b/app/controllers/Testing.scala
@@ -2,10 +2,12 @@ package controllers
 
 import actions.CommonActions._
 import com.typesafe.scalalogging.LazyLogging
-import play.api.mvc.Controller
+import play.api.mvc.{Controller, Cookie}
 import utils.TestUsers.testUsers
 
 object Testing extends Controller with LazyLogging {
+
+  val UnauthenticatedTestUserCookieName = "subscriptions-test-user-name"
 
   def testUser = GoogleAuthenticatedStaffAction { implicit request =>
 
@@ -13,6 +15,7 @@ object Testing extends Controller with LazyLogging {
 
     logger.info(s"Generated test user string $testUserString")
 
-    Ok(views.html.testing.testUsers(testUserString))
+    val testUserCookie = new Cookie(UnauthenticatedTestUserCookieName, testUserString, Some(30 * 60), httpOnly = true)
+    Ok(views.html.testing.testUsers(testUserString)).withCookies(testUserCookie)
   }
 }

--- a/app/controllers/Testing.scala
+++ b/app/controllers/Testing.scala
@@ -1,0 +1,18 @@
+package controllers
+
+import actions.CommonActions._
+import com.typesafe.scalalogging.LazyLogging
+import play.api.mvc.Controller
+import utils.TestUsers.testUsers
+
+object Testing extends Controller with LazyLogging {
+
+  def testUser = GoogleAuthenticatedStaffAction { implicit request =>
+
+    val testUserString = testUsers.generate()
+
+    logger.info(s"Generated test user string $testUserString")
+
+    Ok(views.html.testing.testUsers(testUserString))
+  }
+}

--- a/app/services/AuthenticationService.scala
+++ b/app/services/AuthenticationService.scala
@@ -4,7 +4,7 @@ import com.gu.identity.cookie.IdentityKeys
 import configuration.Config
 
 object AuthenticationService extends com.gu.identity.play.AuthenticationService {
-  override def idWebAppSigninUrl(returnUrl: String): String = Config.Identity.webAppSigninUrl(returnUrl)
+  def idWebAppSigninUrl(returnUrl: String): String = Config.Identity.webAppSigninUrl(returnUrl)
 
   override val identityKeys: IdentityKeys = Config.Identity.keys
 }

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -1,7 +1,7 @@
 package services
 
 import com.amazonaws.regions.{Region, Regions}
-import com.gu.identity.play.IdUser
+import com.gu.identity.play.{AuthenticatedIdUser, IdUser}
 import com.gu.monitoring.{AuthenticationMetrics, CloudWatch, RequestMetrics, StatusMetrics}
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
@@ -39,8 +39,12 @@ class IdentityService(identityApiClient: => IdentityApiClient) extends LazyLoggi
     }
   }
 
-  def updateUserDetails(personalData: PersonalData, userId: UserId, authCookie: AuthCookie): Future[Unit] = {
-    identityApiClient.updateUserDetails(personalData, userId, authCookie).map(_ => Unit)
+  def updateUserDetails(personalData: PersonalData, authenticatedUser: AuthenticatedIdUser): Future[Unit] = {
+    identityApiClient.updateUserDetails(
+      personalData,
+      UserId(authenticatedUser.user.id),
+      AuthCookie(authenticatedUser.authCookie)
+    ).map(_ => Unit)
   }
 }
 

--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -12,6 +12,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 trait SalesforceService extends LazyLogging {
+  def repo: SalesforceRepo
 
   def createOrUpdateUser(personalData: PersonalData, userId: UserId): Future[MemberId]
 
@@ -29,10 +30,9 @@ trait SalesforceService extends LazyLogging {
 
 }
 
-object SalesforceService extends SalesforceService {
+class SalesforceServiceImp(val repo: SalesforceRepo) extends SalesforceService {
   override def createOrUpdateUser(personalData: PersonalData, userId: UserId): Future[MemberId] =
-    //TODO when implementing test-users this requires updating to supply data to correct location
-    TouchpointBackend.Normal.salesforceRepo.upsert(userId.id, createSalesforceUserData(personalData))
+    repo.upsert(userId.id, createSalesforceUserData(personalData))
 }
 
 class SalesforceRepo(salesforceConfig: SalesforceConfig) extends MemberRepository {

--- a/app/services/TouchpointBackend.scala
+++ b/app/services/TouchpointBackend.scala
@@ -1,7 +1,9 @@
 package services
 
 import configuration.Config
+import play.api.mvc.RequestHeader
 import touchpoint.TouchpointBackendConfig
+import utils.TestUsers._
 
 object TouchpointBackend {
   import TouchpointBackendConfig.BackendType
@@ -11,23 +13,31 @@ object TouchpointBackend {
 
   def apply(touchpointBackendConfig: TouchpointBackendConfig): TouchpointBackend = {
     val salesforceRepo = new SalesforceRepo(touchpointBackendConfig.salesforce)
+    val salesforceService = new SalesforceServiceImp(salesforceRepo)
     val zuoraService = new ZuoraApiClient(touchpointBackendConfig.zuora, touchpointBackendConfig.digitalProductPlan, touchpointBackendConfig.zuoraProperties)
 
-    TouchpointBackend(salesforceRepo, zuoraService)
+
+    TouchpointBackend(salesforceService, zuoraService)
   }
 
   val Normal = TouchpointBackend(BackendType.Default)
+  val TestUser = TouchpointBackend(BackendType.Testing)
 
-  val All = Seq(Normal)
+  val All = Seq(Normal, TestUser)
+
+  def forRequest(alternateSource: => Option[String] = None)(implicit request: RequestHeader) =
+    if (isTestUser(alternateSource)) TestUser else Normal
 }
 
 case class TouchpointBackend(
-  salesforceRepo: SalesforceRepo,
+  salesforceService: SalesforceService,
   zuoraService : ZuoraService
 ) {
 
+  val checkoutService = new CheckoutService(IdentityService, salesforceService, zuoraService)
+
   def start() = {
-    salesforceRepo.salesforce.authTask.start()
+    salesforceService.repo.salesforce.authTask.start()
     zuoraService.authTask.start()
   }
 }

--- a/app/utils/TestUsers.scala
+++ b/app/utils/TestUsers.scala
@@ -1,9 +1,10 @@
 package utils
 
 import com.github.nscala_time.time.Imports._
-import com.gu.identity.play.IdMinimalUser
 import com.gu.identity.testing.usernames.TestUsernames
 import configuration.Config
+import play.api.mvc.RequestHeader
+import services.AuthenticationService.authenticatedUserFor
 
 object TestUsers {
 
@@ -14,8 +15,8 @@ object TestUsers {
     recency = ValidityPeriod.standardDuration
   )
 
-  def isTestUser(user: IdMinimalUser): Boolean =
-    user.displayName.flatMap(_.split(' ').headOption).exists(isTestUser)
+  private def isTestUser(username: String): Boolean = TestUsers.testUsers.isValid(username)
 
-  def isTestUser(username: String): Boolean = TestUsers.testUsers.isValid(username)
+  def isTestUser(alternateSource: => Option[String] = None)(implicit request: RequestHeader): Boolean =
+    authenticatedUserFor(request).fold(alternateSource)(_.user.displayName.flatMap(_.split(' ').headOption)).exists(isTestUser)
 }

--- a/app/utils/TestUsers.scala
+++ b/app/utils/TestUsers.scala
@@ -1,0 +1,21 @@
+package utils
+
+import com.github.nscala_time.time.Imports._
+import com.gu.identity.play.IdMinimalUser
+import com.gu.identity.testing.usernames.TestUsernames
+import configuration.Config
+
+object TestUsers {
+
+  val ValidityPeriod = 2.days
+
+  lazy val testUsers = TestUsernames(
+    com.gu.identity.testing.usernames.Encoder.withSecret(Config.Identity.testUsersSecret),
+    recency = ValidityPeriod.standardDuration
+  )
+
+  def isTestUser(user: IdMinimalUser): Boolean =
+    user.displayName.flatMap(_.split(' ').headOption).exists(isTestUser)
+
+  def isTestUser(username: String): Boolean = TestUsers.testUsers.isValid(username)
+}

--- a/app/views/testing/testUsers.scala.html
+++ b/app/views/testing/testUsers.scala.html
@@ -1,0 +1,24 @@
+@(userString: String)
+
+@import configuration.Config.Identity.idWebAppRegisterUrl
+@import routes.Checkout.renderCheckout
+
+@main(title = "Test users") {
+    <main class="page-container gs-container">
+        @fragments.page.header("Test Users", None, Nil)
+
+        <div class="prose">
+            <ul class="u-unstyled">
+                <li>First Name: <strong>@userString</strong></li>
+                <li>Username: <strong>@userString</strong></li>
+                <li>Email: <strong>@userString@@gu.com</strong></li>
+            </ul>
+        </div>
+
+        <div class="actions">
+            <a href="@idWebAppRegisterUrl(renderCheckout().toString())" class="button button--primary button--large">Register an Identity user</a>
+            <a href="@renderCheckout" class="button button--primary button--large">Subscribe as a guest user</a>
+        </div>
+
+    </main>
+}

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ libraryDependencies ++= Seq(
   PlayImport.specs2,
   "com.gu" %% "membership-common" % "0.77",
   "com.gu" %% "play-googleauth" % "0.3.0",
+  "com.gu" %% "identity-test-users" % "0.5",
   "com.gu.identity" %% "identity-play-auth" % "0.5",
   "com.github.nscala-time" %% "nscala-time" % "2.0.0",
   "net.kencochrane.raven" % "raven-logback" % "6.0.0",

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "membership-common" % "0.77",
   "com.gu" %% "play-googleauth" % "0.3.0",
   "com.gu" %% "identity-test-users" % "0.5",
-  "com.gu.identity" %% "identity-play-auth" % "0.5",
+  "com.gu.identity" %% "identity-play-auth" % "0.7",
   "com.github.nscala-time" %% "nscala-time" % "2.0.0",
   "net.kencochrane.raven" % "raven-logback" % "6.0.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -7,6 +7,7 @@ identity {
   baseUri = "https://idapi.code.dev-theguardian.com"
   production.keys=false
   webapp.url="https://profile.thegulocal.com"
+  test.users.secret="a-non-secure-key-for-our-dev-env-only"
 }
 
 subscriptions.url="https://sub.thegulocal.com"

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -1,4 +1,5 @@
 include "touchpoint.DEV.conf"
+include "touchpoint.UAT.conf"
 include "application"
 
 stage = "DEV"
@@ -15,6 +16,7 @@ subscriptions.url="https://sub.thegulocal.com"
 play.ws.acceptAnyCertificate=true
 
 touchpoint.backend.default=DEV
+touchpoint.backend.test=UAT
 
 sentry.dsn = ""
 

--- a/conf/PROD.conf
+++ b/conf/PROD.conf
@@ -12,4 +12,6 @@ identity {
 
 subscriptions.url="https://subscribe.theguardian.com"
 
+// Will change these to default=PROD & test=UAT once we've reviewed this change working in production
 touchpoint.backend.default=UAT
+touchpoint.backend.test=DEV

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -27,6 +27,7 @@ google.oauth {
 identity {
   baseUri = ""
   webapp.url="https://profile.theguardian.com"
+  test.users.secret=""
 }
 subscriptions.url="https://subscribe.theguardian.com"
 

--- a/conf/routes
+++ b/conf/routes
@@ -42,3 +42,5 @@ GET         /patterns                        controllers.PatternLibrary.patterns
 
 # Map static resources from the /public folder to the /assets URL path
 GET         /assets/*file                    controllers.CachedAssets.at(path="/public", file)
+
+GET         /test-users                          controllers.Testing.testUser


### PR DESCRIPTION
Allow to switch touchpoint backends at runtime. This uses use a signed cookie as the main mechanism to distinguish test users from ordinary ones. 

Note that some of the acceptance tests fail as they cover functionality that is part of this PR and has not been deployed on prod yet.

Pair programmed with @jennysivapalan 

@rtyley 