### PR TITLE
Add length limitation to name and address fields

### DIFF
--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -22,11 +22,14 @@ object SubscriptionsForm {
   }
   private val booleanCheckbox: Mapping[Boolean] = of[Boolean] as booleanCheckboxFormatter
 
+  private val nameMaxLength = 50
+  private val addressMaxLength = 255
+
   val addressDataMapping = mapping(
-    "address1" -> text,
-    "address2" -> text,
-    "town" -> text,
-    "postcode" -> text
+    "address1" -> text(0, addressMaxLength),
+    "address2" -> text(0, addressMaxLength),
+    "town" -> text(0, addressMaxLength),
+    "postcode" -> text(0, addressMaxLength)
   )(AddressData.apply)(AddressData.unapply)
 
   val emailMapping = tuple(
@@ -39,8 +42,8 @@ object SubscriptionsForm {
     )
 
   val personalDataMapping = mapping(
-    "first" -> text,
-    "last" -> text,
+    "first" -> text(0, nameMaxLength),
+    "last" -> text(0, nameMaxLength),
     "emailValidation" -> emailMapping,
     "receiveGnmMarketing" -> booleanCheckbox,
     "address" -> addressDataMapping

--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -24,6 +24,7 @@ object SubscriptionsForm {
 
   private val nameMaxLength = 50
   private val addressMaxLength = 255
+  private val emailMaxLength = 240
 
   val addressDataMapping = mapping(
     "address1" -> text(0, addressMaxLength),
@@ -33,7 +34,7 @@ object SubscriptionsForm {
   )(AddressData.apply)(AddressData.unapply)
 
   val emailMapping = tuple(
-    "email" -> email,
+    "email" -> email.verifying("This email is too long", _.length < emailMaxLength + 1),
     "confirm" -> email)
     .verifying("Emails don't match", email => email._1 == email._2)
     .transform[String](

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -58,12 +58,12 @@
                         <div class="form-field js-checkout-first">
                             <label class="label" for="first">First name</label>
                             <input type="text" class="input-text js-input" name="personal.first" id="first" value="@form.data.get("personal.first")">
-                            @fragments.forms.errorMessage("This field is required")
+                            @fragments.forms.errorMessage("")
                         </div>
                         <div class="form-field js-checkout-last">
                             <label class="label" for="last">Last name</label>
                             <input type="text" class="input-text js-input" name="personal.last" id="last" value="@form.data.get("personal.last")">
-                            @fragments.forms.errorMessage("This field is required")
+                            @fragments.forms.errorMessage("")
                         </div>
                         <div class="form-field js-checkout-email">
                             <label class="label" for="email">Email address</label>
@@ -83,23 +83,23 @@
                             <div class="form-field js-checkout-house">
                                 <label class="label" for="address-line-1">Address line 1</label>
                                 <input type="text" class="input-text js-input" id="address-line-1" name="personal.address.address1" value="@form.data.get("personal.address.address1")">
-                                @fragments.forms.errorMessage("This field is required")
+                                @fragments.forms.errorMessage("")
                             </div>
                             <div class="form-field js-checkout-street">
                                 <label class="label optional-marker" for="address-line-2">Address line 2</label>
                                 <input type="text" class="input-text js-input" id="address-line-2" name="personal.address.address2" value="@form.data.get("personal.address.address2")">
-                                @fragments.forms.errorMessage("This field is required")
+                                @fragments.forms.errorMessage("")
                             </div>
                             <div class="form-field js-checkout-town">
                                 <label class="label" for="address-town">Town/City</label>
                                 <input type="text" class="input-text js-input" id="address-town" name="personal.address.town" value="@form.data.get("personal.address.town")">
-                                @fragments.forms.errorMessage("This field is required")
+                                @fragments.forms.errorMessage("")
                             </div>
                         </div>
                         <div class="form-field js-checkout-postcode">
                             <label class="label" for="address-postcode">Postcode</label>
                             <input type="text" class="input-text js-input input-text input-text--small" id="address-postcode" name="personal.address.postcode" value="@form.data.get("personal.address.postcode")">
-                            @fragments.forms.errorMessage("Please enter a valid postal code")
+                            @fragments.forms.errorMessage("")
                         </div>
 
                         <div class="actions">

--- a/assets/javascripts/modules/checkout/personalDetails.js
+++ b/assets/javascripts/modules/checkout/personalDetails.js
@@ -16,6 +16,7 @@ define([
     var FIELDSET_COMPLETE_ATTR = 'data-fieldset-complete';
 
     var MAX_NAME_LENGTH = 50;
+    var MAX_EMAIL_LENGTH = 240;
     var MAX_ADDRESS_LENGTH = 255;
 
     var ERROR_MESSAGES = {
@@ -35,6 +36,7 @@ define([
 
     var firstNameField = new TextField(formEls.$FIRST_NAME_CONTAINER, MAX_NAME_LENGTH);
     var lastNameField = new TextField(formEls.$LAST_NAME_CONTAINER, MAX_NAME_LENGTH);
+    var emailField = new TextField(formEls.$EMAIL_CONTAINER, MAX_EMAIL_LENGTH);
     var address1Field = new TextField(formEls.$ADDRESS1_CONTAINER, MAX_ADDRESS_LENGTH);
     var address2Field = new TextField(formEls.$ADDRESS2_CONTAINER, MAX_ADDRESS_LENGTH);
     var address3Field = new TextField(formEls.$ADDRESS3_CONTAINER, MAX_ADDRESS_LENGTH);
@@ -51,6 +53,7 @@ define([
     var lengthCheckedFields = [
         firstNameField,
         lastNameField,
+        emailField,
         address1Field,
         address2Field,
         address3Field,
@@ -73,10 +76,6 @@ define([
             }
         });
 
-        validity.fieldsTooLong.forEach(function(field) {
-            addError(field, ERROR_MESSAGES.FIELD_TOO_LONG);
-        });
-
         toggleError(formEls.$EMAIL_CONTAINER, !validity.hasValidEmail);
         toggleError(formEls.$CONFIRM_EMAIL_CONTAINER, validity.hasValidEmail && !validity.hasConfirmedEmail);
         toggleError(formEls.$EMAIL_CONTAINER, validity.isEmailInUse);
@@ -85,6 +84,10 @@ define([
             formEls.$EMAIL_ERROR.text(validity.emailMessage);
             toggleError(formEls.$EMAIL_CONTAINER, true);
         }
+
+        validity.fieldsTooLong.forEach(function(field) {
+            addError(field, ERROR_MESSAGES.FIELD_TOO_LONG);
+        });
     }
 
     function nextStep() {

--- a/assets/javascripts/modules/checkout/personalDetails.js
+++ b/assets/javascripts/modules/checkout/personalDetails.js
@@ -1,11 +1,13 @@
 define([
     'modules/forms/toggleError',
     'modules/checkout/formElements',
-    'modules/checkout/validatePersonal'
+    'modules/checkout/validatePersonal',
+    '$'
 ], function (
     toggleError,
     formEls,
-    validatePersonal
+    validatePersonal,
+    $
 ) {
     'use strict';
 
@@ -13,25 +15,66 @@ define([
     var FIELDSET_COMPLETE = 'fieldset--complete';
     var FIELDSET_COMPLETE_ATTR = 'data-fieldset-complete';
 
+    var MAX_NAME_LENGTH = 50;
+    var MAX_ADDRESS_LENGTH = 255;
+
+    var ERROR_MESSAGES = {
+        FIELD_TOO_LONG: 'This field is too long',
+        REQUIRED_FIELD: 'This field is required',
+        INVALID_POSTCODE: 'Please enter a valid postal code'
+    };
+
+    function TextField(containerEl, maxLength) {
+        return {
+            el: containerEl,
+            maxLength: maxLength,
+            input: $('.js-input', containerEl)[0],
+            error: $('.js-error-message', containerEl)[0]
+        };
+    }
+
+    var firstNameField = new TextField(formEls.$FIRST_NAME_CONTAINER, MAX_NAME_LENGTH);
+    var lastNameField = new TextField(formEls.$LAST_NAME_CONTAINER, MAX_NAME_LENGTH);
+    var address1Field = new TextField(formEls.$ADDRESS1_CONTAINER, MAX_ADDRESS_LENGTH);
+    var address2Field = new TextField(formEls.$ADDRESS2_CONTAINER, MAX_ADDRESS_LENGTH);
+    var address3Field = new TextField(formEls.$ADDRESS3_CONTAINER, MAX_ADDRESS_LENGTH);
+    var postcodeField = new TextField(formEls.$POSTCODE_CONTAINER, MAX_ADDRESS_LENGTH);
+
     var requiredFields = [
-        {input: formEls.$FIRST_NAME, container: formEls.$FIRST_NAME_CONTAINER},
-        {input: formEls.$LAST_NAME, container: formEls.$LAST_NAME_CONTAINER},
-        {input: formEls.$ADDRESS1, container: formEls.$ADDRESS1_CONTAINER},
-        {input: formEls.$ADDRESS3, container: formEls.$ADDRESS3_CONTAINER},
-        {input: formEls.$POSTCODE, container: formEls.$POSTCODE_CONTAINER}
+        firstNameField,
+        lastNameField,
+        address1Field,
+        address3Field,
+        postcodeField
     ];
 
-    function requiredFieldVaues(fields) {
-        return fields.map(function(field) {
-            return field.input.val();
-        });
+    var lengthCheckedFields = [
+        firstNameField,
+        lastNameField,
+        address1Field,
+        address2Field,
+        address3Field,
+        postcodeField
+    ];
+
+    function addError(field, message) {
+        if (field === postcodeField) {
+            field.error.textContent = ERROR_MESSAGES.INVALID_POSTCODE;
+        } else {
+            field.error.textContent = message;
+        }
+        toggleError(field.el, true);
     }
 
     function displayErrors(validity) {
-
         requiredFields.forEach(function(field) {
-            var isEmpty = !field.input.val();
-            toggleError(field.container, isEmpty);
+            if (!field.input.value) {
+                addError(field, ERROR_MESSAGES.REQUIRED_FIELD);
+            }
+        });
+
+        validity.fieldsTooLong.forEach(function(field) {
+            addError(field, ERROR_MESSAGES.FIELD_TOO_LONG);
         });
 
         toggleError(formEls.$EMAIL_CONTAINER, !validity.hasValidEmail);
@@ -71,10 +114,12 @@ define([
         if($actionEl.length) {
             actionEl.addEventListener('click', function(e) {
                 e.preventDefault();
+
                 handleValidation({
                     emailAddress: formEls.$EMAIL.val(),
                     emailAddressConfirmed: formEls.$CONFIRM_EMAIL.val(),
-                    requiredFieldValues: requiredFieldVaues(requiredFields)
+                    requiredFields: requiredFields,
+                    lengthCheckedFields: lengthCheckedFields
                 });
             });
         }

--- a/assets/javascripts/modules/checkout/personalDetails.js
+++ b/assets/javascripts/modules/checkout/personalDetails.js
@@ -25,7 +25,7 @@ define([
         INVALID_POSTCODE: 'Please enter a valid postal code'
     };
 
-    function TextField(containerEl, maxLength) {
+    function textField(containerEl, maxLength) {
         return {
             el: containerEl,
             maxLength: maxLength,
@@ -34,28 +34,16 @@ define([
         };
     }
 
-    var firstNameField = new TextField(formEls.$FIRST_NAME_CONTAINER, MAX_NAME_LENGTH);
-    var lastNameField = new TextField(formEls.$LAST_NAME_CONTAINER, MAX_NAME_LENGTH);
-    var emailField = new TextField(formEls.$EMAIL_CONTAINER, MAX_EMAIL_LENGTH);
-    var address1Field = new TextField(formEls.$ADDRESS1_CONTAINER, MAX_ADDRESS_LENGTH);
-    var address2Field = new TextField(formEls.$ADDRESS2_CONTAINER, MAX_ADDRESS_LENGTH);
-    var address3Field = new TextField(formEls.$ADDRESS3_CONTAINER, MAX_ADDRESS_LENGTH);
-    var postcodeField = new TextField(formEls.$POSTCODE_CONTAINER, MAX_ADDRESS_LENGTH);
+    var firstNameField = textField(formEls.$FIRST_NAME_CONTAINER, MAX_NAME_LENGTH);
+    var lastNameField = textField(formEls.$LAST_NAME_CONTAINER, MAX_NAME_LENGTH);
+    var address1Field = textField(formEls.$ADDRESS1_CONTAINER, MAX_ADDRESS_LENGTH);
+    var address3Field = textField(formEls.$ADDRESS3_CONTAINER, MAX_ADDRESS_LENGTH);
+    var postcodeField = textField(formEls.$POSTCODE_CONTAINER, MAX_ADDRESS_LENGTH);
 
     var requiredFields = [
         firstNameField,
         lastNameField,
         address1Field,
-        address3Field,
-        postcodeField
-    ];
-
-    var lengthCheckedFields = [
-        firstNameField,
-        lastNameField,
-        emailField,
-        address1Field,
-        address2Field,
         address3Field,
         postcodeField
     ];
@@ -122,7 +110,15 @@ define([
                     emailAddress: formEls.$EMAIL.val(),
                     emailAddressConfirmed: formEls.$CONFIRM_EMAIL.val(),
                     requiredFields: requiredFields,
-                    lengthCheckedFields: lengthCheckedFields
+                    lengthCheckedFields: [
+                        textField(formEls.$FIRST_NAME_CONTAINER, MAX_NAME_LENGTH),
+                        textField(formEls.$LAST_NAME_CONTAINER, MAX_NAME_LENGTH),
+                        textField(formEls.$EMAIL_CONTAINER, MAX_EMAIL_LENGTH),
+                        textField(formEls.$ADDRESS1_CONTAINER, MAX_ADDRESS_LENGTH),
+                        textField(formEls.$ADDRESS2_CONTAINER, MAX_ADDRESS_LENGTH),
+                        textField(formEls.$ADDRESS3_CONTAINER, MAX_ADDRESS_LENGTH),
+                        textField(formEls.$POSTCODE_CONTAINER, MAX_ADDRESS_LENGTH)
+                    ]
                 });
             });
         }

--- a/assets/javascripts/modules/checkout/validatePersonal.js
+++ b/assets/javascripts/modules/checkout/validatePersonal.js
@@ -27,24 +27,31 @@ define([
             var confirmationEmailValue = data.emailAddressConfirmed;
             var hasConfirmedEmail = emailValue === confirmationEmailValue;
 
-            var emptyFields = data.requiredFieldValues.filter(function (field) {
-                return !field;
+            var emptyFields = data.requiredFields.filter(function (field) {
+                return !field.input.value;
             });
+
+            var fieldsTooLong =
+                data.lengthCheckedFields.filter(function (field) {
+                    return field.input.value.length > field.maxLength;
+                });
 
             var hasBasicValidity = (
                 hasValidEmail &&
                 hasConfirmedEmail &&
-                !emptyFields.length
+                !emptyFields.length &&
+                !fieldsTooLong.length
             );
 
             var validity = {
                 allValid: false,
                 emptyFields: emptyFields,
-                requiredFieldValues: data.requiredFieldValues,
+                requiredFields: data.requiredFields,
                 hasValidEmail: hasValidEmail,
                 hasConfirmedEmail: hasConfirmedEmail,
                 emailMessage: (hasValidEmail) ? false : MESSAGES.emailInvalid,
-                isEmailInUse: false
+                isEmailInUse: false,
+                fieldsTooLong: fieldsTooLong
             };
 
             if(hasBasicValidity) {

--- a/test/forms/SubscriptionsFormSpec.scala
+++ b/test/forms/SubscriptionsFormSpec.scala
@@ -51,14 +51,27 @@ class SubscriptionsFormSpec extends FreeSpec {
     Seq("first", "last").foreach { key =>
       val l = 51
       val data = personalDataMapping.bind(formData + (key -> "a" * l))
-      assert(data.isLeft, s"Personal data's $key should have a max size of ${l - 1}")
+      s"checks the size of the $key field" in {
+        assert(data.isLeft, s"Personal data's $key should have a max size of ${l - 1}")
+      }
     }
 
     Seq("address1", "address2", "town", "postcode").foreach { key =>
       val l = 256
       val data = addressDataMapping.bind(formData + (key -> "a" * l))
-      assert(data.isLeft, s"Personal data's $key should have a max size of ${l - 1}")
+      s"checks the size of the $key field" in {
+        assert(data.isLeft, s"Personal data's $key should have a max size of ${l - 1}")
+      }
     }
 
+    "checks the size of the email field" in {
+      val l = 229 // remove the domain length from 241
+      val email = ("a" * l) + "@example.com"
+      val data = addressDataMapping.bind(
+        formData + ("emailValidation.email" -> email) + ("emailValidation.confirm" -> email)
+      )
+
+      assert(data.isLeft, s"Email should have a max size of 240")
+    }
   }
 }

--- a/test/forms/SubscriptionsFormSpec.scala
+++ b/test/forms/SubscriptionsFormSpec.scala
@@ -1,6 +1,6 @@
 package forms
 
-import forms.SubscriptionsForm.personalDataMapping
+import forms.SubscriptionsForm.{personalDataMapping, addressDataMapping}
 import model.{AddressData, PersonalData}
 import org.scalatest.FreeSpec
 
@@ -46,6 +46,18 @@ class SubscriptionsFormSpec extends FreeSpec {
     "validates email confirmation" in {
       val data = personalDataMapping.bind(formData + ("emailValidation.confirm" -> "other@example.com"))
       assert(data.isLeft)
+    }
+
+    Seq("first", "last").foreach { key =>
+      val l = 51
+      val data = personalDataMapping.bind(formData + (key -> "a" * l))
+      assert(data.isLeft, s"Personal data's $key should have a max size of ${l - 1}")
+    }
+
+    Seq("address1", "address2", "town", "postcode").foreach { key =>
+      val l = 256
+      val data = addressDataMapping.bind(formData + (key -> "a" * l))
+      assert(data.isLeft, s"Personal data's $key should have a max size of ${l - 1}")
     }
 
   }


### PR DESCRIPTION
Re-opened version https://github.com/guardian/subscriptions-frontend/pull/151 with temporary fix for length validations not being live updated.

As a general comment, I regret not pushing harder for a simpler approach to form validation. I've added a card to the backlog to use an approach more similar to Membership. There are solid HTML5 validation attributes we can use an enhance on top of, rather than re-implementing things. Not to diminish @ostapneko's work which was completely appropriate in the context.