### PR TITLE
Update global error handler to catch Payment errors

### DIFF
--- a/app/monitoring/ErrorHandler.scala
+++ b/app/monitoring/ErrorHandler.scala
@@ -30,17 +30,15 @@ class ErrorHandler @Inject() (env: Environment,
   }
 
   override protected def onDevServerError(request: RequestHeader, exception: UsefulException): Future[Result] = {
-    val default: Handler = { case e =>
+    specialHandler.applyOrElse(exception.cause, { case e =>
       super.onDevServerError(request, exception)
-    }
-    specialHandler.applyOrElse(exception.cause, default)
+    }: Handler)
   }
 
   override protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] = {
-    val default: Handler = { case _ =>
+    specialHandler.applyOrElse(exception.cause, { case _ =>
       Future.successful(NoCache(InternalServerError(views.html.error500(exception))))
-    }
-    specialHandler.applyOrElse(exception.cause, default)
+    }: Handler)
   }
 
   private val specialHandler: Handler = {

--- a/app/monitoring/ErrorHandler.scala
+++ b/app/monitoring/ErrorHandler.scala
@@ -31,14 +31,15 @@ class ErrorHandler @Inject() (env: Environment,
 
   override protected def onDevServerError(request: RequestHeader, exception: UsefulException): Future[Result] = {
     val default: Handler = { case e =>
-      println(s"Got a bloody server error ${e.getClass}")
       super.onDevServerError(request, exception)
     }
     specialHandler.applyOrElse(exception.cause, default)
   }
 
   override protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] = {
-    val default: Handler = { case _ => Future.successful(NoCache(InternalServerError(views.html.error500(exception)))) }
+    val default: Handler = { case _ =>
+      Future.successful(NoCache(InternalServerError(views.html.error500(exception))))
+    }
     specialHandler.applyOrElse(exception.cause, default)
   }
 

--- a/app/services/ZuoraService.scala
+++ b/app/services/ZuoraService.scala
@@ -159,6 +159,7 @@ class ZuoraApiClient(zuoraApiConfig: ZuoraApiConfig, digitalProductPlan: Digital
     }
   }
 
+
   override def createSubscription(memberId: MemberId, data: SubscriptionData): Future[SubscribeResult] = {
     request(Subscribe(memberId, data, Some(zuoraProperties.paymentDelayInDays)))
   }

--- a/app/views/error500.scala.html
+++ b/app/views/error500.scala.html
@@ -4,7 +4,7 @@
         @fragments.page.header("Error 500", Some("There was an error on this page"))
         <p>
             Sorry, there was an error on this page. We're aware of the problem. If this error persists, please contact
-            support on <a href="mailto:subscriptions.dev@@theguardian.com">subscriptions.dev@@theguardian.com</a>.
+            support at <a href="mailto:subscriptions.dev@@theguardian.com">subscriptions.dev@@theguardian.com</a>.
         </p>
         @ex match {
             case err: play.api.UsefulException => {

--- a/app/views/zuoraTransactionFailed.scala.html
+++ b/app/views/zuoraTransactionFailed.scala.html
@@ -1,0 +1,9 @@
+@main("Payment failed") {
+    <main class="page-container gs-container">
+        @fragments.page.header("Payment error", None)
+        <p>
+            Sorry, we were unable to process your payment. Please check your details and try again.
+            If this error persists, please contact support on <a href="mailto:subscriptions.dev@@theguardian.com">subscriptions.dev@@theguardian.com</a>.
+        </p>
+    </main>
+}

--- a/app/views/zuoraTransactionFailed.scala.html
+++ b/app/views/zuoraTransactionFailed.scala.html
@@ -3,7 +3,7 @@
         @fragments.page.header("Payment error", None)
         <p>
             Sorry, we were unable to process your payment. Please check your details and try again.
-            If this error persists, please contact support on <a href="mailto:subscriptions.dev@@theguardian.com">subscriptions.dev@@theguardian.com</a>.
+            If this error persists, please contact support at <a href="mailto:subscriptions.dev@@theguardian.com">subscriptions.dev@@theguardian.com</a>.
         </p>
     </main>
 }


### PR DESCRIPTION
Catch Zuora errors with code [TRANSACTION_FAILED](https://knowledgecenter.zuora.com/BC_Developers/SOAP_API/L_Error_Handling/Errors) and display a payment error message to the user (arguably a bit more informative than the standard 500 error page).

![screen shot 2015-08-10 at 14 09 54](https://cloud.githubusercontent.com/assets/63361/9172182/9f9f2ce6-3f69-11e5-8138-aa3a6f79c345.png)

**Note on implementation**

It would be arguably better handling this error explicitly as a value by modelling it into the return type of `CheckoutService.processSubscription`. This would involve changing the definition of `CheckoutResult` into something like:

```scala
trait CheckoutResult

case class CheckoutOk(
    salesforceMember: MemberId,
    userIdData: UserIdData,
    zuoraResult: SubscribeResult) extends CheckoutResult

case object PaymentError extends CheckoutResult
...
```

Happy to change the implementation and doing this, but maybe a bit out of scope given that this ticket is intended as a quick fix.

@tudorraul 