### PR TITLE
Review BUT DON'T MERGE: Send data extension row to ExactTarget upon subscription

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -1,5 +1,6 @@
 package configuration
 
+import com.exacttarget.fuelsdk.{ETClient, ETConfiguration}
 import com.github.nscala_time.time.Imports._
 import com.gocardless.GoCardlessClient
 import com.gocardless.GoCardlessClient.Environment
@@ -68,5 +69,17 @@ object Config {
   object GoCardless {
     private val token = config.getString("gocardless.token")
     val client = GoCardlessClient.create(token, Environment.SANDBOX)
+  }
+
+  object ExactTarget {
+    private val clientId = config.getString("exact-target.client-id")
+    private val clientSecret = config.getString("exact-target.client-secret")
+
+    private val etConfiguration = new ETConfiguration()
+    etConfiguration.set("clientId", clientId)
+    etConfiguration.set("clientSecret", clientSecret)
+
+    val etClient = new ETClient(etConfiguration)
+    val thankYouDataExtensionKey = config.getString("exact-target.data-extension-keys.thank-you")
   }
 }

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -18,8 +18,7 @@ import scala.concurrent.Future
 
 object Checkout extends Controller with LazyLogging {
   private val zuoraService = TouchpointBackend.Normal.zuoraService
-  private val exactTargetService = ExactTargetService
-  private lazy val checkoutService = new CheckoutService(IdentityService, SalesforceService, zuoraService, exactTargetService)
+  private lazy val checkoutService = new CheckoutService(IdentityService, SalesforceService, zuoraService, ExactTargetService)
   private val goCardlessService = GoCardlessService
 
   def identityCookieOpt(implicit request: Request[_]): Option[Cookie] =

--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -1,0 +1,57 @@
+package model.exactTarget
+
+import com.gu.membership.zuora.soap.Zuora._
+import model.SubscriptionData
+
+object SubscriptionDataExtensionRow {
+  def apply(
+      subscription: Subscription,
+      subscriptionData: SubscriptionData,
+      ratePlanCharge: RatePlanCharge,
+      paymentMethod: PaymentMethod,
+      account: Account
+      ): SubscriptionDataExtensionRow = {
+
+    val billingPeriod = ratePlanCharge.billingPeriod.getOrElse(
+      throw new ExactTargetException(s"Error while processing $subscription: Could not create a SubscriptionDataExtensionRow without a billing period")
+    )
+
+    val personalData = subscriptionData.personalData
+
+    val address = personalData.address
+
+    val paymentData = subscriptionData.paymentData
+
+    SubscriptionDataExtensionRow(
+      `SubscriberKey` -> subscription.name,
+      `EmailAddress` -> personalData.email,
+      `Subscription term` -> billingPeriod,
+      `Payment amount` -> ratePlanCharge.price.toString,
+      `Default payment method` -> paymentMethod.`type`,
+      `First Name` -> personalData.firstName,
+      `Last Name` -> personalData.lastName,
+      `Address 1` -> address.address1,
+      `Address 2` -> address.address2,
+      `City` -> address.town,
+      `Post Code` -> address.postcode,
+      //TODO hardcoded!
+      `Country` -> "UK",
+      `Account Name` -> paymentData.holder,
+      `Sort Code` -> paymentData.sortCode,
+      `Account number` -> paymentData.account,
+      `Date of first payment` -> subscription.termStartDate.toString,
+      `Date of second payment` -> ratePlanCharge.chargedThroughDate.toString,
+      `Currency` -> account.currency,
+      //TODO to remove, hardcoded in the template
+      `Trial period` -> "14",
+      `MandateID` -> paymentMethod.mandateId,
+      `Email` -> personalData.email
+    )
+  }
+}
+
+trait DataExtensionRow {
+  def fields: Seq[(DataExtensionColumn, String)]
+}
+
+case class SubscriptionDataExtensionRow(fields: (DataExtensionColumn, String)*) extends DataExtensionRow

--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -27,29 +27,29 @@ object SubscriptionDataExtensionRow {
     val paymentData = subscriptionData.paymentData
 
     SubscriptionDataExtensionRow(
-      `SubscriberKey` -> subscription.name,
-      `EmailAddress` -> personalData.email,
-      `Subscription term` -> billingPeriod,
-      `Payment amount` -> ratePlanCharge.price.toString,
-      `Default payment method` -> paymentMethod.`type`,
-      `First Name` -> personalData.firstName,
-      `Last Name` -> personalData.lastName,
-      `Address 1` -> address.address1,
-      `Address 2` -> address.address2,
-      `City` -> address.town,
-      `Post Code` -> address.postcode,
+      "SubscriberKey" -> subscription.name,
+      "EmailAddress" -> personalData.email,
+      "Subscription term" -> billingPeriod,
+      "Payment amount" -> ratePlanCharge.price.toString,
+      "Default payment method" -> paymentMethod.`type`,
+      "First Name" -> personalData.firstName,
+      "Last Name" -> personalData.lastName,
+      "Address 1" -> address.address1,
+      "Address 2" -> address.address2,
+      "City" -> address.town,
+      "Post Code" -> address.postcode,
       //TODO hardcoded!
-      `Country` -> "UK",
-      `Account Name` -> paymentData.holder,
-      `Sort Code` -> paymentData.sortCode,
-      `Account number` -> paymentData.account,
-      `Date of first payment` -> formatDate(subscription.termStartDate),
-      `Date of second payment` -> secondPaymentDate,
-      `Currency` -> account.currency,
+      "Country" -> "UK",
+      "Account Name" -> paymentData.holder,
+      "Sort Code" -> paymentData.sortCode,
+      "Account number" -> paymentData.account,
+      "Date of first payment" -> formatDate(subscription.termStartDate),
+      "Date of second payment" -> secondPaymentDate,
+      "Currency" -> account.currency,
       //TODO to remove, hardcoded in the template
-      `Trial period` -> "14",
-      `MandateID` -> paymentMethod.mandateId,
-      `Email` -> personalData.email
+      "Trial period" -> "14",
+      "MandateID" -> paymentMethod.mandateId,
+      "Email" -> personalData.email
     )
   }
 
@@ -73,4 +73,4 @@ trait DataExtensionRow {
   def fields: Seq[(DataExtensionColumn, String)]
 }
 
-case class SubscriptionDataExtensionRow(fields: (DataExtensionColumn, String)*) extends DataExtensionRow
+case class SubscriptionDataExtensionRow(fields: (String, String)*) extends DataExtensionRow

--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -70,7 +70,7 @@ object SubscriptionDataExtensionRow {
 }
 
 trait DataExtensionRow {
-  def fields: Seq[(DataExtensionColumn, String)]
+  def fields: Seq[(String, String)]
 }
 
 case class SubscriptionDataExtensionRow(fields: (String, String)*) extends DataExtensionRow

--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -2,6 +2,7 @@ package model.exactTarget
 
 import com.gu.membership.zuora.soap.Zuora._
 import model.SubscriptionData
+import org.joda.time.DateTime
 
 object SubscriptionDataExtensionRow {
   def apply(
@@ -15,6 +16,9 @@ object SubscriptionDataExtensionRow {
     val billingPeriod = ratePlanCharge.billingPeriod.getOrElse(
       throw new ExactTargetException(s"Error while processing $subscription: Could not create a SubscriptionDataExtensionRow without a billing period")
     )
+
+    // FIXME bogus payment day while we figure out when to get it properly
+    val secondPaymentDate = formatDate(DateTime.now().plusYears(100))
 
     val personalData = subscriptionData.personalData
 
@@ -39,14 +43,29 @@ object SubscriptionDataExtensionRow {
       `Account Name` -> paymentData.holder,
       `Sort Code` -> paymentData.sortCode,
       `Account number` -> paymentData.account,
-      `Date of first payment` -> subscription.termStartDate.toString,
-      `Date of second payment` -> ratePlanCharge.chargedThroughDate.toString,
+      `Date of first payment` -> formatDate(subscription.termStartDate),
+      `Date of second payment` -> secondPaymentDate,
       `Currency` -> account.currency,
       //TODO to remove, hardcoded in the template
       `Trial period` -> "14",
       `MandateID` -> paymentMethod.mandateId,
       `Email` -> personalData.email
     )
+  }
+
+  private def formatDate(dateTime: DateTime) = {
+    val day = dateTime.dayOfMonth.getAsString
+    val daySuffix = day.last match {
+      case '1' => "st"
+      case '2' => "nd"
+      case '3' => "rd"
+      case _   => "th"
+    }
+    val month = dateTime.monthOfYear.getAsText
+
+    val year = dateTime.year.getAsString
+
+    s"$day$daySuffix $month $year"
   }
 }
 

--- a/app/model/exactTarget/package.scala
+++ b/app/model/exactTarget/package.scala
@@ -1,29 +1,5 @@
 package model
 
 package object exactTarget {
-  trait DataExtensionColumn
-
-  case object `SubscriberKey` extends DataExtensionColumn
-  case object `EmailAddress` extends DataExtensionColumn
-  case object `Subscription term` extends DataExtensionColumn
-  case object `Payment amount` extends DataExtensionColumn
-  case object `Default payment method` extends DataExtensionColumn
-  case object `First Name` extends DataExtensionColumn
-  case object `Last Name` extends DataExtensionColumn
-  case object `Address 1` extends DataExtensionColumn
-  case object `Address 2` extends DataExtensionColumn
-  case object `City` extends DataExtensionColumn
-  case object `Post Code` extends DataExtensionColumn
-  case object `Country` extends DataExtensionColumn
-  case object `Account Name` extends DataExtensionColumn
-  case object `Sort Code` extends DataExtensionColumn
-  case object `Account number` extends DataExtensionColumn
-  case object `Date of first payment` extends DataExtensionColumn
-  case object `Date of second payment` extends DataExtensionColumn
-  case object `Currency` extends DataExtensionColumn
-  case object `Trial period` extends DataExtensionColumn
-  case object `MandateID` extends DataExtensionColumn
-  case object `Email` extends DataExtensionColumn
-
   case class ExactTargetException(message: String) extends Throwable(message)
 }

--- a/app/model/exactTarget/package.scala
+++ b/app/model/exactTarget/package.scala
@@ -1,0 +1,29 @@
+package model
+
+package object exactTarget {
+  trait DataExtensionColumn
+
+  case object `SubscriberKey` extends DataExtensionColumn
+  case object `EmailAddress` extends DataExtensionColumn
+  case object `Subscription term` extends DataExtensionColumn
+  case object `Payment amount` extends DataExtensionColumn
+  case object `Default payment method` extends DataExtensionColumn
+  case object `First Name` extends DataExtensionColumn
+  case object `Last Name` extends DataExtensionColumn
+  case object `Address 1` extends DataExtensionColumn
+  case object `Address 2` extends DataExtensionColumn
+  case object `City` extends DataExtensionColumn
+  case object `Post Code` extends DataExtensionColumn
+  case object `Country` extends DataExtensionColumn
+  case object `Account Name` extends DataExtensionColumn
+  case object `Sort Code` extends DataExtensionColumn
+  case object `Account number` extends DataExtensionColumn
+  case object `Date of first payment` extends DataExtensionColumn
+  case object `Date of second payment` extends DataExtensionColumn
+  case object `Currency` extends DataExtensionColumn
+  case object `Trial period` extends DataExtensionColumn
+  case object `MandateID` extends DataExtensionColumn
+  case object `Email` extends DataExtensionColumn
+
+  case class ExactTargetException(message: String) extends Throwable(message)
+}

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -1,0 +1,60 @@
+package services
+
+import com.exacttarget.fuelsdk.{ETClient, ETDataExtensionRow, ETResult}
+import com.gu.membership.zuora.soap.Zuora.SubscribeResult
+import com.typesafe.scalalogging.LazyLogging
+import configuration.Config
+import model.SubscriptionData
+import model.exactTarget.{DataExtensionRow, SubscriptionDataExtensionRow}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+trait ExactTargetService extends LazyLogging {
+  def etClient: ETClient
+  def thankYouDataExtensionKey: String
+
+  def makeETRow(row: DataExtensionRow) = {
+    val etRow = new ETDataExtensionRow
+    row.fields.foreach { case (k, v) =>
+      etRow.setColumn(k.toString, v)
+    }
+    etRow.setDataExtensionKey(thankYouDataExtensionKey)
+    etRow
+  }
+
+  def sendETDataExtensionRow(subscribeResult: SubscribeResult, subscriptionData: SubscriptionData, zs: ZuoraService): Future[Unit] = {
+    val subscription = zs.subscriptionByName(subscribeResult.name)
+
+    val  accAndPaymentMethod= for {
+      subs <- subscription
+      acc <- zs.account(subs)
+      pm <- zs.defaultPaymentMethod(acc)
+    } yield (acc, pm)
+
+    for {
+      subs <- subscription
+      rpc <- zs.normalRatePlanCharge(subs)
+      (acc, pm) <- accAndPaymentMethod
+      row = SubscriptionDataExtensionRow(
+        subscription = subs,
+        subscriptionData = subscriptionData,
+        ratePlanCharge = rpc,
+        paymentMethod = pm,
+        account = acc
+      )
+      etRow = makeETRow(row)
+      response <- Future { etClient.create(etRow) }
+    } yield {
+      if (response.getStatus == ETResult.Status.OK)
+        logger.info(s"Successfully sent an email to confirm the subscription: $subscribeResult")
+      else
+        logger.error(s"Failed to confirm the subscription $subscribeResult. Code: ${response.getResponseCode}, message: ${response.getResponseMessage}")
+    }
+  }
+}
+
+object ExactTargetService extends ExactTargetService {
+  lazy val etClient = Config.ExactTarget.etClient
+  lazy val thankYouDataExtensionKey = Config.ExactTarget.thankYouDataExtensionKey
+}

--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -46,7 +46,7 @@ class SalesforceRepo(salesforceConfig: SalesforceConfig) extends MemberRepositor
     override val apiURL =salesforceConfig.apiURL.toString()
     override val stage = salesforceConfig.envName
 
-    val authTask = ScheduledTask("", Authentication("", ""), 0.seconds, 30.minutes)(getAuthentication)
+    lazy val authTask = ScheduledTask("", Authentication("", ""), 0.seconds, 30.minutes)(getAuthentication)
 
     def authentication: Authentication = authTask.get()
   }

--- a/build.sbt
+++ b/build.sbt
@@ -23,12 +23,26 @@ lazy val root = (project in file(".")).enablePlugins(
 
 scalaVersion := "2.11.6"
 
+val cxfV = "2.7.5"
+val cxfUtilsV = "2.7.0"
+val exactTargetDeps = Seq(
+  "com.exacttarget" % "fuelsdk" % "1.0.3" from "https://github.com/salesforcefuel/FuelSDK-Java/releases/download/v1.0.3/fuel-java-1.0.3.jar",
+  "commons-beanutils" % "commons-beanutils" % "1.9.2",
+  "log4j" % "log4j" % "1.2.17",
+  "com.google.code.gson" % "gson" % "2.3.1",
+  "org.apache.cxf" % "cxf-bundle-minimal" % cxfV,
+  "org.apache.cxf" % "cxf-tools-common" % cxfV,
+  "org.apache.cxf" % "cxf-tools-common" % cxfV,
+  "org.apache.cxf.xjc-utils" % "xjc-utils" % cxfUtilsV,
+  "org.apache.cxf.xjc-utils" % "cxf-xjc-runtime" % cxfUtilsV
+)
+
 libraryDependencies ++= Seq(
   cache,
   ws,
   filters,
   PlayImport.specs2,
-  "com.gu" %% "membership-common" % "0.77",
+  "com.gu" %% "membership-common" % "0.79-SNAPSHOT",
   "com.gu" %% "play-googleauth" % "0.3.0",
   "com.gu.identity" %% "identity-play-auth" % "0.5",
   "com.github.nscala-time" %% "nscala-time" % "2.0.0",
@@ -37,7 +51,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "org.seleniumhq.selenium" % "selenium-java" % "2.44.0" % "test",
   "com.gocardless" % "gocardless-pro" % "1.0.0"
-)
+) ++ exactTargetDeps
 
 testOptions in Test ++= Seq(
   Tests.Argument("-oFD") // display full stack errors and execution times in Scalatest output


### PR DESCRIPTION
- [x] Update production configuration with exact target configuration
- [ ] Update membership common once it is merged
- [x] Review the business logic with Renaldo?

Upon subscription, this trigger the creation of an ExactTarget Data Extension row, that should in turn send a confirmation email.

This requires some extra config:

```
exact-target {
  client-id=xxx
  client-secret=xxx
  data-extension-keys {
    thank-you=xxx
  }
}
```

Limitation: The next payment date is not yet calculated, and set to a date set absurdly far in the future.