### PR TITLE
Remove "unauthorised access to a checkout page" acceptance test

### DIFF
--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -59,16 +59,4 @@ class CheckoutSpec extends FeatureSpec with WebBrowser with Util with GivenWhenT
       }
     }
   }
-
-  scenario("unauthorised access to a pre-release page", Acceptance) {
-    val checkout = new Checkout
-
-    Given("No QA cookie is set")
-
-    When("I visit the checkout page ")
-    go.to(checkout)
-
-    Then("I should land on the Google Auth page")
-    assertResult("accounts.google.com")(currentHost)
-  }
 }


### PR DESCRIPTION
...because we enabled public access with https://github.com/guardian/subscriptions-frontend/pull/179 (when I should have removed this test)

Just noticed this after finally getting Prout to successfully trigger an acceptance-test build on Travis (for some reason the log is quite mangled, but you can more or less see what's going on):

https://travis-ci.org/guardian/subscriptions-frontend/builds/75621140

Annoyingly, the build is marked as 'green' in Travis, even though there were two failing tests.

@afiore @TesterSpike 