### PR TITLE
Fix Play session-cookie config so that the cookie is marked Secure

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -15,7 +15,7 @@ play.crypto.secret="Is]F;gOuRS]X[eTv4j9k;_jC3Tc>2Xv<D_On/CRr/MBoJAM5yBB_w2Fp]1c7
 application.langs="en"
 
 # Enable cookie-based session for HTTPS only
-application.session.secure=true
+play.http.session.secure=true
 
 google.oauth {
   // https://console.developers.google.com/project/guardian-subscriptions/apiui/credential?authuser=1


### PR DESCRIPTION
Play changed their config format with Play v2.4, and our old setting became ineffective:

https://www.playframework.com/documentation/2.4.x/Migration24#Configuration-changes

You can check the reference config here:

https://github.com/playframework/playframework/blob/2.4.2/framework/src/play/src/main/resources/reference.conf#L85-L91

With this setting, the cookie will *only* be transmitted on HTTPS connections:

```
$ curl --silent -I https://subscribe.theguardian.com/checkout | grep PLAY_SESSION
Set-Cookie: PLAY_SESSION=...; Path=/; HTTPOnly
```

```
$ curl --silent -I --insecure https://sub.thegulocal.com/checkout | grep PLAY_SESSION
Set-Cookie: PLAY_SESSION=...; Path=/; Secure; HTTPOnly
```

This corresponds to Pentura Finding 1.6. See also #199 for the security-related HTTP response headers

cc @blackyjnz @vivekkr 