### PR TITLE
Switch PROD to use the `UAT` configuration stanzas

### DIFF
--- a/conf/PROD.conf
+++ b/conf/PROD.conf
@@ -1,4 +1,5 @@
 include "touchpoint.PROD.conf"
+include "touchpoint.UAT.conf"
 include "application"
 
 stage="PROD"
@@ -11,4 +12,4 @@ identity {
 
 subscriptions.url="https://subscribe.theguardian.com"
 
-touchpoint.backend.default=PROD
+touchpoint.backend.default=UAT

--- a/conf/touchpoint.DEV.conf
+++ b/conf/touchpoint.DEV.conf
@@ -1,26 +1,26 @@
 # ***NO PRIVATE CREDENTIALS IN THIS FILE *** - use subscriptions-frontend in S3 for private data
 touchpoint.backend.environments {
-  DEV {
-    salesforce {
-      consumer {
-        key = ""
-        secret = ""
-      }
-      api {
-        url="https://test.salesforce.com"
-        username=""
-        password=""
-        token=""
-      }
+    DEV {
+        salesforce {
+            consumer {
+                key = ""
+                secret = ""
+            }
+            api {
+                url = "https://test.salesforce.com"
+                username = ""
+                password = ""
+                token = ""
+            }
+        }
+        zuora {
+            paymentDelayInDays = 1
+            api {
+                url = "https://apisandbox.zuora.com/apps/services/a/58.0"
+                username = ""
+                password = ""
+            }
+            digital = "2c92c0f84b786da2014b91d3629b4298"
+        }
     }
-    zuora {
-      paymentDelayInDays = 1
-      api {
-        url = "https://apisandbox.zuora.com/apps/services/a/58.0"
-        username = ""
-        password = ""
-      }
-      digital = "2c92c0f84b786da2014b91d3629b4298"
-    }
-  }
 }

--- a/conf/touchpoint.UAT.conf
+++ b/conf/touchpoint.UAT.conf
@@ -7,7 +7,7 @@ touchpoint.backend.environments {
                 secret = ""
             }
             api {
-                url = "https://emea.salesforce.com"
+                url = "https://test.salesforce.com"
                 username = ""
                 password = ""
                 token = ""
@@ -16,11 +16,11 @@ touchpoint.backend.environments {
         zuora {
             paymentDelayInDays = 16
             api {
-                url = "https://api.zuora.com/apps/services/a/58.0"
+                url = "https://apisandbox.zuora.com/apps/services/a/58.0"
                 username = ""
                 password = ""
             }
-            digital = "???"
+            digital = "2c92c0f84b786da2014b91b3ef267801"
         }
     }
 }


### PR DESCRIPTION
This is because PROD currently /is/ pointing to Touchpoint UAT, so it's better to be honest - and it allows me to update the PROD config with actual PROD values without breaking the active site.

cc @ostapneko 