### PR TITLE
Use `before_cache` to prevent unnecessary Travis dependency cache repacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,7 @@ cache:
   directories:
   - $HOME/.sbt
   - $HOME/.ivy2
-script: sbt ++$TRAVIS_SCALA_VERSION fast-test && find $HOME/.sbt -name "*.lock" -type f -delete && find $HOME/.ivy2/cache -name "*[\[\]\(\)]*.properties" -type f -delete
+before_cache:
+  - find $HOME/.sbt -name "*.lock" -type f -delete -print
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete -print
+script: sbt ++$TRAVIS_SCALA_VERSION fast-test


### PR DESCRIPTION
http://docs.travis-ci.com/user/caching/#before_cache-phase

This replaces this nasty hack: https://github.com/guardian/gu-who/commit/83d29a150

Looks like this feature was added in March, which was why I didn't spot it for the original introduction of the unpleasant hack.

https://github.com/travis-ci/travis-build/commit/d2a1f8fd626b83fbb3f3ee15f5f5da559c30c53c

**Unfortunately** neither this or the old hack seems to be working at the moment - see https://github.com/travis-ci/travis-ci/issues/4556 - repacks mysteriously get triggered in either case. Sigh. In any case, this is better than the earlier hack, so merging it in, and hoping that it starts working soon.

cc @afiore 
