### PR TITLE
Remove config that does not vary by environment

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -56,7 +56,6 @@ object Config {
     private val stageConfig = config.getConfig("touchpoint.backend.environments").getConfig(stage)
 
     val paymentDelay = stageConfig.getInt("zuora.paymentDelayInDays").days
-    val productsTaskIntervalSeconds = stageConfig.getInt("zuora.productsTaskIntervalSeconds")
   }
 
   val subscriptionsUrl = config.getString("subscriptions.url")

--- a/app/services/ZuoraService.scala
+++ b/app/services/ZuoraService.scala
@@ -41,8 +41,7 @@ class ZuoraApiClient(zuoraApiConfig: ZuoraApiConfig, digitalProductPlan: Digital
   }
 
 
-  val productsTask = ScheduledTask[Seq[SubscriptionProduct]]("Loading rate plans", Nil, 0.seconds,
-    Config.Zuora.productsTaskIntervalSeconds.seconds)(getProducts())
+  val productsTask = ScheduledTask[Seq[SubscriptionProduct]]("Loading rate plans", Nil, 0.seconds, 2.hours)(getProducts())
 
   def products = productsTask.get()
 

--- a/conf/touchpoint.DEV.conf
+++ b/conf/touchpoint.DEV.conf
@@ -15,7 +15,6 @@ touchpoint.backend.environments {
     }
     zuora {
       paymentDelayInDays = 1
-      productsTaskIntervalSeconds = 86400
       api {
         url = "https://apisandbox.zuora.com/apps/services/a/58.0"
         username = ""

--- a/conf/touchpoint.PROD.conf
+++ b/conf/touchpoint.PROD.conf
@@ -15,7 +15,6 @@ touchpoint.backend.environments {
     }
     zuora {
       paymentDelayInDays = 16
-      productsTaskIntervalSeconds = 86400
       api {
         url = "https://apisandbox.zuora.com/apps/services/a/58.0"
         username = ""


### PR DESCRIPTION
Because we can deploy as easily as we can change config, there's no point in putting values that don't vary by environment into config files - best to just hard-code an inline constant.

cc @afiore 