### PR TITLE
Form accessibility fixes

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -4,8 +4,6 @@
 @import routes.Checkout.renderCheckout
 @import configuration.Config.Identity._
 
-@readonly = @{ if (userIsSignedIn) "readonly" else "" }
-
 @main(
     title = "Checkout | Subscriptions | The Guardian",
     jsVars = JsVars.default.copy(userIsSignedIn = userIsSignedIn),
@@ -14,168 +12,95 @@
 ) {
 <main class="page-container gs-container">
 
-    <form class="form js-checkout-form" action="" method="POST">
-
-        <section class="checkout-container">
+    <section class="checkout-container">
+        <form class="form js-checkout-form" action="@renderCheckout().toString()" method="POST">
+            @helper.CSRF.formField
 
             @fragments.checkout.checkoutHeader("Checkout")
 
             <div class="checkout-container__sidebar">
                 @fragments.checkout.basketPreview(Some(touchpointBackendResolution.backend.zuoraService.products))
-            <div class="u-display-from-tablet" data-set="checkout-notices">
-                <div class="js-append">
-                    @fragments.checkout.notices()
+                <div class="u-display-from-tablet" data-set="checkout-notices">
+                    <div class="js-append">
+                        @fragments.checkout.notices()
+                    </div>
                 </div>
             </div>
-        </div>
 
-        <div class="checkout-container__form">
-
-            <form class="form js-checkout-form" method="POST">
+            <div class="checkout-container__form">
 
                 @* ===== Your details ===== *@
-                <fieldset id="yourDetails" class="fieldset js-fieldset-your-details">
-                    @helper.CSRF.formField
-
-                    <div class="fieldset__heading">
-                        <legend class="fieldset__headline">
-                            <span class="fieldset__headline__num">1</span> Your details
+                <div id="yourDetails" class="field-panel js-fieldset-your-details">
+                    <fieldset>
+                        <legend class="field-panel__legend">
+                            <span class="field-panel__legend__num">1</span> Your details
                         </legend>
-                        <div class="fieldset__note fieldset__note--offset">
-                            @if(userIsSignedIn) {
-                                <span class="fieldset__note__label">Not you?</span>
-                                <a href="@idWebAppSignOutUrl(renderCheckout())">Sign out</a>
-                            } else {
-                                <span class="fieldset__note__label">Already have a Guardian account?</span>
-                                <a href="@idWebAppSigninUrl(renderCheckout())">Sign in</a>
-                            }
+                        <div class="field-panel__intro">
+                            <div class="field-note field-note--offset">
+                                @if(userIsSignedIn) {
+                                    <span class="field-note__label">Not you?</span>
+                                    <a href="@idWebAppSignOutUrl(renderCheckout())">Sign out</a>
+                                } else {
+                                    <span class="field-note__label">Already have a Guardian account?</span>
+                                    <a href="@idWebAppSigninUrl(renderCheckout())">Sign in</a>
+                                }
+                            </div>
                         </div>
-                        <div class="fieldset__edit">
+                        <div class="field-panel__edit">
                             <a href="#yourDetails" class="text-button u-button-reset js-edit-your-details">Edit</a>
                         </div>
-                    </div>
-                    <div class="fieldset__fields">
-                        <div class="form-field js-checkout-first">
-                            <label class="label" for="first">First name</label>
-                            <input type="text" class="input-text js-input" name="personal.first" id="first" value="@form.data.get("personal.first")">
-                            @fragments.forms.errorMessage("This field is required")
-                        </div>
-                        <div class="form-field js-checkout-last">
-                            <label class="label" for="last">Last name</label>
-                            <input type="text" class="input-text js-input" name="personal.last" id="last" value="@form.data.get("personal.last")">
-                            @fragments.forms.errorMessage("This field is required")
-                        </div>
-                        <div class="form-field @if(!userIsSignedIn) {js-checkout-email}">
-                            <label class="label" for="email">Email address</label>
-                            <input type="email" class="input-text js-input" name="personal.emailValidation.email" id="email" value="@form.data.get("personal.emailValidation.email")" @readonly>
-                            @fragments.forms.errorMessage("")
-                        </div>
-                        <div class="form-field @if(!userIsSignedIn) {js-checkout-confirm-email}">
-                            @if(userIsSignedIn) {
-                                <input type="hidden" name="personal.emailValidation.confirm" id="confirm" value="@form.data.get("personal.emailValidation.confirm")">
-                            } else {
-                                <label class="label" for="confirm">Confirm email address</label>
-                                <input type="email" class="input-text js-input" name="personal.emailValidation.confirm" id="confirm" value="@form.data.get("personal.emailValidation.confirm")">
-                                @fragments.forms.errorMessage("The confirmation email must match your email address")
-                            }
-                        </div>
-                        <div class="js-checkout-full-address">
-                            <div class="form-field js-checkout-house">
-                                <label class="label" for="address-line-1">Address line 1</label>
-                                <input type="text" class="input-text js-input" id="address-line-1" name="personal.address.address1" value="@form.data.get("personal.address.address1")">
-                                @fragments.forms.errorMessage("This field is required")
-                            </div>
-                            <div class="form-field js-checkout-street">
-                                <label class="label optional-marker" for="address-line-2">Address line 2</label>
-                                <input type="text" class="input-text js-input" id="address-line-2" name="personal.address.address2" value="@form.data.get("personal.address.address2")">
-                                @fragments.forms.errorMessage("This field is required")
-                            </div>
-                            <div class="form-field js-checkout-town">
-                                <label class="label" for="address-town">Town/City</label>
-                                <input type="text" class="input-text js-input" id="address-town" name="personal.address.town" value="@form.data.get("personal.address.town")">
-                                @fragments.forms.errorMessage("This field is required")
-                            </div>
-                        </div>
-                        <div class="form-field js-checkout-postcode">
-                            <label class="label" for="address-postcode">Postcode</label>
-                            <input type="text" class="input-text js-input input-text input-text--small" id="address-postcode" name="personal.address.postcode" value="@form.data.get("personal.address.postcode")">
-                            @fragments.forms.errorMessage("Please enter a valid postal code")
-                        </div>
+                        <div class="field-panel__fields">
+                            @fragments.checkout.fieldsPersonal(form, userIsSignedIn)
 
-                        <div class="actions">
-                            <a href="#paymentDetails" class="button button--primary button--large js-checkout-your-details-submit">Continue</a>
+                            <div class="actions">
+                                <a href="#paymentDetails" class="button button--primary button--large js-checkout-your-details-submit">Continue</a>
+                            </div>
                         </div>
-                    </div>
-                </fieldset>
+                    </fieldset>
+                </div>
 
                 @* ===== Payment ===== *@
-                <fieldset id="paymentDetails" class="fieldset fieldset--collapsed js-fieldset-payment-details">
-                    <div class="fieldset__heading">
-                        <legend class="fieldset__headline">
-                            <span class="fieldset__headline__num">2</span> Payment details
+                <div id="paymentDetails" class="field-panel is-collapsed js-fieldset-payment-details">
+                    <fieldset>
+                        <legend class="field-panel__legend">
+                            <span class="field-panel__legend__num">2</span> Payment details
                         </legend>
-                        <div class="fieldset__note fieldset__note--offset">
-                            @fragments.forms.securityNote()
-                            Payment will be taken by Direct Debit
+                        <div class="field-panel__intro">
+                            <div class="field-note field-note--offset">
+                                @fragments.forms.securityNote()
+                                Payment will be taken by Direct Debit
+                            </div>
                         </div>
-                        <div class="fieldset__edit">
+                        <div class="field-panel__edit">
                             <a href="#paymentDetails" class="text-button u-button-reset js-edit-payment-details">Edit</a>
                         </div>
-                    </div>
-                    <div class="fieldset__fields">
-                        <div class="form-field js-checkout-account">
-                            <label class="label" for="account">Bank account number</label>
-                            <input type="text" pattern="[0-9]*" minlength="6" maxlength="10" class="input-text js-input" name="payment.account">
-                            @fragments.forms.errorMessage("Please enter between 6 and 10 digits for the account number")
+                        <div class="field-panel__fields">
+                            @fragments.checkout.fieldsPayment(form)
+
+                            <div class="actions">
+                                <a href="#formReview" class="button button--primary button--large js-checkout-payment-details-submit">Continue</a>
+                            </div>
                         </div>
-                        <div class="form-field js-checkout-sortcode">
-                            <label class="label" for="sortcode">Bank sort code</label>
-                            <input type="text" class="input-text input-text--small js-input"
-                                name="payment.sortcode" maxlength="8"
-                                placeholder="00-00-00" required
-                                data-masker-delim="-" data-masker-length="2">
-                            @fragments.forms.errorMessage("")
-                        </div>
-                        <div class="form-field js-checkout-holder">
-                            <label class="label" for="holder">Name of account holder</label>
-                            <input type="text" maxlength="18" class="input-text js-input" name="payment.holder">
-                            @* TODO: Why limited to 18 characters? *@
-                            @fragments.forms.errorMessage("Please enter between 1 and 18 characters for the account holder name")
-                        </div>
-                        <div class="form-field js-checkout-confirm-payment">
-                            <label class="option">
-                                <span class="option__input">
-                                    <input type="checkbox" class="js-input">
-                                </span>
-                                <span class="option__label">
-                                    I confirm that I am the account holder and I am solely able to authorise debit from the account
-                                </span>
-                            </label>
-                            @fragments.forms.errorMessage("Please confirm that you are the account holder")
-                        </div>
-                        <div class="actions">
-                            <a href="#formReview" class="button button--primary button--large js-checkout-payment-details-submit">Continue</a>
-                        </div>
-                    </div>
-                </fieldset>
+                    </fieldset>
+                </div>
 
                 @* ===== Review ===== *@
-                <fieldset id="formReview" class="fieldset fieldset--single fieldset--collapsed js-fieldset-review">
-                    <div class="fieldset__heading">
-                        <legend class="fieldset__headline">
-                            <span class="fieldset__headline__num">3</span> Review and confirm
+                <div id="formReview" class="field-panel field-panel--single is-collapsed js-fieldset-review">
+                    <fieldset>
+                        <legend class="field-panel__legend">
+                            <span class="field-panel__legend__num">3</span> Review and confirm
                         </legend>
-                    </div>
-                    <div class="fieldset__fields">
-                        @fragments.checkout.reviewDetails(form)
-                    </div>
-                </fieldset>
+                        <div class="field-panel__fields">
+                            @fragments.checkout.reviewDetails(form)
+                        </div>
+                    </fieldset>
+                </div>
 
-            </form>
+            </div>
 
-        </div>
+            <div class="u-display-until-tablet" data-set="checkout-notices"></div>
 
-        <div class="u-display-until-tablet" data-set="checkout-notices"></div>
+        </form>
 
     </section>
 

--- a/app/views/fragments/checkout/fieldsPayment.scala.html
+++ b/app/views/fragments/checkout/fieldsPayment.scala.html
@@ -1,0 +1,32 @@
+@(form: Form[model.SubscriptionData])
+
+<div class="form-field js-checkout-account">
+    <label class="label" for="payment-account">Bank account number</label>
+    <input type="text" pattern="[0-9]*" minlength="6" maxlength="10" class="input-text js-input" id="payment-account" name="payment.account">
+    @fragments.forms.errorMessage("Please enter between 6 and 10 digits for the account number")
+</div>
+<div class="form-field js-checkout-sortcode">
+    <label class="label" for="payment-sortcode">Bank sort code</label>
+    <input type="text" class="input-text input-text--small js-input"
+        name="payment.sortcode" id="payment-sortcode" maxlength="8"
+        placeholder="00-00-00" required
+        data-masker-delim="-" data-masker-length="2">
+    @fragments.forms.errorMessage("")
+</div>
+<div class="form-field js-checkout-holder">
+    <label class="label" for="payment-holder">Name of account holder</label>
+    <input type="text" maxlength="18" class="input-text js-input" id="payment-holder" name="payment.holder">
+    @* TODO: Why limited to 18 characters? *@
+    @fragments.forms.errorMessage("Please enter between 1 and 18 characters for the account holder name")
+</div>
+<div class="form-field js-checkout-confirm-payment">
+    <label class="option">
+        <span class="option__input">
+            <input type="checkbox" class="js-input">
+        </span>
+        <span class="option__label">
+            I confirm that I am the account holder and I am solely able to authorise debit from the account
+        </span>
+    </label>
+    @fragments.forms.errorMessage("Please confirm that you are the account holder")
+</div>

--- a/app/views/fragments/checkout/fieldsPayment.scala.html
+++ b/app/views/fragments/checkout/fieldsPayment.scala.html
@@ -14,10 +14,16 @@
     @fragments.forms.errorMessage("")
 </div>
 <div class="form-field js-checkout-holder">
+    @*
+        BACS requirement:
+        "The payer’s account name (maximum of 18 characters).
+        This must be the name of the person who is paying the Direct Debit
+        and has signed the Direct Debit Instruction (DDI)."
+        http://www.bacs.co.uk/Bacs/Businesses/Resources/Pages/Glossary.aspx
+    *@
     <label class="label" for="payment-holder">Name of account holder</label>
     <input type="text" maxlength="18" class="input-text js-input" id="payment-holder" name="payment.holder">
-    @* TODO: Why limited to 18 characters? *@
-    @fragments.forms.errorMessage("Please enter between 1 and 18 characters for the account holder name")
+    @fragments.forms.errorMessage("The account holder name must be less that 18 characters")
 </div>
 <div class="form-field js-checkout-confirm-payment">
     <label class="option">

--- a/app/views/fragments/checkout/fieldsPersonal.scala.html
+++ b/app/views/fragments/checkout/fieldsPersonal.scala.html
@@ -1,0 +1,50 @@
+@(form: Form[model.SubscriptionData], userIsSignedIn: Boolean)
+
+@readonly = @{ if (userIsSignedIn) "readonly" else "" }
+
+<div class="form-field js-checkout-first">
+    <label class="label" for="first">First name</label>
+    <input type="text" class="input-text js-input" name="personal.first" id="first" value="@form.data.get("personal.first")">
+    @fragments.forms.errorMessage("This field is required")
+</div>
+<div class="form-field js-checkout-last">
+    <label class="label" for="last">Last name</label>
+    <input type="text" class="input-text js-input" name="personal.last" id="last" value="@form.data.get("personal.last")">
+    @fragments.forms.errorMessage("This field is required")
+</div>
+<div class="form-field @if(!userIsSignedIn) {js-checkout-email}">
+    <label class="label" for="email">Email address</label>
+    <input type="email" class="input-text js-input" name="personal.emailValidation.email" id="email" value="@form.data.get("personal.emailValidation.email")" @readonly>
+    @fragments.forms.errorMessage("")
+</div>
+<div class="form-field @if(!userIsSignedIn) {js-checkout-confirm-email}">
+    @if(userIsSignedIn) {
+        <input type="hidden" name="personal.emailValidation.confirm" id="confirm" value="@form.data.get("personal.emailValidation.confirm")">
+    } else {
+        <label class="label" for="confirm">Confirm email address</label>
+        <input type="email" class="input-text js-input" name="personal.emailValidation.confirm" id="confirm" value="@form.data.get("personal.emailValidation.confirm")">
+        @fragments.forms.errorMessage("The confirmation email must match your email address")
+    }
+</div>
+<div class="js-checkout-full-address">
+    <div class="form-field js-checkout-house">
+        <label class="label" for="address-line-1">Address line 1</label>
+        <input type="text" class="input-text js-input" id="address-line-1" name="personal.address.address1" value="@form.data.get("personal.address.address1")">
+        @fragments.forms.errorMessage("This field is required")
+    </div>
+    <div class="form-field js-checkout-street">
+        <label class="label optional-marker" for="address-line-2">Address line 2</label>
+        <input type="text" class="input-text js-input" id="address-line-2" name="personal.address.address2" value="@form.data.get("personal.address.address2")">
+        @fragments.forms.errorMessage("This field is required")
+    </div>
+    <div class="form-field js-checkout-town">
+        <label class="label" for="address-town">Town/City</label>
+        <input type="text" class="input-text js-input" id="address-town" name="personal.address.town" value="@form.data.get("personal.address.town")">
+        @fragments.forms.errorMessage("This field is required")
+    </div>
+</div>
+<div class="form-field js-checkout-postcode">
+    <label class="label" for="address-postcode">Postcode</label>
+    <input type="text" class="input-text js-input input-text input-text--small" id="address-postcode" name="personal.address.postcode" value="@form.data.get("personal.address.postcode")">
+    @fragments.forms.errorMessage("Please enter a valid postal code")
+</div>

--- a/app/views/fragments/checkout/notices.scala.html
+++ b/app/views/fragments/checkout/notices.scala.html
@@ -5,7 +5,7 @@
 
 @notice(title: String)(content: Html) = {
     <div class="notice">
-        <h4 class="notice__header">@title</h4>
+        <h3 class="notice__header">@title</h3>
         <div class="notice__content">@content</div>
     </div>
 }
@@ -66,7 +66,7 @@
                     You can cancel a Direct Debit at any time by simply contacting your bank or building society.
                     Written confirmation may be required. Please also notify Guardian Subscriptions.
                 </li>
-            </ol>
+            </ul>
         </div>
     </aside>
 

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -4,7 +4,7 @@
 
 <div class="review-details">
     <div class="review-details__item">
-        <h3 class="review-details__heading">Your details</h3>
+        <span class="review-details__heading">Your details</span>
         <div class="review-details__list">
             <ul class="u-unstyled-list">
                 <li class="js-checkout-review-name"></li>
@@ -14,7 +14,7 @@
         </div>
     </div>
     <div class="review-details__item">
-        <h3 class="review-details__heading">Payment details</h3>
+        <span class="review-details__heading">Payment details</span>
         <div class="review-details__list">
             <ul class="u-unstyled-list">
                 <li><span class="review-details__detail">Payment method:</span> Direct Debit</li>

--- a/assets/javascripts/modules/checkout/editFieldsets.js
+++ b/assets/javascripts/modules/checkout/editFieldsets.js
@@ -1,8 +1,8 @@
 define(['bean', 'modules/checkout/formElements'], function (bean, formEls) {
     'use strict';
 
-    var FIELDSET_COMPLETE = 'fieldset--complete';
-    var FIELDSET_COLLAPSED = 'fieldset--collapsed';
+    var FIELDSET_COMPLETE = 'is-complete';
+    var FIELDSET_COLLAPSED = 'is-collapsed';
 
     function collapseFieldsets(extra) {
         [

--- a/assets/javascripts/modules/checkout/paymentDetails.js
+++ b/assets/javascripts/modules/checkout/paymentDetails.js
@@ -13,9 +13,8 @@ define([
 ) {
     'use strict';
 
-    var FIELDSET_COLLAPSED = 'fieldset--collapsed';
-    var FIELDSET_COMPLETE = 'fieldset--complete';
-    var FIELDSET_COMPLETE_ATTR = 'data-fieldset-complete';
+    var FIELDSET_COMPLETE = 'is-complete';
+    var FIELDSET_COLLAPSED = 'is-collapsed';
 
     function displayErrors(validity) {
         toggleError(formEls.$ACCOUNT_CONTAINER, !validity.accountNumberValid);
@@ -27,8 +26,7 @@ define([
     function nextStep() {
         formEls.$FIELDSET_PAYMENT_DETAILS
             .addClass(FIELDSET_COLLAPSED)
-            .addClass(FIELDSET_COMPLETE)
-            .attr(FIELDSET_COMPLETE_ATTR, '');
+            .addClass(FIELDSET_COMPLETE);
 
         formEls.$FIELDSET_REVIEW
             .removeClass(FIELDSET_COLLAPSED);

--- a/assets/javascripts/modules/checkout/personalDetails.js
+++ b/assets/javascripts/modules/checkout/personalDetails.js
@@ -9,9 +9,8 @@ define([
 ) {
     'use strict';
 
-    var FIELDSET_COLLAPSED = 'fieldset--collapsed';
-    var FIELDSET_COMPLETE = 'fieldset--complete';
-    var FIELDSET_COMPLETE_ATTR = 'data-fieldset-complete';
+    var FIELDSET_COMPLETE = 'is-complete';
+    var FIELDSET_COLLAPSED = 'is-collapsed';
 
     var requiredFields = [
         {input: formEls.$FIRST_NAME, container: formEls.$FIRST_NAME_CONTAINER},
@@ -47,8 +46,7 @@ define([
     function nextStep() {
         formEls.$FIELDSET_YOUR_DETAILS
             .addClass(FIELDSET_COLLAPSED)
-            .addClass(FIELDSET_COMPLETE)
-            .attr(FIELDSET_COMPLETE_ATTR, '');
+            .addClass(FIELDSET_COMPLETE);
 
         formEls.$FIELDSET_PAYMENT_DETAILS
             .removeClass(FIELDSET_COLLAPSED);

--- a/assets/stylesheets/modules/_forms.scss
+++ b/assets/stylesheets/modules/_forms.scss
@@ -2,22 +2,24 @@
    Forms
    ========================================================================== */
 
-// Form
-// ============================================================================
-
-.form {
-    margin-bottom: 0;
-}
-
-// Form Fieldset
-// ============================================================================
-
-fieldset {
-    border: none;
+legend {
     padding: 0;
+    display: table;
+}
+fieldset {
+    border: 0;
+    padding: 0.01em 0 0 0;
+    margin: 0;
+    min-width: 0;
+}
+body:not(:-moz-handler-blocked) fieldset {
+    display: table-cell;
 }
 
-.fieldset {
+// Field Panel
+// ============================================================================
+
+.field-panel {
     position: relative;
     background-color: $c-neutral7;
     margin: 0;
@@ -26,58 +28,40 @@ fieldset {
     padding: ($gs-gutter / 2);
 
     @include mq(tablet) {
-        display: table;
-        width: 100%;
+        @include clearfix();
     }
 }
-.fieldset__heading,
-.fieldset__fields {
-    @include mq(tablet) {
-        display: table-cell;
-        vertical-align: top;
-    }
+.field-panel__legend {
+    width: 100%;
+    @include fs-header(3);
+    margin-bottom: $gs-baseline / 2;
 }
-.fieldset__fields {
-    padding-bottom: $gs-baseline * 2;
+.field-panel__legend__num {
+    color: lighten($c-neutral1, 20%);
+    display: inline-block;
+    width: $gs-gutter;
 }
-.fieldset__heading {
+.field-panel__intro {
     @include mq(tablet) {
         width: 35%;
+        float: left;
+        clear: left;
         padding-right: $gs-gutter / 2;
     }
     @include mq(desktop) {
         padding-right: $gs-gutter * 2;
     }
 }
-.fieldset__headline {
-    @include fs-header(3);
-    margin-bottom: $gs-baseline / 2;
-}
-.fieldset__headline__num {
-    color: guss-colour(news-main-2);
-    display: inline-block;
-    width: $gs-gutter;
-}
-.fieldset__note {
-    @include fs-textSans(2);
-    color: $c-neutral2;
-}
-.fieldset__note__label {
-    margin-left: .2em;
+.field-panel__fields {
+    padding-bottom: $gs-baseline * 2;
 
-    @include mq(desktop) {
-        display: block;
-        margin-left: 0;
+    @include mq(tablet) {
+        float: right;
+        width: 65%;
     }
 }
-.fieldset__note--offset {
-    @include mq(desktop) {
-        // Semi-magic number
-        // Optical alignment with field headlins
-        padding-left: $gs-gutter + 3px;
-    }
-}
-.fieldset__edit {
+
+.field-panel__edit {
     @include fs-textSans(1);
     position: absolute;
     top: $gs-baseline;
@@ -87,28 +71,51 @@ fieldset {
     display: none;
 }
 
-.fieldset--single {
-    .fieldset__heading,
-    .fieldset__fields {
+.field-panel--single {
+    .field-panel__intro,
+    .field-panel__fields {
         display: block;
         width: auto;
     }
     @include mq(tablet) {
-        .fieldset__fields {
+        .field-panel__fields {
             display: block;
         }
     }
 }
 
-.fieldset--complete {
-    .fieldset__edit {
+.field-panel.is-complete {
+    .field-panel__edit {
         display: block;
     }
 }
-.fieldset--collapsed {
-    .fieldset__note,
-    .fieldset__fields {
+.js-on .field-panel.is-collapsed {
+    .field-panel__intro,
+    .field-panel__fields {
         display: none;
+    }
+}
+
+// Field Notes
+// ============================================================================
+
+.field-note {
+    @include fs-textSans(2);
+    color: lighten($c-neutral1, 15%);
+}
+.field-note__label {
+    margin-left: .2em;
+
+    @include mq(desktop) {
+        display: block;
+        margin-left: 0;
+    }
+}
+.field-note--offset {
+    @include mq(desktop) {
+        // Semi-magic number
+        // Optical alignment with field headline
+        padding-left: $gs-gutter + 3px;
     }
 }
 


### PR DESCRIPTION
Ran the checkout pages through a validator and [tota11y](http://khan.github.io/tota11y/) and fixed a few accessibility issues. Largely around how we used fieldsets and how we associate fields.

- Reworks form markup to allow for the correct usage of `<fieldset>` and
`<legend>`.
- Fixes some field label assignments
- Corrects heading levels on checkout page
- Extracts fields out into fragments to make this template a little more
  readable, and easier to change.

Re-do of https://github.com/guardian/subscriptions-frontend/pull/177 which needed too many conflicts fixing.

@afiore @tudorraul 