### PR TITLE
Display a test-user banner if the user is using the site as a test-user

### DIFF
--- a/app/controllers/Testing.scala
+++ b/app/controllers/Testing.scala
@@ -7,7 +7,7 @@ import utils.TestUsers.testUsers
 
 object Testing extends Controller with LazyLogging {
 
-  val UnauthenticatedTestUserCookieName = "subscriptions-test-user-name"
+  val PreSigninTestCookieName = "pre-signin-test-user"
 
   def testUser = GoogleAuthenticatedStaffAction { implicit request =>
 
@@ -15,7 +15,7 @@ object Testing extends Controller with LazyLogging {
 
     logger.info(s"Generated test user string $testUserString")
 
-    val testUserCookie = new Cookie(UnauthenticatedTestUserCookieName, testUserString, Some(30 * 60), httpOnly = true)
+    val testUserCookie = new Cookie(PreSigninTestCookieName, testUserString, Some(30 * 60), httpOnly = true)
     Ok(views.html.testing.testUsers(testUserString)).withCookies(testUserCookie)
   }
 }

--- a/app/services/TouchpointBackend.scala
+++ b/app/services/TouchpointBackend.scala
@@ -3,32 +3,49 @@ package services
 import configuration.Config
 import play.api.mvc.RequestHeader
 import touchpoint.TouchpointBackendConfig
+import touchpoint.TouchpointBackendConfig.BackendType
 import utils.TestUsers._
 
 object TouchpointBackend {
-  import TouchpointBackendConfig.BackendType
 
-  def apply(backendType: TouchpointBackendConfig.BackendType): TouchpointBackend =
-    TouchpointBackend(TouchpointBackendConfig.backendType(backendType, Config.config))
-
-  def apply(touchpointBackendConfig: TouchpointBackendConfig): TouchpointBackend = {
-    val salesforceRepo = new SalesforceRepo(touchpointBackendConfig.salesforce)
-    val salesforceService = new SalesforceServiceImp(salesforceRepo)
+  def apply(backendType: TouchpointBackendConfig.BackendType): TouchpointBackend = {
+    val touchpointBackendConfig = TouchpointBackendConfig.backendType(backendType, Config.config)
+    val salesforceService = new SalesforceServiceImp(new SalesforceRepo(touchpointBackendConfig.salesforce))
     val zuoraService = new ZuoraApiClient(touchpointBackendConfig.zuora, touchpointBackendConfig.digitalProductPlan, touchpointBackendConfig.zuoraProperties)
 
-    TouchpointBackend(salesforceService, zuoraService)
+    TouchpointBackend(
+      touchpointBackendConfig.environmentName,
+      salesforceService,
+      zuoraService
+    )
   }
 
-  val Normal = TouchpointBackend(BackendType.Default)
-  val TestUser = TouchpointBackend(BackendType.Testing)
+  val BackendsByType = BackendType.All.map(typ => typ -> TouchpointBackend(typ)).toMap
 
-  val All = Seq(Normal, TestUser)
+  val Normal = BackendsByType(BackendType.Default)
 
-  def forRequest(alternateSource: => Option[String] = None)(implicit request: RequestHeader) =
-    if (isTestUser(alternateSource)) TestUser else Normal
+  val All = BackendsByType.values.toSeq
+
+  case class Resolution(
+    backend: TouchpointBackend,
+    typ: TouchpointBackendConfig.BackendType,
+    validTestUserCredentialOpt: Option[TestUserCredentialType[_]]
+  )
+
+  /**
+   * Alternate credentials are used *only* when the user is not signed in - if you're logged in as
+   * a 'normal' non-test user, it doesn't make any difference what pre-signin-test-cookie you have.
+   */
+  def forRequest[C](permittedAltCredentialType: TestUserCredentialType[C], altCredentialSource: C)(
+    implicit request: RequestHeader): Resolution = {
+    val validTestUserCredentialOpt = isTestUser(permittedAltCredentialType, altCredentialSource)
+    val backendType = if (validTestUserCredentialOpt.isDefined) BackendType.Testing else BackendType.Default
+    Resolution(BackendsByType(backendType), backendType, validTestUserCredentialOpt)
+  }
 }
 
 case class TouchpointBackend(
+  environmentName: String,
   salesforceService: SalesforceService,
   zuoraService : ZuoraService
 ) {

--- a/app/touchpoint/TouchpointBackendConfig.scala
+++ b/app/touchpoint/TouchpointBackendConfig.scala
@@ -7,7 +7,13 @@ import com.typesafe.scalalogging.LazyLogging
 import model.zuora.DigitalProductPlan
 import org.joda.time.Period
 
-case class TouchpointBackendConfig(salesforce: SalesforceConfig, zuora: ZuoraApiConfig, zuoraProperties: ZuoraProperties, digitalProductPlan: DigitalProductPlan)
+case class TouchpointBackendConfig(
+  environmentName: String,
+  salesforce: SalesforceConfig,
+  zuora: ZuoraApiConfig,
+  zuoraProperties: ZuoraProperties,
+  digitalProductPlan: DigitalProductPlan
+)
 
 object TouchpointBackendConfig extends LazyLogging {
 
@@ -19,6 +25,7 @@ object TouchpointBackendConfig extends LazyLogging {
 
     object Testing extends BackendType("test")
 
+    val All = Seq(Default, Testing)
   }
 
   def backendType(typ: BackendType = BackendType.Default, config: com.typesafe.config.Config) = {
@@ -36,6 +43,7 @@ object TouchpointBackendConfig extends LazyLogging {
     val envBackendConf = backendsConfig.getConfig(s"environments.$environmentName")
 
     TouchpointBackendConfig(
+      environmentName,
       SalesforceConfig.from(envBackendConf, environmentName),
       ZuoraApiConfig.from(envBackendConf, environmentName),
       ZuoraProperties.from(envBackendConf, environmentName),

--- a/app/utils/TestUsers.scala
+++ b/app/utils/TestUsers.scala
@@ -1,9 +1,12 @@
 package utils
 
 import com.github.nscala_time.time.Imports._
+import com.gu.identity.play.{IdMinimalUser, AuthenticatedIdUser}
 import com.gu.identity.testing.usernames.TestUsernames
 import configuration.Config
-import play.api.mvc.RequestHeader
+import controllers.Testing
+import model.SubscriptionData
+import play.api.mvc.{Cookies, RequestHeader}
 import services.AuthenticationService.authenticatedUserFor
 
 object TestUsers {
@@ -17,6 +20,29 @@ object TestUsers {
 
   private def isTestUser(username: String): Boolean = TestUsers.testUsers.isValid(username)
 
-  def isTestUser(alternateSource: => Option[String] = None)(implicit request: RequestHeader): Boolean =
-    authenticatedUserFor(request).fold(alternateSource)(_.user.displayName.flatMap(_.split(' ').headOption)).exists(isTestUser)
+  sealed trait TestUserCredentialType[C] {
+    def token(credential: C): Option[String]
+    def passes(credential: C): Option[this.type] = token(credential).filter(isTestUser).map(_ => this)
+  }
+
+  object PreSigninTestCookie extends TestUserCredentialType[Cookies] {
+    def token(cookies: Cookies) = cookies.get(Testing.PreSigninTestCookieName).map(_.value)
+  }
+
+  object NameEnteredInForm extends TestUserCredentialType[SubscriptionData] {
+    def token(formData: SubscriptionData) = Some(formData.personalData.firstName)
+  }
+
+  object SignedInUsername extends TestUserCredentialType[IdMinimalUser] {
+    def token(idUser: IdMinimalUser) = idUser.displayName.flatMap(_.split(' ').headOption)
+  }
+
+
+  def isTestUser[C](permittedAltCredentialType: TestUserCredentialType[C], altCredentialSource: C)(implicit request: RequestHeader)
+    : Option[TestUserCredentialType[_]] = {
+
+    authenticatedUserFor(request).map(_.user).fold[Option[TestUserCredentialType[_]]] {
+      permittedAltCredentialType.passes(altCredentialSource)
+    }(SignedInUsername.passes)
+  }
 }

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -1,4 +1,4 @@
-@(form: Form[model.SubscriptionData], userIsSignedIn: Boolean, subscriptionProducts: Seq[model.zuora.SubscriptionProduct])(implicit request: RequestHeader)
+@(form: Form[model.SubscriptionData], userIsSignedIn: Boolean, touchpointBackendResolution: services.TouchpointBackend.Resolution)(implicit request: RequestHeader)
 
 @import model.JsVars
 @import routes.Checkout.renderCheckout
@@ -9,9 +9,9 @@
 @main(
     title = "Checkout | Subscriptions | The Guardian",
     jsVars = JsVars.default.copy(userIsSignedIn = userIsSignedIn),
-    bodyClasses = List("is-wide")
+    bodyClasses = List("is-wide"),
+    touchpointBackendResolutionOpt = Some(touchpointBackendResolution)
 ) {
-
 <main class="page-container gs-container">
 
     <form class="form js-checkout-form" action="" method="POST">
@@ -21,7 +21,7 @@
             @fragments.checkout.checkoutHeader("Checkout")
 
             <div class="checkout-container__sidebar">
-                @fragments.checkout.basketPreview(Some(subscriptionProducts))
+                @fragments.checkout.basketPreview(Some(touchpointBackendResolution.backend.zuoraService.products))
             <div class="u-display-from-tablet" data-set="checkout-notices">
                 <div class="js-append">
                     @fragments.checkout.notices()

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -1,4 +1,8 @@
-@(subscriptionName: String, personalData: model.PersonalData, guestAccountForm: Option[Form[model.GuestAccountData]] = None)(implicit request: RequestHeader)
+@(subscriptionName: String,
+    personalData: model.PersonalData,
+    guestAccountForm: Option[Form[model.GuestAccountData]] = None,
+    touchpointBackendResolution: services.TouchpointBackend.Resolution
+)(implicit request: RequestHeader)
 
 @import configuration.Details
 @import configuration.Config.Identity.webAppProfileUrl
@@ -7,7 +11,7 @@
 @import routes.Checkout.processFinishAccount
 
 
-@main("Thank you | Subscriptions | The Guardian", bodyClasses=List("is-wide")) {
+@main("Thank you | Subscriptions | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
 <main class="page-container gs-container gs-container--slim">
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -2,8 +2,10 @@
     title: String,
     jsVars: model.JsVars = model.JsVars.default,
     isInternational: Boolean = false,
-    bodyClasses: Seq[String] = Nil
+    bodyClasses: Seq[String] = Nil,
+    touchpointBackendResolutionOpt: Option[services.TouchpointBackend.Resolution] = None
 )(content: Html)
+@import utils.TestUsers.{PreSigninTestCookie, NameEnteredInForm, SignedInUsername}
 
 <!DOCTYPE html>
 <html lang="en-GB">
@@ -11,7 +13,20 @@
     @fragments.head(title, jsVars)
 </head>
     <body class="js-off @bodyClasses.mkString(" ")">
-
+        @for(
+            touchpointBackendResolution <- touchpointBackendResolutionOpt;
+            validTestUserCredential <- touchpointBackendResolution.validTestUserCredentialOpt;
+            backend = touchpointBackendResolution.backend
+        ) {
+            <div class="warning-message">
+                Using @touchpointBackendResolution.typ.name backend: <strong><code>@backend.environmentName</code></strong>
+                because you @validTestUserCredential match {
+                case PreSigninTestCookie => { have a valid <code>@Testing.PreSigninTestCookieName</code> cookie - note you still need to create the user with the Test Username }
+                case NameEnteredInForm => { entered a valid Test Username into the form }
+                case SignedInUsername => { are signed in as a user with a valid Test Username }
+            }
+            </div>
+        }
         @fragments.global.warnings()
         @fragments.global.header()
         @fragments.global.navigation()


### PR DESCRIPTION
...and also tell them what credential it is that's making them a test-user.

Guest users, post-purchase account creation, and the need for env-appropriate Zuora rate plans in pre-purchase forms have made working out whether someone is a test user complicated. There are [3 different predicates](https://github.com/guardian/subscriptions-frontend/blob/f1ff7a95f1e/app/utils/TestUsers.scala#L28-L38), with only one valid for all pages on the site:

* `PreSigninTestCookie` <- valid for viewing correct rateplans pre-purchase
* `NameEnteredInForm` <- valid for posting the Checkout form
* `SignedInUsername` <- valid for all pages

`SignedInUsername` trumps any other credential, if it exists.

##### Screenshots

Using `PreSigninTestCookie` :

![image](https://cloud.githubusercontent.com/assets/52038/9117204/9c0f5602-3c60-11e5-8ed5-74aab9918182.png)

Using `SignedInUsername` :

![image](https://cloud.githubusercontent.com/assets/52038/9117300/18479284-3c61-11e5-91e5-c4a8400ea090.png)

cc @dominickendrick 