### PR TITLE
Use new Flat Fee product in UAT

### DIFF
--- a/conf/touchpoint.UAT.conf
+++ b/conf/touchpoint.UAT.conf
@@ -20,7 +20,7 @@ touchpoint.backend.environments {
                 username = ""
                 password = ""
             }
-            digital = "2c92c0f84b786da2014b91b3ef267801"
+            digital = "2c92c0f84f2ac59d014f2c8f0f853d09"
         }
     }
 }


### PR DESCRIPTION
Jason's provided us with a new product for the UAT environment:

---------- Forwarded message ----------
From: Jason Burr
Date: 14 August 2015 at 15:32
Subject: Re: Exact Target email sending issues, and Zuora UAT config

Hi Roberto

I have had to create a completely new digital tier with Flat Fee set in UAT

Could you please replace 

Kind regards

Jason


digital = "[2c92c0f84b786da2014b91b3ef267801](https://apisandbox.zuora.com/apps/Product.do?method=view&id=2c92c0f84b786da2014b91b3ef267801)"
       
to

digital = "[2c92c0f84f2ac59d014f2c8f0f853d09](https://apisandbox.zuora.com/apps/Product.do?method=view&id=2c92c0f84f2ac59d014f2c8f0f853d09)"



cc @dominickendrick 