### PR TITLE
Render payment form with errors

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -60,7 +60,7 @@ object Checkout extends Controller with LazyLogging {
         val touchpointBackendResolution = TouchpointBackend.forRequest(NameEnteredInForm, userData)
         touchpointBackendResolution.backend.checkoutService.processSubscription(userData, authenticatedUserFor(request)).map { case CheckoutResult(_, userIdData, subscription) =>
           val passwordForm = userIdData.toGuestAccountForm
-          val subscriptionProduct = touchpointBackendResolution.backend.zuoraService.products.filter(_.ratePlanId == formData.ratePlanId).head
+          val subscriptionProduct = touchpointBackendResolution.backend.zuoraService.products.filter(_.ratePlanId == userData.ratePlanId).head
           Ok(view.thankyou(subscription.name, userData.personalData, passwordForm, touchpointBackendResolution, subscriptionProduct))
         }
       }

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -20,7 +20,7 @@ import scala.concurrent.Future
 
 object Checkout extends Controller with LazyLogging {
 
-  def fillForm(form: Form[SubscriptionData], authUserOpt: Option[AuthenticatedIdUser]): Future[Form[SubscriptionData]] = {
+  private def fillForm(form: Form[SubscriptionData], authUserOpt: Option[AuthenticatedIdUser]): Future[Form[SubscriptionData]] = {
     for {
       fullUserOpt <- authUserOpt.fold[Future[Option[IdUser]]](Future.successful(None))(au => IdentityService.userLookupByScGuU(AuthCookie(au.authCookie)))
     } yield fullUserOpt.map { idUser =>

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -13,7 +13,7 @@
 <main class="page-container gs-container">
 
     <section class="checkout-container">
-        <form class="form js-checkout-form" action="@renderCheckout().toString()" method="POST">
+        <form class="form js-checkout-form" action="@renderCheckout().toString()" method="POST" novalidate>
             @helper.CSRF.formField
 
             @fragments.checkout.checkoutHeader("Checkout")
@@ -28,6 +28,12 @@
             </div>
 
             <div class="checkout-container__form">
+
+                @if(form.errors.nonEmpty) {
+                    <div class="flash-message flash-message--error">
+                        This form has errors, please check your details and try again.
+                    </div>
+                }
 
                 @* ===== Your details ===== *@
                 <div id="yourDetails" class="field-panel js-fieldset-your-details">

--- a/app/views/fragments/checkout/fieldsPayment.scala.html
+++ b/app/views/fragments/checkout/fieldsPayment.scala.html
@@ -1,11 +1,15 @@
 @(form: Form[model.SubscriptionData])
 
-<div class="form-field js-checkout-account">
+@hasError(key: String) = @{
+    if(form(key).hasErrors) { "has-error" }
+}
+
+<div class="form-field js-checkout-account @hasError("payment.account")">
     <label class="label" for="payment-account">Bank account number</label>
     <input type="text" pattern="[0-9]*" minlength="6" maxlength="10" class="input-text js-input" id="payment-account" name="payment.account">
     @fragments.forms.errorMessage("Please enter between 6 and 10 digits for the account number")
 </div>
-<div class="form-field js-checkout-sortcode">
+<div class="form-field js-checkout-sortcode @hasError("payment.sortcode")">
     <label class="label" for="payment-sortcode">Bank sort code</label>
     <input type="text" class="input-text input-text--small js-input"
         name="payment.sortcode" id="payment-sortcode" maxlength="8"
@@ -13,7 +17,7 @@
         data-masker-delim="-" data-masker-length="2">
     @fragments.forms.errorMessage("")
 </div>
-<div class="form-field js-checkout-holder">
+<div class="form-field js-checkout-holder @hasError("payment.holder")">
     @*
         BACS requirement:
         "The payer’s account name (maximum of 18 characters).

--- a/app/views/fragments/checkout/fieldsPersonal.scala.html
+++ b/app/views/fragments/checkout/fieldsPersonal.scala.html
@@ -2,22 +2,26 @@
 
 @readonly = @{ if (userIsSignedIn) "readonly" else "" }
 
-<div class="form-field js-checkout-first">
+@hasError(key: String) = @{
+    if(form(key).hasErrors) { "has-error" }
+}
+
+<div class="form-field js-checkout-first @hasError("personal.first")">
     <label class="label" for="first">First name</label>
     <input type="text" class="input-text js-input" name="personal.first" id="first" value="@form.data.get("personal.first")">
     @fragments.forms.errorMessage("This field is required")
 </div>
-<div class="form-field js-checkout-last">
+<div class="form-field js-checkout-last @hasError("personal.last")">
     <label class="label" for="last">Last name</label>
     <input type="text" class="input-text js-input" name="personal.last" id="last" value="@form.data.get("personal.last")">
     @fragments.forms.errorMessage("This field is required")
 </div>
-<div class="form-field @if(!userIsSignedIn) {js-checkout-email}">
+<div class="form-field @if(!userIsSignedIn) {js-checkout-email} @hasError("personal.emailValidation.email")">
     <label class="label" for="email">Email address</label>
     <input type="email" class="input-text js-input" name="personal.emailValidation.email" id="email" value="@form.data.get("personal.emailValidation.email")" @readonly>
     @fragments.forms.errorMessage("")
 </div>
-<div class="form-field @if(!userIsSignedIn) {js-checkout-confirm-email}">
+<div class="form-field @if(!userIsSignedIn) {js-checkout-confirm-email} @hasError("personal.emailValidation.confirm")">
     @if(userIsSignedIn) {
         <input type="hidden" name="personal.emailValidation.confirm" id="confirm" value="@form.data.get("personal.emailValidation.confirm")">
     } else {
@@ -27,23 +31,23 @@
     }
 </div>
 <div class="js-checkout-full-address">
-    <div class="form-field js-checkout-house">
+    <div class="form-field js-checkout-house @hasError("personal.address.address1")">
         <label class="label" for="address-line-1">Address line 1</label>
         <input type="text" class="input-text js-input" id="address-line-1" name="personal.address.address1" value="@form.data.get("personal.address.address1")">
         @fragments.forms.errorMessage("This field is required")
     </div>
-    <div class="form-field js-checkout-street">
+    <div class="form-field js-checkout-street @hasError("personal.address.address2")">
         <label class="label optional-marker" for="address-line-2">Address line 2</label>
         <input type="text" class="input-text js-input" id="address-line-2" name="personal.address.address2" value="@form.data.get("personal.address.address2")">
         @fragments.forms.errorMessage("This field is required")
     </div>
-    <div class="form-field js-checkout-town">
+    <div class="form-field js-checkout-town @hasError("personal.address.town")">
         <label class="label" for="address-town">Town/City</label>
         <input type="text" class="input-text js-input" id="address-town" name="personal.address.town" value="@form.data.get("personal.address.town")">
         @fragments.forms.errorMessage("This field is required")
     </div>
 </div>
-<div class="form-field js-checkout-postcode">
+<div class="form-field js-checkout-postcode @hasError("personal.address.postcode")">
     <label class="label" for="address-postcode">Postcode</label>
     <input type="text" class="input-text js-input input-text input-text--small" id="address-postcode" name="personal.address.postcode" value="@form.data.get("personal.address.postcode")">
     @fragments.forms.errorMessage("Please enter a valid postal code")

--- a/assets/stylesheets/_vars.scss
+++ b/assets/stylesheets/_vars.scss
@@ -38,6 +38,14 @@ $c-link: guss-colour(guardian-brand);
 $c-link-hover: #6e99b2;
 $c-link-active: guss-colour(news-main-2);
 
+// Messages
+$c-flash-error: #d61d00;
+$c-flash-error-border: #ff998a;
+$c-flash-error-background: #fdf4f3;
+$c-flash-success: #1c6326;
+$c-flash-success-border: #33a22b;
+$c-flash-success-background: #faffe5;
+
 // Layout
 // =============================================================================
 

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -45,6 +45,7 @@
 @import 'modules/apps';
 @import 'modules/forms';
 @import 'modules/forms-password';
+@import 'modules/messages';
 @import 'modules/buttons';
 @import 'modules/packages';
 @import 'modules/checkout';

--- a/assets/stylesheets/modules/_forms.scss
+++ b/assets/stylesheets/modules/_forms.scss
@@ -239,7 +239,9 @@ input[type=number] {
 .form-field--no-margin {
     margin-bottom: 0;
 }
-.form-field--error {
+.form-field--error,
+.form-field:invalid,
+.form-field.has-error {
     .label {
         color: guss-colour(error);
     }

--- a/assets/stylesheets/modules/_messages.scss
+++ b/assets/stylesheets/modules/_messages.scss
@@ -1,0 +1,23 @@
+/* ==========================================================================
+   Messages
+   ========================================================================== */
+
+.flash-message {
+    @include fs-data(4);
+    padding: 7px (($gs-baseline / 3) * 2);
+    border-top: 1px solid;
+    border-bottom: 1px solid;
+    margin: $gs-baseline 0;
+    background-color: $c-neutral6;
+    border-color: $c-neutral2;
+}
+.flash-message--error {
+    background-color: $c-flash-error-background;
+    border-color: $c-flash-error-border;
+    color: $c-flash-error;
+}
+.flash-message--success {
+    background-color: $c-flash-success-background;
+    border-color: $c-flash-success-border;
+    color: $c-flash-success;
+}


### PR DESCRIPTION
It was bugging me that we don't handle form errors server-side. This PR updates the checkout form to render-with errors if there is an issue.

**Warning** I've just Play documentation copy-pasted and IntelliJ autocompleted my way to a solution for this. I'm sure there is a more idiomatic way to do this; but it was a useful learning experiment trying this.

I'm also aware that Play has a bunch of form helpers so I'm probably repeating some things, but as we're not using them anywhere it felt OK to follow suit and keep the error class handling manual.

![screen shot 2015-08-14 at 14 43 26](https://cloud.githubusercontent.com/assets/123386/9275230/91743c88-4293-11e5-994e-b56d78271112.png)

@afiore 