### PR TITLE
Don't run acceptance-tests before an environment is available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ cache:
   directories:
   - $HOME/.sbt
   - $HOME/.ivy2
-script: sbt ++$TRAVIS_SCALA_VERSION test && find $HOME/.sbt -name "*.lock" -type f -delete && find $HOME/.ivy2/cache -name "*[\[\]\(\)]*.properties" -type f -delete
+script: sbt ++$TRAVIS_SCALA_VERSION fast-test && find $HOME/.sbt -name "*.lock" -type f -delete && find $HOME/.ivy2/cache -name "*[\[\]\(\)]*.properties" -type f -delete


### PR DESCRIPTION
The default Travis build is triggered when a PR is made or merged, but at that point there is no deployed environment that is actually running that code, so we don't want to run the acceptance tests (which drive a web browser) at that point. This change reverts part of https://github.com/guardian/subscriptions-frontend/pull/127.

There's an upcoming feature in @prout-bot which will trigger a Travis build post-deploy to run the acceptance-tests... cc @afiore 