### PR TITLE
Checkout message tweaks

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -101,22 +101,7 @@
                             <input type="text" class="input-text js-input input-text input-text--small" id="address-postcode" name="personal.address.postcode" value="@form.data.get("personal.address.postcode")">
                             @fragments.forms.errorMessage("Please enter a valid postal code")
                         </div>
-                        <div class="form-field">
-                            <label class="option" for="receive-gnm-marketing">
-                            @defining(form.data.get("personal.receiveGnmMarketing")) { gnmMarketingOpt =>
-                                <span class="option__input">
-                                    <input type="checkbox"
-                                        name="personal.receiveGnmMarketing"
-                                        id="receive-gnm-marketing"
-                                        @if(gnmMarketingOpt.contains("on")) { checked="checked" }
-                                        >
-                                </span>
-                            }
-                                <span class="option__label">
-                                    I'd like to be kept up to to date by email with offers and developments from Guardian News &amp; Media Limited
-                                </span>
-                            </label>
-                        </div>
+
                         <div class="actions">
                             <button class="button button--primary button--large js-checkout-your-details-submit">Continue</button>
                         </div>
@@ -190,7 +175,7 @@
                         </legend>
                     </div>
                     <div class="fieldset__fields">
-                        @fragments.checkout.reviewDetails()
+                        @fragments.checkout.reviewDetails(form)
                     </div>
                 </fieldset>
 

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -34,7 +34,11 @@
         </p>
         <p class="u-note">
             <strong>GC re: Guardian Media Group</strong> will appear on your bank statement.
-            <button class="u-button-reset u-link js-mandate-pdf">View your Direct Debit instruction</button>
+            <button class="u-button-reset u-link js-mandate-pdf"
+                    data-loading-message="Generating your Direct Debit instruction"
+                    data-error-message="There was a problem generating your Direct Debit instruction, please try again">
+                View your Direct Debit instruction
+            </button>
         </p>
 
     </div>

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -1,4 +1,4 @@
-@()
+@(form: Form[model.SubscriptionData])
 
 @import configuration.Links
 
@@ -25,13 +25,31 @@
         </div>
     </div>
     <div class="review-details__actions">
-        <p><input type="submit" class="button button--primary button--large" value="Submit payment" /></p>
+        <p class="u-note">Your subscription includes a range of exclusive benefits. From time to time we’ll send you details. These may include special offers from partners, but will be sent to you from Guardian subscriptions.</p>
+
+        <label class="option u-pad-bottom" for="receive-gnm-marketing">
+        @defining(form.data.get("personal.receiveGnmMarketing")) { gnmMarketingOpt =>
+            <span class="option__input">
+                <input type="checkbox"
+                    name="personal.receiveGnmMarketing"
+                    id="receive-gnm-marketing"
+                    @if(gnmMarketingOpt.contains("on")) { checked="checked" }
+                    >
+            </span>
+        }
+            <span class="option__label">
+                Guardian News &amp; Media would also like your permission to contact you about other services.
+            </span>
+        </label>
+
+        <input type="submit" class="button button--primary button--large u-margin-bottom" value="Submit payment">
 
         <p class="u-note">
             By proceeding you agree to the Guardian's
             <a href="@Links.termsOfService.href" target="_blank">@Links.termsOfService.title</a> and
             <a href="@Links.privacyPolicy.href" target="_blank">@Links.privacyPolicy.title</a>
         </p>
+
         <p class="u-note">
             <strong>GC re: Guardian Media Group</strong> will appear on your bank statement.
             <button class="u-button-reset u-link js-mandate-pdf"

--- a/assets/javascripts/modules/checkout/reviewDetails.js
+++ b/assets/javascripts/modules/checkout/reviewDetails.js
@@ -50,20 +50,53 @@ define([
     }
 
     function mandatePDF() {
-        clickHelper(formEls.$MANDATE_PDF, function() {
+
+        var $mandateLink = formEls.$MANDATE_PDF;
+        var mandateLink = $mandateLink[0];
+
+
+        function setLoadingState(link) {
+            link.setAttribute('disabled', 'disabled');
+            link.textContent = link.getAttribute('data-loading-message');
+        }
+
+        function resetMandateLink(link, label) {
+            link.textContent = label;
+            link.removeAttribute('disabled');
+        }
+
+        function displayErrorMessage(link, label) {
+            link.parentNode.insertAdjacentHTML('afterend', [
+                '<p class="u-error">',
+                    link.getAttribute('data-error-message'),
+                '</p>'
+            ].join(''));
+            resetMandateLink(link, label);
+        }
+
+        clickHelper($mandateLink, function() {
+
             var formData = ajax.reqwest.serialize(formEls.$CHECKOUT_FORM[0]);
+            var originalLabel = mandateLink.textContent;
+
+            setLoadingState(mandateLink);
+
             ajax({
                 method: 'POST',
                 data: formData,
                 url: '/checkout/mandate-pdf'
             }).then(function (resp) {
                 if(resp && resp.mandatePDFUrl) {
+                    resetMandateLink(mandateLink, originalLabel);
                     window.open(resp.mandatePDFUrl);
+                } else {
+                    displayErrorMessage(mandateLink, originalLabel);
                 }
-            }).catch(function (jsonError) {
-                // TODO display error message to user
-                Raven.captureException(jsonError);
+            }).catch(function (err) {
+                displayErrorMessage(mandateLink, originalLabel);
+                Raven.captureException(err);
             });
+
         });
     }
 

--- a/assets/stylesheets/base/_helpers.scss
+++ b/assets/stylesheets/base/_helpers.scss
@@ -7,6 +7,7 @@
     @include u-h;
 }
 
+
 .u-unstyled-list {
     margin: 0;
     padding: 0;
@@ -16,6 +17,10 @@
 .u-note {
     @include fs-textSans(3);
     color: $c-neutral2;
+}
+.u-error {
+    @include fs-data(3);
+    color: guss-colour(error);
 }
 
 .u-pad-top {
@@ -46,6 +51,10 @@
         color: $c-link-active;
         border-color: $c-link-active;
     }
+}
+.u-link[disabled] {
+    color: $c-neutral2;
+    border-bottom: none;
 }
 
 .break-tablet {

--- a/assets/stylesheets/base/_helpers.scss
+++ b/assets/stylesheets/base/_helpers.scss
@@ -30,6 +30,13 @@
     padding-bottom: $gs-baseline;
 }
 
+.u-margin-top {
+    margin-top: $gs-baseline;
+}
+.u-margin-bottom {
+    margin-bottom: $gs-baseline;
+}
+
 .u-button-reset {
     padding: 0;
     border: 0;


### PR DESCRIPTION
Update payment terms and privacy messages, as per [this card](https://trello.com/c/gJVlV2nc/90-email-marketing-preferences-copy-updates); with some UX refinements.

![screen shot 2015-07-24 at 11 26 56](https://cloud.githubusercontent.com/assets/123386/8872667/0f4b5e3c-31f7-11e5-8fc4-ce057f064261.png)

Branched off https://github.com/guardian/subscriptions-frontend/pull/139

@ostapneko