### PR TITLE
Fix double-slash in Identity return urls

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -9,6 +9,7 @@ import com.gu.membership.salesforce.SalesforceConfig
 import com.netaporter.uri.dsl._
 import com.typesafe.config.ConfigFactory
 import net.kencochrane.raven.dsn.Dsn
+import play.api.mvc.{Call, RequestHeader}
 
 import scala.util.Try
 
@@ -45,17 +46,15 @@ object Config {
 
     val webAppProfileUrl = webAppUrl / "account" / "edit"
 
-    def webAppSigninUrl(path: String): String =
-      (webAppUrl / "signin") ? ("returnUrl" -> absoluteUrl(path)) ? ("skipConfirmation" -> "true")
+    def idWebAppSigninUrl(returnTo: Call)(implicit request: RequestHeader) = idWebAppUrl("signin", returnTo)
 
-    def idWebAppSignOutUrl(path: String): String =
-      (webAppUrl / "signout") ? ("returnUrl" -> absoluteUrl(path)) ? ("skipConfirmation" -> "true")
+    def idWebAppSignOutUrl(returnTo: Call)(implicit request: RequestHeader) = idWebAppUrl("signout", returnTo)
 
-    def idWebAppRegisterUrl(path : String): String =
-      (webAppUrl / "register") ? ("returnUrl" -> absoluteUrl(path)) ? ("skipConfirmation" -> "true")
+    def idWebAppRegisterUrl(returnTo: Call)(implicit request: RequestHeader) = idWebAppUrl("register", returnTo)
 
+    def idWebAppUrl(idPath: String, returnTo : Call)(implicit request: RequestHeader): String =
+      (webAppUrl / idPath) ? ("returnUrl" -> returnTo.absoluteURL(secure = true)) ? ("skipConfirmation" -> "true")
 
-    private def absoluteUrl(path: String): String = (subscriptionsUrl / path).toString()
   }
 
   object Zuora {

--- a/app/services/AuthenticationService.scala
+++ b/app/services/AuthenticationService.scala
@@ -4,7 +4,5 @@ import com.gu.identity.cookie.IdentityKeys
 import configuration.Config
 
 object AuthenticationService extends com.gu.identity.play.AuthenticationService {
-  def idWebAppSigninUrl(returnUrl: String): String = Config.Identity.webAppSigninUrl(returnUrl)
-
   override val identityKeys: IdentityKeys = Config.Identity.keys
 }

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -44,10 +44,10 @@
                         <div class="fieldset__note fieldset__note--offset">
                             @if(userIsSignedIn) {
                                 <span class="fieldset__note__label">Not you?</span>
-                                <a href="@idWebAppSignOutUrl(renderCheckout().toString())">Sign out</a>
+                                <a href="@idWebAppSignOutUrl(renderCheckout())">Sign out</a>
                             } else {
                                 <span class="fieldset__note__label">Already have a Guardian account?</span>
-                                <a href="@webAppSigninUrl(renderCheckout().toString())">Sign in</a>
+                                <a href="@idWebAppSigninUrl(renderCheckout())">Sign in</a>
                             }
                         </div>
                         <div class="fieldset__edit">

--- a/app/views/testing/testUsers.scala.html
+++ b/app/views/testing/testUsers.scala.html
@@ -1,4 +1,4 @@
-@(userString: String)
+@(userString: String)(implicit request: RequestHeader)
 
 @import configuration.Config.Identity.idWebAppRegisterUrl
 @import routes.Checkout.renderCheckout
@@ -16,7 +16,7 @@
         </div>
 
         <div class="actions">
-            <a href="@idWebAppRegisterUrl(renderCheckout().toString())" class="button button--primary button--large">Register an Identity user</a>
+            <a href="@idWebAppRegisterUrl(renderCheckout())" class="button button--primary button--large">Register an Identity user</a>
             <a href="@renderCheckout" class="button button--primary button--large">Subscribe as a guest user</a>
         </div>
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "membership-common" % "0.79",
   "com.gu" %% "play-googleauth" % "0.3.0",
   "com.gu" %% "identity-test-users" % "0.5",
-  "com.gu.identity" %% "identity-play-auth" % "0.7",
+  "com.gu.identity" %% "identity-play-auth" % "0.8",
   "com.github.nscala-time" %% "nscala-time" % "2.0.0",
   "net.kencochrane.raven" % "raven-logback" % "6.0.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",


### PR DESCRIPTION
It was driving me crazy that the returnUrl in the identity links was introducing a double slash ("https://subscribe.theguardian.com//checkout"):

```
https://profile.theguardian.com/signin?returnUrl=https://subscribe.theguardian.com//checkout&skipConfirmation=true
```

The links only appear on uncached pages so we're safe to read the `RequestHeader` - don't need to use a configured host, and can use Play's `call.absoluteURL()` method.