### PR TITLE
Pdf mandate

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -1,13 +1,14 @@
 package configuration
 
 import com.github.nscala_time.time.Imports._
+import com.gocardless.GoCardlessClient
+import com.gocardless.GoCardlessClient.Environment
 import com.gu.googleauth.GoogleAuthConfig
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.membership.salesforce.SalesforceConfig
 import com.netaporter.uri.dsl._
 import com.typesafe.config.ConfigFactory
 import net.kencochrane.raven.dsn.Dsn
-import com.github.nscala_time.time.Imports._
 
 import scala.util.Try
 
@@ -63,4 +64,9 @@ object Config {
   val sentryDsn = Try(new Dsn(config.getString("sentry.dsn")))
 
   lazy val Salesforce =  SalesforceConfig.from(config.getConfig("touchpoint.backend.environments").getConfig(stage), stage)
+
+  object GoCardless {
+    private val token = config.getString("gocardless.token")
+    val client = GoCardlessClient.create(token, Environment.SANDBOX)
+  }
 }

--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -60,5 +60,7 @@ object SubscriptionsForm {
     "ratePlanId" -> text
   )(SubscriptionData.apply)(SubscriptionData.unapply))
 
+  def paymentDataForm = Form("payment" -> paymentDataMapping)
+
   def apply() = subsForm
 }

--- a/app/services/GocardlessService.scala
+++ b/app/services/GocardlessService.scala
@@ -1,0 +1,28 @@
+package services
+
+import java.net.URL
+
+import configuration.Config
+import model.PaymentData
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+trait GoCardlessService {
+  def mandatePDF(paymentData: PaymentData): Future[URL]
+}
+
+object GoCardlessService extends GoCardlessService {
+  lazy val client = Config.GoCardless.client
+
+  override def mandatePDF(paymentData: PaymentData): Future[URL] =
+    Future {
+      val pdf = client.mandatePdfs().create()
+        .withAccountHolderName(paymentData.holder)
+        .withAccountNumber(paymentData.account)
+        .withBranchCode(paymentData.sortCode)
+        .withCountryCode("GB")
+        .execute()
+      new URL(pdf.getUrl)
+    }
+}

--- a/app/services/GocardlessService.scala
+++ b/app/services/GocardlessService.scala
@@ -1,7 +1,5 @@
 package services
 
-import java.net.URL
-
 import configuration.Config
 import model.PaymentData
 
@@ -9,20 +7,20 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 trait GoCardlessService {
-  def mandatePDF(paymentData: PaymentData): Future[URL]
+  def mandatePDFUrl(paymentData: PaymentData): Future[String]
 }
 
 object GoCardlessService extends GoCardlessService {
   lazy val client = Config.GoCardless.client
 
-  override def mandatePDF(paymentData: PaymentData): Future[URL] =
+  override def mandatePDFUrl(paymentData: PaymentData): Future[String] =
     Future {
-      val pdf = client.mandatePdfs().create()
+      client.mandatePdfs().create()
         .withAccountHolderName(paymentData.holder)
         .withAccountNumber(paymentData.account)
         .withBranchCode(paymentData.sortCode)
         .withCountryCode("GB")
         .execute()
-      new URL(pdf.getUrl)
+        .getUrl
     }
 }

--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -8,7 +8,6 @@ import model.PersonalData
 import play.api.libs.json.{JsObject, Json}
 import utils.ScheduledTask
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -44,7 +43,7 @@ class SalesforceRepo(salesforceConfig: SalesforceConfig) extends MemberRepositor
     override val apiToken = salesforceConfig.apiToken
     override val apiPassword = salesforceConfig.apiPassword
     override val application = Config.appName
-    override val apiURL =salesforceConfig.apiURL.toString
+    override val apiURL =salesforceConfig.apiURL.toString()
     override val stage = salesforceConfig.envName
 
     val authTask = ScheduledTask("", Authentication("", ""), 0.seconds, 30.minutes)(getAuthentication)

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -25,15 +25,17 @@
         </div>
     </div>
     <div class="review-details__actions">
+        <p><input type="submit" class="button button--primary button--large" value="Submit payment" /></p>
+
         <p class="u-note">
             By proceeding you agree to the Guardian's
             <a href="@Links.termsOfService.href" target="_blank">@Links.termsOfService.title</a> and
             <a href="@Links.privacyPolicy.href" target="_blank">@Links.privacyPolicy.title</a>
         </p>
+        <p class="u-note">
+            <strong>GC re: Guardian Media Group</strong> will appear on your bank statement.
+            <button class="u-button-reset u-link js-mandate-pdf">View you Direct Debit instruction</button>
+        </p>
 
-        <button type="submit" class="button button--primary button--large">Submit payment</button>
-
-        <p><strong>GC re: Guardian Media Group</strong> will appear on your bank statement.</p>
-        <p><a class="js-mandate-pdf" href="#">View you Direct Debit instruction</a></p>
     </div>
 </div>

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -34,7 +34,7 @@
         </p>
         <p class="u-note">
             <strong>GC re: Guardian Media Group</strong> will appear on your bank statement.
-            <button class="u-button-reset u-link js-mandate-pdf">View you Direct Debit instruction</button>
+            <button class="u-button-reset u-link js-mandate-pdf">View your Direct Debit instruction</button>
         </p>
 
     </div>

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -32,5 +32,8 @@
         </p>
 
         <button type="submit" class="button button--primary button--large">Submit payment</button>
+
+        <p><strong>GC re: Guardian Media Group</strong> will appear on your bank statement.</p>
+        <p><a class="js-mandate-pdf" href="#">View you Direct Debit instruction</a></p>
     </div>
 </div>

--- a/assets/javascripts/modules/checkout/formElements.js
+++ b/assets/javascripts/modules/checkout/formElements.js
@@ -47,6 +47,9 @@ define(['$'], function ($) {
         $FIELDSET_YOUR_DETAILS: $('.js-fieldset-your-details'),
         $FIELDSET_PAYMENT_DETAILS: $('.js-fieldset-payment-details'),
         $FIELDSET_REVIEW: $('.js-fieldset-review'),
+
+        $MANDATE_PDF: $('.js-mandate-pdf'),
+
         $EDIT_YOUR_DETAILS: $('.js-edit-your-details'),
         $EDIT_PAYMENT_DETAILS: $('.js-edit-payment-details')
     };

--- a/assets/javascripts/modules/checkout/reviewDetails.js
+++ b/assets/javascripts/modules/checkout/reviewDetails.js
@@ -1,50 +1,75 @@
 define([
     'bean',
+    'utils/ajax',
     'utils/text',
     'modules/checkout/formElements'
-], function (bean, textUtils, formEls) {
+], function (bean, ajax, textUtils, formEls) {
     'use strict';
 
+    function clickHelper($elem, callback) {
+        if($elem.length) {
+            bean.on($elem[0], 'click', function (e) {
+                e.preventDefault();
+                callback();
+            });
+        }
+    }
+
     function populateDetails() {
-        formEls.$REVIEW_NAME.text(textUtils.mergeValues([
-            formEls.$FIRST_NAME.val(),
-            formEls.$LAST_NAME.val()
-        ], ' '));
+        clickHelper(formEls.$PAYMENT_DETAILS_SUBMIT, function() {
+            formEls.$REVIEW_NAME.text(textUtils.mergeValues([
+                formEls.$FIRST_NAME.val(),
+                formEls.$LAST_NAME.val()
+            ], ' '));
 
-        formEls.$REVIEW_ADDRESS.text(textUtils.mergeValues([
-            formEls.$ADDRESS1.val(),
-            formEls.$ADDRESS2.val(),
-            formEls.$ADDRESS3.val(),
-            formEls.$POSTCODE.val()
-        ], ', '));
+            formEls.$REVIEW_ADDRESS.text(textUtils.mergeValues([
+                formEls.$ADDRESS1.val(),
+                formEls.$ADDRESS2.val(),
+                formEls.$ADDRESS3.val(),
+                formEls.$POSTCODE.val()
+            ], ', '));
 
-        formEls.$REVIEW_EMAIL.text(textUtils.mergeValues([
-            formEls.$EMAIL.val()
-        ], ''));
+            formEls.$REVIEW_EMAIL.text(textUtils.mergeValues([
+                formEls.$EMAIL.val()
+            ], ''));
 
-        formEls.$REVIEW_ACCOUNT.text(textUtils.mergeValues([
-            formEls.$ACCOUNT.val()
-        ], ''));
+            formEls.$REVIEW_ACCOUNT.text(textUtils.mergeValues([
+                formEls.$ACCOUNT.val()
+            ], ''));
 
-        formEls.$REVIEW_SORTCODE.text(textUtils.mergeValues([
-            formEls.$SORTCODE1.val(),
-            formEls.$SORTCODE2.val(),
-            formEls.$SORTCODE3.val()
-        ], '-'));
+            formEls.$REVIEW_SORTCODE.text(textUtils.mergeValues([
+                formEls.$SORTCODE1.val(),
+                formEls.$SORTCODE2.val(),
+                formEls.$SORTCODE3.val()
+            ], '-'));
 
-        formEls.$REVIEW_HOLDER.text(textUtils.mergeValues([
-            formEls.$HOLDER.val()
-        ], ''));
+            formEls.$REVIEW_HOLDER.text(textUtils.mergeValues([
+                formEls.$HOLDER.val()
+            ], ''));
+        });
+    }
+
+    function mandatePDF() {
+        clickHelper(formEls.$MANDATE_PDF, function() {
+            var formData = ajax.reqwest.serialize(formEls.$CHECKOUT_FORM[0]);
+            ajax({
+                method: 'POST',
+                data: formData,
+                url: '/checkout/mandate-pdf'
+            }).then(function (resp) {
+                if(resp && resp.mandatePDFUrl) {
+                    window.open(resp.mandatePDFUrl);
+                }
+            }).catch(function (jsonError) {
+                // TODO display error message to user
+                Raven.captureException(jsonError);
+            });
+        });
     }
 
     function init() {
-        var $detailsSubmit = formEls.$PAYMENT_DETAILS_SUBMIT;
-        if($detailsSubmit.length) {
-            bean.on($detailsSubmit[0], 'click', function (evt) {
-                evt.preventDefault();
-                populateDetails();
-            });
-        }
+        populateDetails();
+        mandatePDF();
     }
 
     return {

--- a/assets/stylesheets/base/_helpers.scss
+++ b/assets/stylesheets/base/_helpers.scss
@@ -32,6 +32,22 @@
     background: transparent;
 }
 
+.u-link {
+    color: $c-link;
+    text-decoration: none;
+    border-bottom: 1px solid $c-neutral4;
+
+    &:hover,
+    &:focus {
+        border-color: $c-link-hover
+    }
+
+    &:active {
+        color: $c-link-active;
+        border-color: $c-link-active;
+    }
+}
+
 .break-tablet {
     @include mq(tablet) {
         display: block;

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,8 @@ libraryDependencies ++= Seq(
   "net.kencochrane.raven" % "raven-logback" % "6.0.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.seleniumhq.selenium" % "selenium-java" % "2.44.0" % "test"
+  "org.seleniumhq.selenium" % "selenium-java" % "2.44.0" % "test",
+  "com.gocardless" % "gocardless-pro" % "1.0.0"
 )
 
 testOptions in Test ++= Seq(

--- a/conf/routes
+++ b/conf/routes
@@ -25,6 +25,7 @@ GET         /checkout                        controllers.Checkout.renderCheckout
 POST        /checkout                        controllers.Checkout.handleCheckout
 GET         /checkout/check-identity         controllers.Checkout.checkIdentity(email: String)
 POST        /checkout/register-guest-user    controllers.Checkout.processFinishAccount
+POST        /checkout/mandate-pdf            controllers.Checkout.mandatePDF
 
 # collection and delivery
 GET         /collection/paper-digital        controllers.Shipping.viewCollectionPaperDigital


### PR DESCRIPTION
Create a link to a mandate preview PDF, as described on the [Trello task](https://trello.com/c/5ohvsm8t/75-display-the-name-that-will-appear-on-the-customer-s-bank-statement-and-add-a-link-to-a-pdf-of-the-customers-direct-debit-mandate).

The link is currently unstyled:


![mandate-1](https://cloud.githubusercontent.com/assets/1781471/8805800/1d298f7a-2fcb-11e5-86ce-15aebacc0cfb.png)

It opens the PDF in a separate tab:


![mandate](https://cloud.githubusercontent.com/assets/1781471/8805843/4e941de6-2fcb-11e5-9ebb-bfc8c5e21a13.jpg)
