### PR TITLE
Include marketing preferences to salesforce API call

### DIFF
--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -24,9 +24,7 @@ trait SalesforceService extends LazyLogging {
       Keys.MAILING_CITY -> personalData.address.town,
       Keys.MAILING_POSTCODE -> personalData.address.postcode,
       Keys.MAILING_COUNTRY -> "United Kingdom",
-      Keys.ALLOW_MEMBERSHIP_MAIL -> true,
-      Keys.ALLOW_THIRD_PARTY_EMAIL -> true,
-      Keys.ALLOW_GU_RELATED_MAIL -> true)
+      Keys.ALLOW_GU_RELATED_MAIL -> personalData.receiveGnmMarketing)
 
 }
 


### PR DESCRIPTION
Fixes an [issue](https://trello.com/c/RANmZpQ5/108-email-preferences-are-not-sending-through-to-salesforce) reported on UAT whereby end-user email preferences are not being sent to Salesforce.

**TODO:**

- [x] Get access to Salesforce
- [x] Verify on Salesforce that the fix is effective 

@rtyley @tudorraul 
