### PR TITLE
Improve checkout edit details flow

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -51,7 +51,7 @@
                             }
                         </div>
                         <div class="fieldset__edit">
-                            <button class="text-button u-button-reset js-edit-your-details is-hidden">Edit</button>
+                            <button class="text-button u-button-reset js-edit-your-details">Edit</button>
                         </div>
                     </div>
                     <div class="fieldset__fields">
@@ -119,7 +119,7 @@
                             Payment will be taken by Direct Debit
                         </div>
                         <div class="fieldset__edit">
-                            <button class="text-button u-button-reset js-edit-payment-details is-hidden">Edit</button>
+                            <button class="text-button u-button-reset js-edit-payment-details">Edit</button>
                         </div>
                     </div>
                     <div class="fieldset__fields">

--- a/assets/javascripts/modules/checkout/editFieldsets.js
+++ b/assets/javascripts/modules/checkout/editFieldsets.js
@@ -1,19 +1,17 @@
 define(['bean', 'modules/checkout/formElements'], function (bean, formEls) {
     'use strict';
 
+    var FIELDSET_COMPLETE = 'fieldset--complete';
     var FIELDSET_COLLAPSED = 'fieldset--collapsed';
-    var FIELDSET_COMPLETE = 'data-fieldset-complete';
-    var HIDDEN_CLASS = 'is-hidden';
-
-    function swap(from, to) {
-        from.addClass(HIDDEN_CLASS);
-        to.removeClass(HIDDEN_CLASS);
-    }
 
     function collapseFieldsets(extra) {
-        formEls.$FIELDSET_YOUR_DETAILS.addClass(FIELDSET_COLLAPSED);
-        formEls.$FIELDSET_PAYMENT_DETAILS.addClass(FIELDSET_COLLAPSED);
-        formEls.$FIELDSET_REVIEW.addClass(FIELDSET_COLLAPSED);
+        [
+            formEls.$FIELDSET_YOUR_DETAILS,
+            formEls.$FIELDSET_PAYMENT_DETAILS,
+            formEls.$FIELDSET_REVIEW
+        ].forEach(function(item) {
+            item.addClass(FIELDSET_COLLAPSED);
+        });
         if(extra) {
             extra.removeClass(FIELDSET_COLLAPSED);
         }
@@ -24,26 +22,20 @@ define(['bean', 'modules/checkout/formElements'], function (bean, formEls) {
         var $editPayment = formEls.$EDIT_PAYMENT_DETAILS;
 
         if($editDetails.length && $editPayment.length){
+
             bean.on($editDetails[0], 'click', function (e) {
                 e.preventDefault();
-
                 collapseFieldsets(formEls.$FIELDSET_YOUR_DETAILS);
-
-                $editDetails.addClass(HIDDEN_CLASS);
-
-                if (formEls.$FIELDSET_PAYMENT_DETAILS.attr(FIELDSET_COMPLETE) !== null) {
-                    $editPayment.removeClass(HIDDEN_CLASS);
-                } else {
-                    $editPayment.addClass(HIDDEN_CLASS);
-                }
+                formEls.$FIELDSET_YOUR_DETAILS.removeClass(FIELDSET_COMPLETE);
+                formEls.$FIELDSET_PAYMENT_DETAILS.removeClass(FIELDSET_COMPLETE);
             });
 
             bean.on($editPayment[0], 'click', function (e) {
                 e.preventDefault();
-
                 collapseFieldsets(formEls.$FIELDSET_PAYMENT_DETAILS);
-                swap($editPayment, $editDetails);
+                formEls.$FIELDSET_PAYMENT_DETAILS.removeClass(FIELDSET_COMPLETE);
             });
+
         }
     }
 

--- a/assets/javascripts/modules/checkout/paymentDetails.js
+++ b/assets/javascripts/modules/checkout/paymentDetails.js
@@ -13,6 +13,10 @@ define([
 ) {
     'use strict';
 
+    var FIELDSET_COLLAPSED = 'fieldset--collapsed';
+    var FIELDSET_COMPLETE = 'fieldset--complete';
+    var FIELDSET_COMPLETE_ATTR = 'data-fieldset-complete';
+
     function displayErrors(validity) {
         toggleError(formEls.$ACCOUNT_CONTAINER, !validity.accountNumberValid);
         toggleError(formEls.$HOLDER_CONTAINER, !validity.accountHolderNameValid);
@@ -21,13 +25,13 @@ define([
     }
 
     function nextStep() {
-        var FIELDSET_COLLAPSED = 'fieldset--collapsed';
-        var FIELDSET_COMPLETE = 'data-fieldset-complete';
-        var IS_HIDDEN = 'is-hidden';
+        formEls.$FIELDSET_PAYMENT_DETAILS
+            .addClass(FIELDSET_COLLAPSED)
+            .addClass(FIELDSET_COMPLETE)
+            .attr(FIELDSET_COMPLETE_ATTR, '');
 
-        formEls.$FIELDSET_PAYMENT_DETAILS.addClass(FIELDSET_COLLAPSED).attr(FIELDSET_COMPLETE, '');
-        formEls.$FIELDSET_REVIEW.removeClass(FIELDSET_COLLAPSED);
-        formEls.$EDIT_PAYMENT_DETAILS.removeClass(IS_HIDDEN);
+        formEls.$FIELDSET_REVIEW
+            .removeClass(FIELDSET_COLLAPSED);
     }
 
     function handleValidation() {

--- a/assets/javascripts/modules/checkout/personalDetails.js
+++ b/assets/javascripts/modules/checkout/personalDetails.js
@@ -10,8 +10,8 @@ define([
     'use strict';
 
     var FIELDSET_COLLAPSED = 'fieldset--collapsed';
-    var FIELDSET_COMPLETE = 'data-fieldset-complete';
-    var HIDDEN_CLASS = 'is-hidden';
+    var FIELDSET_COMPLETE = 'fieldset--complete';
+    var FIELDSET_COMPLETE_ATTR = 'data-fieldset-complete';
 
     var requiredFields = [
         {input: formEls.$FIRST_NAME, container: formEls.$FIRST_NAME_CONTAINER},
@@ -45,11 +45,13 @@ define([
     }
 
     function nextStep() {
-        formEls.$FIELDSET_YOUR_DETAILS.addClass(FIELDSET_COLLAPSED).attr(FIELDSET_COMPLETE, '');
-        formEls.$FIELDSET_PAYMENT_DETAILS.removeClass(FIELDSET_COLLAPSED);
+        formEls.$FIELDSET_YOUR_DETAILS
+            .addClass(FIELDSET_COLLAPSED)
+            .addClass(FIELDSET_COMPLETE)
+            .attr(FIELDSET_COMPLETE_ATTR, '');
 
-        formEls.$EDIT_YOUR_DETAILS.addClass(HIDDEN_CLASS);
-        formEls.$EDIT_PAYMENT_DETAILS.removeClass(HIDDEN_CLASS);
+        formEls.$FIELDSET_PAYMENT_DETAILS
+            .removeClass(FIELDSET_COLLAPSED);
     }
 
     function handleValidation(personalDetails) {

--- a/assets/stylesheets/modules/_forms.scss
+++ b/assets/stylesheets/modules/_forms.scss
@@ -78,11 +78,13 @@ fieldset {
     }
 }
 .fieldset__edit {
+    @include fs-textSans(1);
     position: absolute;
     top: $gs-baseline;
     right: $gs-gutter;
     text-transform: lowercase;
-    @include fs-textSans(1);
+
+    display: none;
 }
 
 .fieldset--single {
@@ -98,6 +100,11 @@ fieldset {
     }
 }
 
+.fieldset--complete {
+    .fieldset__edit {
+        display: block;
+    }
+}
 .fieldset--collapsed {
     .fieldset__note,
     .fieldset__fields {


### PR DESCRIPTION
Improves a couple of edge-cases with editing checkout sections; avoids this:

![screen shot 2015-07-24 at 12 55 47](https://cloud.githubusercontent.com/assets/123386/8873953/dc498ba0-3203-11e5-9efa-4e2a1731eeab.png)

@ostapneko 