### PR TITLE
updating formatting for email fields

### DIFF
--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -3,6 +3,7 @@ package model.exactTarget
 import com.gu.membership.zuora.soap.Zuora._
 import model.SubscriptionData
 import org.joda.time.DateTime
+import scala.math.BigDecimal.decimal
 
 object SubscriptionDataExtensionRow {
   def apply(
@@ -27,8 +28,8 @@ object SubscriptionDataExtensionRow {
       subscription.name,
       "SubscriberKey" -> personalData.email,
       "EmailAddress" -> personalData.email,
-      "Subscription term" -> billingPeriod,
-      "Payment amount" -> ratePlanCharge.price.toString,
+      "Subscription term" -> formatSubscriptionTerm(billingPeriod),
+      "Payment amount" -> formatPrice(ratePlanCharge.price),
       "Default payment method" -> paymentMethod.`type`,
       "First Name" -> personalData.firstName,
       "Last Name" -> personalData.lastName,
@@ -63,6 +64,17 @@ object SubscriptionDataExtensionRow {
     val year = dateTime.year.getAsString
 
     s"$day$daySuffix $month $year"
+  }
+
+  private def formatPrice(price: Float): String = {
+    decimal(price).bigDecimal.stripTrailingZeros.toPlainString
+  }
+
+  private def formatSubscriptionTerm(term: String): String = {
+    term match {
+      case "Annual" => "year"
+      case otherTerm => otherTerm.toLowerCase
+    }
   }
 }
 

--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -30,7 +30,7 @@ object SubscriptionDataExtensionRow {
       "EmailAddress" -> personalData.email,
       "Subscription term" -> formatSubscriptionTerm(billingPeriod),
       "Payment amount" -> formatPrice(ratePlanCharge.price),
-      "Default payment method" -> paymentMethod.`type`,
+      "Default payment method" -> formatPaymentMethod(paymentMethod.`type`),
       "First Name" -> personalData.firstName,
       "Last Name" -> personalData.lastName,
       "Address 1" -> address.address1,
@@ -41,7 +41,7 @@ object SubscriptionDataExtensionRow {
       "Country" -> "UK",
       "Account Name" -> paymentData.holder,
       "Sort Code" -> paymentData.sortCode,
-      "Account number" -> paymentData.account,
+      "Account number" -> formatAccountNumber(paymentData.account),
       "Date of first payment" -> formatDate(subscription.contractAcceptanceDate),
       "Currency" -> account.currency,
       //TODO to remove, hardcoded in the template
@@ -75,6 +75,18 @@ object SubscriptionDataExtensionRow {
       case "Annual" => "year"
       case otherTerm => otherTerm.toLowerCase
     }
+  }
+
+  private def formatPaymentMethod(method: String): String = {
+    method match {
+      case "BankTransfer" => "Direct Debit"
+      case otherMethod => otherMethod
+    }
+  }
+
+  private def formatAccountNumber(AccountNumber: String): String = {
+    val lastFour = AccountNumber takeRight 4
+    s"****$lastFour"
   }
 }
 

--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -40,10 +40,10 @@ object SubscriptionDataExtensionRow {
       //TODO hardcoded!
       "Country" -> "UK",
       "Account Name" -> paymentData.holder,
-      "Sort Code" -> paymentData.sortCode,
+      "Sort Code" -> formatSortCode(paymentData.sortCode),
       "Account number" -> formatAccountNumber(paymentData.account),
       "Date of first payment" -> formatDate(subscription.contractAcceptanceDate),
-      "Currency" -> account.currency,
+      "Currency" -> formatCurrency(account.currency),
       //TODO to remove, hardcoded in the template
       "Trial period" -> "14",
       "MandateID" -> paymentMethod.mandateId,
@@ -87,6 +87,17 @@ object SubscriptionDataExtensionRow {
   private def formatAccountNumber(AccountNumber: String): String = {
     val lastFour = AccountNumber takeRight 4
     s"****$lastFour"
+  }
+
+  private def formatSortCode(sortCode: String): String = {
+    sortCode.grouped(2).mkString("-")
+  }
+
+  private def formatCurrency(currency: String): String = {
+    currency match {
+      case "GBP" => "£"
+      case other => other
+    }
   }
 }
 

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -104,7 +104,7 @@ object ETClient extends ETClient with LazyLogging {
    * See https://code.exacttarget.com/apis-sdks/rest-api/v1/hub/data-events/putDataExtensionRowByKey.html
    */
   override def sendSubscriptionRow(row: SubscriptionDataExtensionRow): Future[Response] = {
-    def endpoint = s"$restEndpoint/dataevents/key:$thankYouDataExtensionKey/rows/SubscriberId:${row.subscriptionId}"
+    def endpoint = s"$restEndpoint/dataevents/key:$thankYouDataExtensionKey/rows/ZuoraSubscriberId:${row.subscriptionId}"
 
     Future {
       val payload = Json.obj(


### PR DESCRIPTION
Adding some extra formatting tweaks to data so that it works in the email template
<img width="800" alt="guardian digipack template 20150807" src="https://cloud.githubusercontent.com/assets/1289259/9133819/86b653d2-3cf6-11e5-9b65-039120927818.png">
Some amendments:
![2015-08-13](https://cloud.githubusercontent.com/assets/1289259/9248206/c318c854-41b1-11e5-848f-2b327a9221ba.png)

