### PR TITLE
Acceptance tests for guest user checkout

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -80,7 +80,7 @@ object Checkout extends Controller with LazyLogging {
     })
   }
 
-  def checkIdentity(email: String) = GoogleAuthenticatedStaffAction.async { implicit request =>
+  def checkIdentity(email: String) = NoCacheAction.async { implicit request =>
     for {
       doesUserExist <- IdentityService.doesUserExist(email)
     } yield Ok(Json.obj("emailInUse" -> doesUserExist))

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -80,7 +80,7 @@ object Checkout extends Controller with LazyLogging {
     })
   }
 
-  def checkIdentity(email: String) = NoCacheAction.async { implicit request =>
+  def checkIdentity(email: String) = CachedAction.async { implicit request =>
     for {
       doesUserExist <- IdentityService.doesUserExist(email)
     } yield Ok(Json.obj("emailInUse" -> doesUserExist))

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -5,7 +5,7 @@ import com.gu.identity.play.IdUser
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config.Identity.webAppProfileUrl
 import forms.{FinishAccountForm, SubscriptionsForm}
-import model.{GuestAccountData, SubscriptionData}
+import model.SubscriptionData
 import play.api.data.Form
 import play.api.libs.json._
 import play.api.mvc._

--- a/assets/javascripts/modules/checkout/validatePersonal.js
+++ b/assets/javascripts/modules/checkout/validatePersonal.js
@@ -25,7 +25,7 @@ define([
             var emailValue = data.emailAddress;
             var hasValidEmail = regex.isValidEmail(emailValue);
             var confirmationEmailValue = data.emailAddressConfirmed;
-            var hasConfirmedEmail = confirmationEmailValue === confirmationEmailValue;
+            var hasConfirmedEmail = emailValue === confirmationEmailValue;
 
             var emptyFields = data.requiredFieldValues.filter(function (field) {
                 return !field;

--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -3,11 +3,16 @@ package acceptance
 import acceptance.pages.Checkout
 import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.WebBrowser
-import org.scalatest.{FeatureSpec, GivenWhenThen}
+import org.scalatest.{BeforeAndAfter, FeatureSpec, GivenWhenThen}
+import org.specs2.mutable.BeforeAfter
 
-class CheckoutSpec extends FeatureSpec with WebBrowser with Util with GivenWhenThen{
+class CheckoutSpec extends FeatureSpec with WebBrowser with Util with GivenWhenThen with BeforeAndAfter {
 
   implicit lazy val driver: WebDriver = Config.driver
+
+  before {
+    resetDriver()
+  }
 
   feature("pre-release pages") {
     scenario("QA access to a pre-release page", Acceptance) {

--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -13,7 +13,6 @@ class CheckoutSpec extends FeatureSpec with WebBrowser with Util with GivenWhenT
     resetDriver()
   }
 
-
   feature("Checkout page") {
     scenario("Guest user completes a checkout and sets an account password", Acceptance) {
       withQACookie {
@@ -41,12 +40,11 @@ class CheckoutSpec extends FeatureSpec with WebBrowser with Util with GivenWhenT
       }
     }
 
-    scenario("Guest user supplies invalid details", Acceptance) {
-      val checkout = new Checkout()
-
-      import checkout.PersonalDetails
-
+    scenario("Guest user supplies invalid details", Acceptance)
       withQACookie {
+        val checkout = new Checkout()
+        import checkout.PersonalDetails
+
         When("I visit the checkout page")
         go.to(checkout)
 

--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -54,7 +54,6 @@ class CheckoutSpec extends FeatureSpec with WebBrowser with Util with GivenWhenT
         PersonalDetails.fillIn()
         PersonalDetails.emailConfirmation.value = "non-matching-email@example.com"
 
-        Thread.sleep(1000)
         PersonalDetails.continue()
 
         Then("The email field should be marked with an error")

--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -40,7 +40,7 @@ class CheckoutSpec extends FeatureSpec with WebBrowser with Util with GivenWhenT
       }
     }
 
-    scenario("Guest user supplies invalid details", Acceptance)
+    scenario("Guest user supplies invalid details", Acceptance) {
       withQACookie {
         val checkout = new Checkout()
         import checkout.PersonalDetails
@@ -58,17 +58,17 @@ class CheckoutSpec extends FeatureSpec with WebBrowser with Util with GivenWhenT
         assert(PersonalDetails.emailNotValid(), "email confirmation should not be valid")
       }
     }
+  }
 
-    scenario("ordinary access to a pre-release page", Acceptance) {
-      val checkout = new Checkout
+  scenario("unauthorised access to a pre-release page", Acceptance) {
+    val checkout = new Checkout
 
-      Given("No QA cookie is set")
+    Given("No QA cookie is set")
 
-      When("I visit the checkout page ")
-      go.to(checkout)
+    When("I visit the checkout page ")
+    go.to(checkout)
 
-      Then("I should land on the Google Auth page")
-      assertResult("accounts.google.com")(currentHost)
-    }
+    Then("I should land on the Google Auth page")
+    assertResult("accounts.google.com")(currentHost)
   }
 }

--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -1,10 +1,9 @@
 package acceptance
 
-import acceptance.pages.Checkout
+import acceptance.pages.{Checkout, ThankYou}
 import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.WebBrowser
 import org.scalatest.{BeforeAndAfter, FeatureSpec, GivenWhenThen}
-import org.specs2.mutable.BeforeAfter
 
 class CheckoutSpec extends FeatureSpec with WebBrowser with Util with GivenWhenThen with BeforeAndAfter {
 
@@ -14,23 +13,62 @@ class CheckoutSpec extends FeatureSpec with WebBrowser with Util with GivenWhenT
     resetDriver()
   }
 
-  feature("pre-release pages") {
-    scenario("QA access to a pre-release page", Acceptance) {
+
+  feature("Checkout page") {
+    scenario("Guest user completes a checkout and sets an account password", Acceptance) {
       withQACookie {
-        Given("The QA cookie is set")
-
+        val checkout = new pages.Checkout
         When("I visit the checkout page ")
-        go.to(Checkout)
+        go.to(checkout)
 
-        Then("I should see the digital pack checkout page")
-        assert(pageHasText("Digital Pack"))
+        And("I fill in personal details")
+        checkout.fillInPersonalDetails()
+
+        And("I fill in payment details")
+        checkout.fillInPaymentDetails()
+
+        And("I submit the form")
+        checkout.submit()
+
+        Then("I should land on the Thank You page")
+        assert(pageHasText("Thank you for your order"))
+
+        When("I set a password for my account")
+        new ThankYou().setPassword("supers4af3passw0rd")
+
+        Then("I should read a confirmation message")
+        assert(pageHasText("All done"))
+      }
+    }
+
+    scenario("Guest user supplies invalid details", Acceptance) {
+      val checkout = new Checkout()
+
+      import checkout.PersonalDetails
+
+      withQACookie {
+        When("I visit the checkout page")
+        go.to(checkout)
+
+        And("I fill in personal details with inconsistent emails")
+        PersonalDetails.fillIn()
+        PersonalDetails.emailConfirmation.value = "non-matching-email@example.com"
+
+        Thread.sleep(1000)
+        PersonalDetails.continue()
+
+        Then("The email field should be marked with an error")
+        assert(PersonalDetails.emailNotValid(), "email confirmation should not be valid")
       }
     }
 
     scenario("ordinary access to a pre-release page", Acceptance) {
+      val checkout = new Checkout
+
       Given("No QA cookie is set")
+
       When("I visit the checkout page ")
-      go.to(Checkout)
+      go.to(checkout)
 
       Then("I should land on the Google Auth page")
       assertResult("accounts.google.com")(currentHost)

--- a/test/acceptance/PrintSubscriptionsSpec.scala
+++ b/test/acceptance/PrintSubscriptionsSpec.scala
@@ -1,7 +1,7 @@
 package acceptance
 
 import acceptance.Config.appUrl
-import acceptance.pages.{DigitalPack, Home, SubscriptionPlan}
+import acceptance.pages.{Home, SubscriptionPlan}
 import org.openqa.selenium.WebDriver
 import org.scalatest._
 import org.scalatest.selenium.WebBrowser
@@ -15,8 +15,12 @@ object SubscriptionTest {
     SubscriptionTest(url, name, "www.guardiandirectsubs.co.uk")
 }
 
-class PrintSubscriptionsSpec extends FeatureSpec with Util with WebBrowser with GivenWhenThen {
+class PrintSubscriptionsSpec extends FeatureSpec with Util with WebBrowser with GivenWhenThen with BeforeAndAfter {
   implicit lazy val driver: WebDriver = Config.driver
+
+  before {
+    resetDriver()
+  }
 
   val testData = Seq(
     SubscriptionTest.collection("/collection/paper", "Paper voucher subscription"),
@@ -25,39 +29,25 @@ class PrintSubscriptionsSpec extends FeatureSpec with Util with WebBrowser with 
     SubscriptionTest.delivery("/delivery/paper-digital", "Paper + digital home delivery subscription")
   )
 
-  feature("Lucrative subscriptions") {
+  feature("Print subscriptions") {
     for (test <- testData) yield scenario(test.name, Acceptance) {
-      goTo(s"$appUrl/${test.url}")
-      SubscriptionPlan.selectSixdayPackage()
+      go.to(s"$appUrl/${test.url}")
+      new SubscriptionPlan().selectSixdayPackage()
       assert(pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
       assertResult(test.landingHost)(currentHost)
     }
 
     scenario("Paper + Digital subscription", Acceptance) {
       Home.selectPaperPlusDigital()
-      SubscriptionPlan.selectSixdayPackage()
+      new SubscriptionPlan().selectSixdayPackage()
       assert(pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
       assertResult("www.guardiansubscriptions.co.uk")(currentHost)
     }
 
     scenario("Paper only subscription", Acceptance) {
       Home.selectPaper()
-      SubscriptionPlan.selectWeekendPackage()
+      new SubscriptionPlan().selectWeekendPackage()
       assert(pageHasText("You have chosen\nWEEKEND"), "document contains selected plan")
-      assertResult("www.guardiansubscriptions.co.uk")(currentHost)
-    }
-  }
-
-  feature("Digital Pack") {
-    scenario("selecting UK", Acceptance){
-      pending
-      DigitalPack.selectUK
-      assert(pageHasText("You have chosen:\nDigital pack"))
-    }
-
-    scenario("selecting not UK", Acceptance) {
-      pending
-      DigitalPack.selectNonUK
       assertResult("www.guardiansubscriptions.co.uk")(currentHost)
     }
   }

--- a/test/acceptance/PrintSubscriptionsSpec.scala
+++ b/test/acceptance/PrintSubscriptionsSpec.scala
@@ -32,21 +32,21 @@ class PrintSubscriptionsSpec extends FeatureSpec with Util with WebBrowser with 
   feature("Print subscriptions") {
     for (test <- testData) yield scenario(test.name, Acceptance) {
       go.to(s"$appUrl/${test.url}")
-      new SubscriptionPlan().selectSixdayPackage()
+      SubscriptionPlan.selectSixdayPackage()
       assert(pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
       assertResult(test.landingHost)(currentHost)
     }
 
     scenario("Paper + Digital subscription", Acceptance) {
       Home.selectPaperPlusDigital()
-      new SubscriptionPlan().selectSixdayPackage()
+      SubscriptionPlan.selectSixdayPackage()
       assert(pageHasText("You have chosen\nSIXDAY"), "document contains selected plan")
       assertResult("www.guardiansubscriptions.co.uk")(currentHost)
     }
 
     scenario("Paper only subscription", Acceptance) {
       Home.selectPaper()
-      new SubscriptionPlan().selectWeekendPackage()
+      SubscriptionPlan.selectWeekendPackage()
       assert(pageHasText("You have chosen\nWEEKEND"), "document contains selected plan")
       assertResult("www.guardiansubscriptions.co.uk")(currentHost)
     }

--- a/test/acceptance/Util.scala
+++ b/test/acceptance/Util.scala
@@ -9,6 +9,8 @@ import org.scalatest.selenium.WebBrowser
 import acceptance.Config.appUrl
 import configuration.QA.{passthroughCookie => qaCookie}
 
+import scala.util.Try
+
 trait Util { this: WebBrowser =>
   implicit val driver: WebDriver
 
@@ -28,10 +30,17 @@ trait Util { this: WebBrowser =>
     driver.manage().timeouts().implicitlyWait(60, TimeUnit.SECONDS)
   }
 
-  protected def currentHost: String = new URL(currentUrl).getHost
-
   protected def pageHasText(text: String, timeoutSecs: Int=50): Boolean = {
     val pred = ExpectedConditions.textToBePresentInElementLocated(By.tagName("body"), text)
     new WebDriverWait(driver, timeoutSecs).until(pred)
   }
+
+  protected def pageHasElement(q: Query, timeoutSecs: Int=50): Boolean = {
+    val pred = ExpectedConditions.presenceOfElementLocated(q.by)
+    Try {
+      new WebDriverWait(driver, timeoutSecs).until(pred)
+    }.isSuccess
+  }
+
+  protected def currentHost: String = new URL(currentUrl).getHost
 }

--- a/test/acceptance/Util.scala
+++ b/test/acceptance/Util.scala
@@ -1,15 +1,18 @@
 package acceptance
 
 import java.net.URL
+import java.util.concurrent.TimeUnit
 
-import org.openqa.selenium.{Cookie, WebDriver}
+import org.openqa.selenium.support.ui.{WebDriverWait, ExpectedConditions}
+import org.openqa.selenium.{By, Cookie, WebDriver}
 import org.scalatest.selenium.WebBrowser
 import acceptance.Config.appUrl
 import configuration.QA.{passthroughCookie => qaCookie}
 
 trait Util { this: WebBrowser =>
+  implicit val driver: WebDriver
 
-  protected def withQACookie(block: => Unit)(implicit driver: WebDriver): Unit = {
+  protected def withQACookie(block: => Unit): Unit = {
     val cookie = new Cookie(qaCookie.name, qaCookie.value)
     go.to(appUrl)
     driver.manage().addCookie(cookie)
@@ -19,9 +22,16 @@ trait Util { this: WebBrowser =>
     }
   }
 
-  protected def currentHost(implicit d: WebDriver): String = new URL(currentUrl).getHost
-  protected def pageHasText(text: String)(implicit d: WebDriver): Boolean = {
-    find(tagName("body")).get.text.contains(text)
+  def resetDriver() = {
+    driver.get("about:about")
+    driver.manage().deleteAllCookies()
+    driver.manage().timeouts().implicitlyWait(60, TimeUnit.SECONDS)
   }
 
+  protected def currentHost: String = new URL(currentUrl).getHost
+
+  protected def pageHasText(text: String, timeoutSecs: Int=50): Boolean = {
+    val pred = ExpectedConditions.textToBePresentInElementLocated(By.tagName("body"), text)
+    new WebDriverWait(driver, timeoutSecs).until(pred)
+  }
 }

--- a/test/acceptance/pages/Checkout.scala
+++ b/test/acceptance/pages/Checkout.scala
@@ -2,8 +2,87 @@ package acceptance.pages
 
 
 import acceptance.Config.appUrl
-import org.scalatest.selenium.Page
+import acceptance.Util
+import org.openqa.selenium.WebDriver
+import org.scalatest.selenium.{WebBrowser, Page}
 
-object Checkout extends Page {
+class Checkout(implicit val driver: WebDriver) extends Page with WebBrowser with Util {
   val url = s"$appUrl/checkout"
+
+  val formErrorClass = ".form-field--error"
+
+  object PersonalDetails {
+    val firstName = textField(name("personal.first"))
+    val lastName = textField(name("personal.last"))
+    val email = emailField(name("personal.emailValidation.email"))
+    val emailConfirmation = emailField(name("personal.emailValidation.confirm"))
+    val address1 = textField(name("personal.address.address1"))
+    val address2 = textField(name("personal.address.address2"))
+    val town = textField(name("personal.address.town"))
+    val postcode = textField(name("personal.address.postcode"))
+    val receiveGnmMarketing = checkbox(name("personal.receiveGnmMarketing"))
+
+
+    def fillIn(): Unit = {
+      val emailValue = s"test-${System.currentTimeMillis()}@example.com"
+      firstName.value = "first"
+      lastName.value = "last"
+      email.value = emailValue
+      emailConfirmation.value = emailValue
+      address1.value = "address 1"
+      address2.value = "address 2"
+      town.value = "town"
+      postcode.value = "E8123"
+      receiveGnmMarketing.select()
+    }
+
+    def emailNotValid(): Boolean =
+      fieldHasError(emailConfirmation)
+
+    def continue(): Unit = {
+      click.on(cssSelector(".js-checkout-your-details-submit"))
+    }
+  }
+
+  object PaymentDetails {
+    val account = numberField(name("payment.account"))
+    val sortcode1 = numberField(name("payment.sortcode1"))
+    val sortcode2 = numberField(name("payment.sortcode2"))
+    val sortcode3 = numberField(name("payment.sortcode3"))
+    val payment = textField(name("payment.holder"))
+    val confirm = checkbox(cssSelector(""".js-checkout-confirm-payment input[type="checkbox"]"""))
+
+    def fillIn(): Unit = {
+      account.value = "55779911"
+      sortcode1.value = "20"
+      sortcode2.value = "00"
+      sortcode3.value = "00"
+      payment.value = "payment"
+      confirm.select()
+    }
+
+    def continue(): Unit = {
+      click.on(cssSelector(".js-checkout-payment-details-submit"))
+    }
+  }
+
+  private def fieldHasError(elem: Element): Boolean = {
+    elem.attribute("name").map { inputName =>
+      pageHasElement(cssSelector(s"""$formErrorClass *[name="$inputName"]"""), 5)
+    }.isDefined
+  }
+
+  def fillInPersonalDetails(): Unit = {
+    PersonalDetails.fillIn()
+    PersonalDetails.continue()
+  }
+
+  def fillInPaymentDetails(): Unit = {
+    PaymentDetails.fillIn()
+    PaymentDetails.continue()
+  }
+
+  def submit(): Unit = {
+    click.on(cssSelector("""input[type="submit"]"""))
+  }
 }

--- a/test/acceptance/pages/Home.scala
+++ b/test/acceptance/pages/Home.scala
@@ -14,7 +14,7 @@ object Home extends Page with WebBrowser {
     selectPlan( """*[data-test-id="subscriptions-uk-paper"]""")
 
   private def selectPlan(selector: String)(implicit d: WebDriver) = {
-    if (currentUrl != url) go.to(this)
+    go.to(this)
     clickOn(cssSelector(selector))
   }
 }

--- a/test/acceptance/pages/SubscriptionPlan.scala
+++ b/test/acceptance/pages/SubscriptionPlan.scala
@@ -3,12 +3,12 @@ package acceptance.pages
 import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.WebBrowser
 
-object SubscriptionPlan extends  WebBrowser {
-  def selectEverydayPackage()(implicit d: WebDriver) = selectPackage("everyday")
-  def selectSixdayPackage()(implicit d: WebDriver) = selectPackage("sixday")
-  def selectWeekendPackage()(implicit d: WebDriver) = selectPackage("weekend")
+class SubscriptionPlan(implicit val driver: WebDriver) extends  WebBrowser {
+  def selectEverydayPackage() = selectPackage("everyday")
+  def selectSixdayPackage() = selectPackage("sixday")
+  def selectWeekendPackage() = selectPackage("weekend")
 
-  private def selectPackage(id: String)(implicit d: WebDriver) = {
+  private def selectPackage(id: String) = {
     clickOn(cssSelector(s"""label[for="$id"]"""))
     clickOn(cssSelector("""*[data-test-id="choose-package-select"]"""))
   }

--- a/test/acceptance/pages/SubscriptionPlan.scala
+++ b/test/acceptance/pages/SubscriptionPlan.scala
@@ -3,12 +3,12 @@ package acceptance.pages
 import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.WebBrowser
 
-class SubscriptionPlan(implicit val driver: WebDriver) extends  WebBrowser {
-  def selectEverydayPackage() = selectPackage("everyday")
-  def selectSixdayPackage() = selectPackage("sixday")
-  def selectWeekendPackage() = selectPackage("weekend")
+object SubscriptionPlan extends WebBrowser {
+  def selectEverydayPackage()(implicit d: WebDriver) = selectPackage("everyday")
+  def selectSixdayPackage()(implicit d: WebDriver) = selectPackage("sixday")
+  def selectWeekendPackage()(implicit d: WebDriver) = selectPackage("weekend")
 
-  private def selectPackage(id: String) = {
+  private def selectPackage(id: String)(implicit d: WebDriver) = {
     clickOn(cssSelector(s"""label[for="$id"]"""))
     clickOn(cssSelector("""*[data-test-id="choose-package-select"]"""))
   }

--- a/test/acceptance/pages/ThankYou.scala
+++ b/test/acceptance/pages/ThankYou.scala
@@ -1,0 +1,18 @@
+package acceptance.pages
+
+import org.openqa.selenium.WebDriver
+import org.scalatest.selenium.{Page, WebBrowser}
+import acceptance.Config.appUrl
+
+class ThankYou(implicit driver: WebDriver) extends Page with WebBrowser {
+  override val url = s"$appUrl/checkout"
+
+  object PasswordForm {
+    val password = pwdField(id("password"))
+  }
+
+  def setPassword(pwd: String): Unit = {
+    PasswordForm.password.value = pwd
+    click.on(cssSelector(".js-checkout-finish-account-submit"))
+  }
+}


### PR DESCRIPTION
Implements two acceptance tests covering the following scenarios:

- guest user completes a successful checkout and sets a password for his newly created account.
- guest user supplies an invalid email confirmation and encounters a validation error.

![screencast](https://cloud.githubusercontent.com/assets/63361/8854338/51d612a6-3157-11e5-80e8-66c340b12bc0.gif)

Depends on #142 

**Notes:**
- Fixes a recent regression in the front-end code whereby the form was happily accepting a non-matching email confirmation (@davidrapson and I discovered this while I was writing the test).
- I had to remove the Google authentication from the  `controllers.Checkout.checkIdentity` action. By default, Ajax calls do not include cookies, so the QA cookie cannot be picked up resulting in a validation error. An alternative solution would be to rework the relevant ajax call so that the `XMLHttpRequest.withCredentials`flag is set to true. We think that the downsize with this approach would be that we might incur into issues with old browser versions (e.g. IE8).

@rtyley @TesterSpike