### PR TITLE
Switching to the triggered send api 

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -77,6 +77,6 @@ object Config {
   object ExactTarget {
     val clientId = config.getString("exact-target.client-id")
     val clientSecret = config.getString("exact-target.client-secret")
-    val thankYouDataExtensionKey = config.getString("exact-target.data-extension-keys.thank-you")
+    val welcomeTriggeredSendKey = config.getString("exact-target.triggered-send-keys.welcome")
   }
 }

--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -25,7 +25,8 @@ object SubscriptionDataExtensionRow {
     val paymentData = subscriptionData.paymentData
 
     SubscriptionDataExtensionRow(
-      subscription.name,
+      personalData.email,
+      "ZuoraSubscriberId" -> subscription.name,
       "SubscriberKey" -> personalData.email,
       "EmailAddress" -> personalData.email,
       "Subscription term" -> formatSubscriptionTerm(billingPeriod),
@@ -105,4 +106,4 @@ trait DataExtensionRow {
   def fields: Seq[(String, String)]
 }
 
-case class SubscriptionDataExtensionRow(subscriptionId: String, fields: (String, String)*) extends DataExtensionRow
+case class SubscriptionDataExtensionRow(email: String, fields: (String, String)*) extends DataExtensionRow


### PR DESCRIPTION
This PR moves our exacttarget triggered send integration to using the triggeredSend API.

## QA

- [ ] A succesfull checkout should deliver an email to the email address used.