### PR TITLE
IE cross-browser fixes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -146,7 +146,7 @@ module.exports = function(grunt) {
                     baseUrl: '<%= dirs.assets.javascripts %>',
                     paths: {
                         '$': 'utils/$',
-                        'Promise': 'bower_components/native-promise-only/lib/npo.src',
+                        'Promise': 'bower_components/promise-polyfill/Promise',
                         'bean': 'bower_components/bean/bean',
                         'bonzo': 'bower_components/bonzo/bonzo',
                         'lodash': 'bower_components/lodash-amd/modern',

--- a/assets/javascripts/bower.json
+++ b/assets/javascripts/bower.json
@@ -1,14 +1,14 @@
 {
-    "name": "Subscriptions JavaScripts",
-    "dependencies": {
-        "bean": "~1.0.6",
-        "bonzo": "~2.0.0",
-        "lodash-amd": "~3.10.0",
-        "native-promise-only": "guardian/native-promise-only#master",
-        "qwery": "~4.0.0",
-        "raven-js": "~1.1.16",
-        "requirejs": "~2.1.17",
-        "reqwest": "~1.1.0",
-        "zxcvbn": "90b7d2908d1305e0ab9f0fe0d983041e546af760"
-    }
+  "name": "Subscriptions JavaScript",
+  "dependencies": {
+    "bean": "~1.0.6",
+    "bonzo": "~2.0.0",
+    "lodash-amd": "~3.10.0",
+    "promise-polyfill": "~2.1.0",
+    "qwery": "~4.0.0",
+    "raven-js": "~1.1.16",
+    "requirejs": "~2.1.17",
+    "reqwest": "~1.1.0",
+    "zxcvbn": "90b7d2908d1305e0ab9f0fe0d983041e546af760"
+  }
 }

--- a/assets/javascripts/main.js
+++ b/assets/javascripts/main.js
@@ -9,6 +9,7 @@ require([
     'modules/confirmation',
     'modules/patterns',
     // Add new dependencies ABOVE this
+    'Promise',
     'raven'
 ], function(
     ajax,


### PR DESCRIPTION
Some cross-browser fixes to better support IE on checkout pages.

- Uses an alternate `Promise` polyfill; and actually loads it…
I'm not a huge fan of using an internal guardian fork that isn't even used on frontend anymore. Also we actually never loaded the polyfill. The fact we missed this for so long shows how good native `Promise` support is now…maybe.

- ~~Fixes some dodgy form markup. Double `<form>`!!
I can only assume this was a merge conflict gone awry. IE 10 has handy markup validation reporting in the console which is how I spotted it. Otherwise it seems most browsers just don't care. Resilience!~~ Moved to https://github.com/guardian/subscriptions-frontend/pull/161

None of this is even slightly embarrassing; nope.

@TesterSpike @rtyley 