### PR TITLE
Terms copy changes & remove mandate PDF

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -22,8 +22,6 @@ import AuthenticationService.authenticatedUserFor
 
 object Checkout extends Controller with LazyLogging {
 
-  private val goCardlessService = GoCardlessService
-
   def renderCheckout = GoogleAuthenticatedStaffAction.async { implicit request =>
 
     val authUserOpt = authenticatedUserFor(request)
@@ -61,16 +59,6 @@ object Checkout extends Controller with LazyLogging {
       val passwordForm = userIdData.toGuestAccountForm
       Ok(view.thankyou(subscription.name, formData.personalData, passwordForm, touchpointBackendResolution))
     }
-  }
-
-  def mandatePDF = GoogleAuthenticatedStaffAction.async { implicit request =>
-    SubscriptionsForm.paymentDataForm.bindFromRequest.fold(
-      handleWithBadRequest,
-      paymentData =>
-        goCardlessService.mandatePDFUrl(paymentData).map(url =>
-          Ok(Json.obj("mandatePDFUrl" -> url))
-        )
-    )
   }
 
   def processFinishAccount = GoogleAuthenticatedStaffAction.async { implicit request =>

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -27,7 +27,8 @@
     <div class="review-details__actions">
         <p class="u-note">
             Your subscription includes a range of exclusive benefits.
-            These may include special offers from other companies, but will be sent to you from Guardian Subscriptions.
+            These may include special offers from other companies,
+            but will be sent to you from Guardian Subscriptions.
         </p>
 
         <label class="option u-pad-bottom" for="receive-gnm-marketing">
@@ -47,25 +48,19 @@
 
         <p class="u-note">
             Guardian News &amp; Media will not share your data with any 3rd party companies.
-            Our <a href="@Links.privacyPolicy.href" target="_blank">@Links.privacyPolicy.title</a>
-            explains in further detail how we use your information and you can find out why your data matters to us here.
         </p>
 
         <input type="submit" class="button button--primary button--large u-margin-bottom" value="Submit payment">
 
         <p class="u-note">
-            By proceeding you agree to the
-            <a href="@Links.terms.href" target="_blank">@Links.terms.title</a>
-            for Guardian Digital Pack subscriptions.
+            Our <a href="@Links.privacyPolicy.href" target="_blank">@Links.privacyPolicy.title</a>
+            explains in further detail how we use your information and why your data matters to us.
         </p>
 
         <p class="u-note">
-            <strong>GC re: Guardian Media Group</strong> will appear on your bank statement.
-            <button class="u-button-reset u-link js-mandate-pdf"
-                    data-loading-message="Generating your Direct Debit instruction"
-                    data-error-message="There was a problem generating your Direct Debit instruction, please try again">
-                View your Direct Debit instruction
-            </button>
+            By proceeding you agree to the
+            <a href="@Links.terms.href" target="_blank">@Links.terms.title</a>
+            for Guardian Digital Pack subscriptions.
         </p>
 
     </div>

--- a/assets/javascripts/modules/checkout/formElements.js
+++ b/assets/javascripts/modules/checkout/formElements.js
@@ -48,8 +48,6 @@ define(['$'], function ($) {
         $FIELDSET_PAYMENT_DETAILS: $('.js-fieldset-payment-details'),
         $FIELDSET_REVIEW: $('.js-fieldset-review'),
 
-        $MANDATE_PDF: $('.js-mandate-pdf'),
-
         $EDIT_YOUR_DETAILS: $('.js-edit-your-details'),
         $EDIT_PAYMENT_DETAILS: $('.js-edit-payment-details')
     };

--- a/assets/javascripts/modules/checkout/reviewDetails.js
+++ b/assets/javascripts/modules/checkout/reviewDetails.js
@@ -49,60 +49,8 @@ define([
         });
     }
 
-    function mandatePDF() {
-
-        var $mandateLink = formEls.$MANDATE_PDF;
-        var mandateLink = $mandateLink[0];
-
-
-        function setLoadingState(link) {
-            link.setAttribute('disabled', 'disabled');
-            link.textContent = link.getAttribute('data-loading-message');
-        }
-
-        function resetMandateLink(link, label) {
-            link.textContent = label;
-            link.removeAttribute('disabled');
-        }
-
-        function displayErrorMessage(link, label) {
-            link.parentNode.insertAdjacentHTML('afterend', [
-                '<p class="u-error">',
-                    link.getAttribute('data-error-message'),
-                '</p>'
-            ].join(''));
-            resetMandateLink(link, label);
-        }
-
-        clickHelper($mandateLink, function() {
-
-            var formData = ajax.reqwest.serialize(formEls.$CHECKOUT_FORM[0]);
-            var originalLabel = mandateLink.textContent;
-
-            setLoadingState(mandateLink);
-
-            ajax({
-                method: 'POST',
-                data: formData,
-                url: '/checkout/mandate-pdf'
-            }).then(function (resp) {
-                if(resp && resp.mandatePDFUrl) {
-                    resetMandateLink(mandateLink, originalLabel);
-                    window.open(resp.mandatePDFUrl);
-                } else {
-                    displayErrorMessage(mandateLink, originalLabel);
-                }
-            }).catch(function (err) {
-                displayErrorMessage(mandateLink, originalLabel);
-                Raven.captureException(err);
-            });
-
-        });
-    }
-
     function init() {
         populateDetails();
-        mandatePDF();
     }
 
     return {

--- a/conf/routes
+++ b/conf/routes
@@ -24,7 +24,6 @@ GET         /checkout                        controllers.Checkout.renderCheckout
 POST        /checkout                        controllers.Checkout.handleCheckout
 GET         /checkout/check-identity         controllers.Checkout.checkIdentity(email: String)
 POST        /checkout/register-guest-user    controllers.Checkout.processFinishAccount
-POST        /checkout/mandate-pdf            controllers.Checkout.mandatePDF
 
 # collection and delivery
 GET         /collection/paper-digital        controllers.Shipping.viewCollectionPaperDigital


### PR DESCRIPTION
This PR

- Updates terms copy on payment page
- Removes mandate generation as it is no longer required (sorry @ostapneko)

![screen shot 2015-08-10 at 12 35 00](https://cloud.githubusercontent.com/assets/123386/9170611/3d8dac42-3f5c-11e5-9c18-c3d56874270b.png)

@afiore @rtyley 