### PR TITLE
Move Zuora paymentDelay to be an attribute of the touchpoint backend

### DIFF
--- a/app/services/TouchpointBackend.scala
+++ b/app/services/TouchpointBackend.scala
@@ -11,7 +11,7 @@ object TouchpointBackend {
 
   def apply(touchpointBackendConfig: TouchpointBackendConfig): TouchpointBackend = {
     val salesforceRepo = new SalesforceRepo(touchpointBackendConfig.salesforce)
-    val zuoraService = new ZuoraApiClient(touchpointBackendConfig.zuora, touchpointBackendConfig.digitalProductPlan)
+    val zuoraService = new ZuoraApiClient(touchpointBackendConfig.zuora, touchpointBackendConfig.digitalProductPlan, touchpointBackendConfig.zuoraProperties)
 
     TouchpointBackend(salesforceRepo, zuoraService)
   }

--- a/app/services/ZuoraService.scala
+++ b/app/services/ZuoraService.scala
@@ -11,6 +11,7 @@ import model.SubscriptionData
 import model.zuora.{BillingFrequency, SubscriptionProduct, DigitalProductPlan}
 import org.joda.time.Period
 import services.zuora.Subscribe
+import touchpoint.ZuoraProperties
 import utils.ScheduledTask
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -23,7 +24,7 @@ trait ZuoraService {
   def products: Seq[SubscriptionProduct]
 }
 
-class ZuoraApiClient(zuoraApiConfig: ZuoraApiConfig, digitalProductPlan: DigitalProductPlan) extends ZuoraApi with ZuoraService {
+class ZuoraApiClient(zuoraApiConfig: ZuoraApiConfig, digitalProductPlan: DigitalProductPlan, zuoraProperties: ZuoraProperties) extends ZuoraApi with ZuoraService {
   override implicit def authentication: Authentication = authTask.get()
 
   override val apiConfig = zuoraApiConfig
@@ -97,6 +98,6 @@ class ZuoraApiClient(zuoraApiConfig: ZuoraApiConfig, digitalProductPlan: Digital
   }
 
   override def createSubscription(memberId: MemberId, data: SubscriptionData): Future[SubscribeResult] = {
-    request(Subscribe(memberId, data))
+    request(Subscribe(memberId, data, Some(zuoraProperties.paymentDelayInDays)))
   }
 }

--- a/app/services/zuora/Subscribe.scala
+++ b/app/services/zuora/Subscribe.scala
@@ -5,16 +5,15 @@ import com.gu.membership.zuora.Countries
 import com.gu.membership.zuora.soap.Zuora.SubscribeResult
 import com.gu.membership.zuora.soap.ZuoraAction
 import com.gu.membership.zuora.soap.ZuoraServiceHelpers._
-import configuration.Config
 import model.SubscriptionData
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, Period}
 
 import scala.xml.Elem
 
-case class Subscribe(memberId: MemberId, data: SubscriptionData) extends ZuoraAction[SubscribeResult] {
+case class Subscribe(memberId: MemberId, data: SubscriptionData, paymentDelay: Option[Period]) extends ZuoraAction[SubscribeResult] {
 
   override protected val body: Elem = {
-    lazy val paymentDelay = Some(Config.Zuora.paymentDelay)
+
     val now = DateTime.now
     val effectiveDate = formatDateTime(now)
     val contractAcceptanceDate = paymentDelay.map(delay => formatDateTime(now.plus(delay))).getOrElse(effectiveDate)

--- a/app/touchpoint/TouchpointBackendConfig.scala
+++ b/app/touchpoint/TouchpointBackendConfig.scala
@@ -1,11 +1,13 @@
 package touchpoint
 
+import com.github.nscala_time.time.Imports._
 import com.gu.membership.salesforce.SalesforceConfig
 import com.gu.membership.zuora.ZuoraApiConfig
 import com.typesafe.scalalogging.LazyLogging
 import model.zuora.DigitalProductPlan
+import org.joda.time.Period
 
-case class TouchpointBackendConfig(salesforce: SalesforceConfig, zuora: ZuoraApiConfig, digitalProductPlan: DigitalProductPlan)
+case class TouchpointBackendConfig(salesforce: SalesforceConfig, zuora: ZuoraApiConfig, zuoraProperties: ZuoraProperties, digitalProductPlan: DigitalProductPlan)
 
 object TouchpointBackendConfig extends LazyLogging {
 
@@ -36,7 +38,19 @@ object TouchpointBackendConfig extends LazyLogging {
     TouchpointBackendConfig(
       SalesforceConfig.from(envBackendConf, environmentName),
       ZuoraApiConfig.from(envBackendConf, environmentName),
+      ZuoraProperties.from(envBackendConf, environmentName),
       DigitalProductPlan(envBackendConf.getString("zuora.digital"))
     )
   }
 }
+
+object ZuoraProperties {
+  def from(config: com.typesafe.config.Config, environmentName: String) = {
+    ZuoraProperties(
+      config.getInt("zuora.paymentDelayInDays").days
+    )
+  }
+}
+case class ZuoraProperties(
+  paymentDelayInDays: Period
+)


### PR DESCRIPTION
What we're trying to capture here is that test users should get a shorter paymentDelay than regular users.

This is just a chunk of the test-users branch that I thought I could split out, to make the test-users branch a bit smaller.

cc @afiore 