### PR TITLE
Add security headers as suggested by Pentura

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -3,9 +3,18 @@ import play.filters.csrf.CSRFFilter
 import monitoring.SentryLogging
 import play.api.Application
 import play.api.mvc.WithFilters
+import play.filters.headers.{SecurityHeadersConfig, SecurityHeadersFilter}
 import services.TouchpointBackend
 
-object Global extends WithFilters(CheckCacheHeadersFilter, CSRFFilter(), AddEC2InstanceHeader) {
+object Global extends WithFilters(
+  CheckCacheHeadersFilter,
+  SecurityHeadersFilter(SecurityHeadersConfig(
+    frameOptions=Some("SAME-ORIGIN"),
+    permittedCrossDomainPolicies = None,
+    contentSecurityPolicy = None
+  )),
+  CSRFFilter(),
+  AddEC2InstanceHeader) {
   override def onStart(app: Application) {
     SentryLogging.init()
     TouchpointBackend.All.foreach(_.start())


### PR DESCRIPTION
These 3 headers are added by this config:

```
$ curl --silent --insecure -I https://sub.thegulocal.com/ | grep X-
X-Frame-Options: SAME-ORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
```

This is how the headers relate to the Penture report:

X-XSS-Protection: Finding 1.1
X-Frame-Options: Finding 1.3
X-Content-Type-Options: Not mentioned by Pentura, but a reasonable addition


https://www.playframework.com/documentation/2.4.x/SecurityHeaders

I chose to just directly configure the SecurityHeadersFilter through a case class, rather than muck around with the config file.

I chose to not enable the `permittedCrossDomainPolicies` and `contentSecurityPolicy` headers because I wasn't sure how those would interact with analytics, tracking etc.

@vivekkr @davidrapson @blackyjnz 