### PR TITLE
Add length limitation to name and address fields

### DIFF
--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -22,11 +22,14 @@ object SubscriptionsForm {
   }
   private val booleanCheckbox: Mapping[Boolean] = of[Boolean] as booleanCheckboxFormatter
 
+  private val nameMaxLength = 50
+  private val addressMaxLength = 255
+
   val addressDataMapping = mapping(
-    "address1" -> text,
-    "address2" -> text,
-    "town" -> text,
-    "postcode" -> text
+    "address1" -> text(0, addressMaxLength),
+    "address2" -> text(0, addressMaxLength),
+    "town" -> text(0, addressMaxLength),
+    "postcode" -> text(0, addressMaxLength)
   )(AddressData.apply)(AddressData.unapply)
 
   val emailMapping = tuple(
@@ -39,8 +42,8 @@ object SubscriptionsForm {
     )
 
   val personalDataMapping = mapping(
-    "first" -> text,
-    "last" -> text,
+    "first" -> text(0, nameMaxLength),
+    "last" -> text(0, nameMaxLength),
     "emailValidation" -> emailMapping,
     "receiveGnmMarketing" -> booleanCheckbox,
     "address" -> addressDataMapping

--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -24,6 +24,7 @@ object SubscriptionsForm {
 
   private val nameMaxLength = 50
   private val addressMaxLength = 255
+  private val emailMaxLength = 240
 
   val addressDataMapping = mapping(
     "address1" -> text(0, addressMaxLength),
@@ -33,7 +34,7 @@ object SubscriptionsForm {
   )(AddressData.apply)(AddressData.unapply)
 
   val emailMapping = tuple(
-    "email" -> email,
+    "email" -> email.verifying("This email is too long", _.length < emailMaxLength + 1),
     "confirm" -> email)
     .verifying("Emails don't match", email => email._1 == email._2)
     .transform[String](

--- a/test/forms/SubscriptionsFormSpec.scala
+++ b/test/forms/SubscriptionsFormSpec.scala
@@ -51,13 +51,27 @@ class SubscriptionsFormSpec extends FreeSpec {
     Seq("first", "last").foreach { key =>
       val l = 51
       val data = personalDataMapping.bind(formData + (key -> "a" * l))
-      assert(data.isLeft, s"Personal data's $key should have a max size of ${l - 1}")
+      s"checks the size of the $key field" in {
+        assert(data.isLeft, s"Personal data's $key should have a max size of ${l - 1}")
+      }
     }
 
     Seq("address1", "address2", "town", "postcode").foreach { key =>
       val l = 256
       val data = addressDataMapping.bind(formData + (key -> "a" * l))
-      assert(data.isLeft, s"Personal data's $key should have a max size of ${l - 1}")
+      s"checks the size of the $key field" in {
+        assert(data.isLeft, s"Personal data's $key should have a max size of ${l - 1}")
+      }
+    }
+
+    "checks the size of the email field" in {
+      val l = 229 // remove the domain length from 241
+      val email = ("a" * l) + "@example.com"
+      val data = addressDataMapping.bind(
+        formData + ("emailValidation.email" -> email) + ("emailValidation.confirm" -> email)
+      )
+
+      assert(data.isLeft, s"Email should have a max size of 240")
     }
 
   }

--- a/test/forms/SubscriptionsFormSpec.scala
+++ b/test/forms/SubscriptionsFormSpec.scala
@@ -1,6 +1,6 @@
 package forms
 
-import forms.SubscriptionsForm.personalDataMapping
+import forms.SubscriptionsForm.{personalDataMapping, addressDataMapping}
 import model.{AddressData, PersonalData}
 import org.scalatest.FreeSpec
 
@@ -46,6 +46,18 @@ class SubscriptionsFormSpec extends FreeSpec {
     "validates email confirmation" in {
       val data = personalDataMapping.bind(formData + ("emailValidation.confirm" -> "other@example.com"))
       assert(data.isLeft)
+    }
+
+    Seq("first", "last").foreach { key =>
+      val l = 51
+      val data = personalDataMapping.bind(formData + (key -> "a" * l))
+      assert(data.isLeft, s"Personal data's $key should have a max size of ${l - 1}")
+    }
+
+    Seq("address1", "address2", "town", "postcode").foreach { key =>
+      val l = 256
+      val data = addressDataMapping.bind(formData + (key -> "a" * l))
+      assert(data.isLeft, s"Personal data's $key should have a max size of ${l - 1}")
     }
 
   }


### PR DESCRIPTION
This is a version of https://github.com/guardian/subscriptions-frontend/pull/162 with the JS validation removed, only including the basic server validation from @ostapneko .

@TesterSpike 