### PR TITLE
Get Prout to run acceptance tests after build is seen as deployed

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,5 +1,15 @@
 {
-  "checkpoints": {
-    "PROD": { "url": "https://subscribe.theguardian.com/", "overdue": "14M" }
-  }
+    "checkpoints": {
+        "PROD": {
+            "url": "https://subscribe.theguardian.com/",
+            "overdue": "14M",
+            "afterSeen": {
+                "travis": {
+                    "config": {
+                        "script": "sbt ++$TRAVIS_SCALA_VERSION acceptance-test && find $HOME/.sbt -name \"*.lock\" -type f -delete && find $HOME/.ivy2/cache -name \"*[\[\]\(\)]*.properties\" -type f -delete"
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This follows on from https://github.com/guardian/subscriptions-frontend/pull/134

Incidentally, @afiore mentioned that rather than specifying the full travis script (which includes the https://github.com/guardian/gu-who/commit/83d29a150 hack for better build times) we could maybe update the default `.travis.yml` to use an environment variable to identify the sbt task (`fast-test` or `acceptance-test`) which would result in less duplication. That would be nice - though getting Travis to understand by default that certain files shouldn't trigger a repack of the cached dependencies would be even better.