### PR TITLE
Remove Google authentication from checkout process

### DIFF
--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -12,9 +12,7 @@ object CommonActions {
 
   val NoCacheAction = resultModifier(noCache)
 
-  val GoogleAuthAction = OAuthActions.AuthAction
-
-  val GoogleAuthenticatedStaffAction = NoCacheAction andThen PreReleaseFeature
+  val GoogleAuthenticatedStaffAction = NoCacheAction andThen OAuthActions.AuthAction
 
   val CachedAction = resultModifier(Cached(_))
 

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -22,7 +22,7 @@ import AuthenticationService.authenticatedUserFor
 
 object Checkout extends Controller with LazyLogging {
 
-  def renderCheckout = GoogleAuthenticatedStaffAction.async { implicit request =>
+  def renderCheckout = NoCacheAction.async { implicit request =>
 
     val authUserOpt = authenticatedUserFor(request)
     val touchpointBackendResolution = TouchpointBackend.forRequest(PreSigninTestCookie, request.cookies)
@@ -49,7 +49,7 @@ object Checkout extends Controller with LazyLogging {
     BadRequest
   })
 
-  def handleCheckout = GoogleAuthenticatedStaffAction.async(parseCheckoutForm) { implicit request =>
+  def handleCheckout = NoCacheAction.async(parseCheckoutForm) { implicit request =>
     val formData = request.body
     val idUserOpt = authenticatedUserFor(request)
 
@@ -61,7 +61,7 @@ object Checkout extends Controller with LazyLogging {
     }
   }
 
-  def processFinishAccount = GoogleAuthenticatedStaffAction.async { implicit request =>
+  def processFinishAccount = NoCacheAction.async { implicit request =>
     FinishAccountForm().bindFromRequest.fold(
       handleWithBadRequest,
       guestAccountData => {


### PR DESCRIPTION
We don't link to the checkout page, but as the process is soon to launch (and be pen-tested) we need to remove the Guardian-staff-only access restriction.

cc @TesterSpike @vivekkr 
