### PR TITLE
Add bank details validation

### DIFF
--- a/app/services/GocardlessService.scala
+++ b/app/services/GocardlessService.scala
@@ -1,5 +1,7 @@
 package services
 
+import com.gocardless.errors.GoCardlessApiException
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import model.PaymentData
 
@@ -8,9 +10,10 @@ import scala.concurrent.Future
 
 trait GoCardlessService {
   def mandatePDFUrl(paymentData: PaymentData): Future[String]
+  def checkBankDetails(paymentData: PaymentData): Future[Boolean]
 }
 
-object GoCardlessService extends GoCardlessService {
+object GoCardlessService extends GoCardlessService with LazyLogging {
   lazy val client = Config.GoCardless.client
 
   override def mandatePDFUrl(paymentData: PaymentData): Future[String] =
@@ -23,4 +26,19 @@ object GoCardlessService extends GoCardlessService {
         .execute()
         .getUrl
     }
+
+  override def checkBankDetails(paymentData: PaymentData): Future[Boolean] = {
+    val sortCode = paymentData.sortCode.replaceAllLiterally("-", "")
+
+    Future {
+      client.bankDetailsLookups().create()
+        .withAccountNumber(paymentData.account)
+        .withBranchCode(sortCode)
+        .withCountryCode("GB")
+        .execute()
+      true
+    } recover { case e: GoCardlessApiException =>
+      false
+    }
+  }
 }

--- a/app/views/fragments/checkout/fieldsPayment.scala.html
+++ b/app/views/fragments/checkout/fieldsPayment.scala.html
@@ -5,7 +5,7 @@
     <label class="label" for="payment-account">Bank account number</label>
     <input type="text" class="input-text js-input" id="payment-account"
         name="payment.account" pattern="[0-9]*" minlength="6" maxlength="10" required>
-    @fragments.forms.errorMessage("Please enter between 6 and 10 digits for the account number")
+    @fragments.forms.errorMessage("Please enter between 6 and 10 digits for the account number, and make sure the account is valid")
 </div>
 
 @* ===== Sortcode ===== *@

--- a/assets/javascripts/modules/checkout/paymentDetails.js
+++ b/assets/javascripts/modules/checkout/paymentDetails.js
@@ -20,6 +20,7 @@ define([
 
     function displayErrors(validity) {
         toggleError(formEls.$ACCOUNT_CONTAINER, !validity.accountNumberValid);
+        toggleError(formEls.$ACCOUNT_CONTAINER, !validity.accountValid);
         toggleError(formEls.$HOLDER_CONTAINER, !validity.accountHolderNameValid);
         toggleError(formEls.$SORTCODE_CONTAINER, !validity.sortCodeValid);
         toggleError(formEls.$CONFIRM_PAYMENT_CONTAINER, !validity.detailsConfirmedValid);
@@ -37,16 +38,19 @@ define([
     }
 
     function handleValidation() {
-        var validity = validatePayment({
+        validatePayment({
             accountNumber: formEls.$ACCOUNT.val(),
             accountHolderName: formEls.$HOLDER.val(),
             sortCode: formEls.$SORTCODE.val(),
             detailsConfirmed: formEls.$CONFIRM_PAYMENT[0].checked
+        }).then(function(validity){
+            if (validity.allValid) {
+                nextStep();
+            } else {
+                console.log(validity);
+                displayErrors(validity);
+            }
         });
-        displayErrors(validity);
-        if(validity.allValid) {
-            nextStep();
-        }
     }
 
     function init() {

--- a/assets/javascripts/modules/checkout/paymentDetails.js
+++ b/assets/javascripts/modules/checkout/paymentDetails.js
@@ -47,7 +47,6 @@ define([
             if (validity.allValid) {
                 nextStep();
             } else {
-                console.log(validity);
                 displayErrors(validity);
             }
         });

--- a/assets/javascripts/modules/checkout/validatePaymentFormat.js
+++ b/assets/javascripts/modules/checkout/validatePaymentFormat.js
@@ -1,0 +1,37 @@
+define(['modules/forms/regex'], function (regex) {
+    'use strict';
+
+    return function (data) {
+
+        var validity = {};
+
+        validity.accountNumberValid = (
+            data.accountNumber !== '' &&
+            data.accountNumber.length >= 6 &&
+            data.accountNumber.length <= 10 &&
+            regex.isNumber(data.accountNumber)
+        );
+
+        validity.accountHolderNameValid = (
+            data.accountHolderName !== '' &&
+            data.accountHolderName.length <= 18
+        );
+
+        validity.sortCodeValid = data.sortCode && (data.sortCode.split('-')).filter(function(code) {
+            var codeAsNumber = parseInt(code, 10);
+            return codeAsNumber >= 0 && codeAsNumber <= 99;
+        }).length === 3;
+
+        validity.detailsConfirmedValid = data.detailsConfirmed;
+
+        validity.allValid = (
+            validity.accountNumberValid &&
+            validity.accountHolderNameValid &&
+            validity.sortCodeValid &&
+            validity.detailsConfirmedValid
+        );
+
+        return validity;
+    };
+
+});

--- a/conf/routes
+++ b/conf/routes
@@ -25,6 +25,7 @@ GET         /au/digital                      controllers.DigitalPack.au
 GET         /checkout                        controllers.Checkout.renderCheckout
 POST        /checkout                        controllers.Checkout.handleCheckout
 GET         /checkout/check-identity         controllers.Checkout.checkIdentity(email: String)
+POST        /checkout/check-account          controllers.Checkout.checkAccount
 POST        /checkout/register-guest-user    controllers.Checkout.processFinishAccount
 
 # collection and delivery

--- a/test/acceptance/Util.scala
+++ b/test/acceptance/Util.scala
@@ -36,7 +36,7 @@ trait Util { this: WebBrowser =>
   }
 
   protected def pageHasElement(q: Query, timeoutSecs: Int=50): Boolean = {
-    val pred = ExpectedConditions.presenceOfElementLocated(q.by)
+    val pred = ExpectedConditions.visibilityOfElementLocated(q.by)
     Try {
       new WebDriverWait(driver, timeoutSecs).until(pred)
     }.isSuccess

--- a/test/acceptance/pages/Checkout.scala
+++ b/test/acceptance/pages/Checkout.scala
@@ -77,7 +77,9 @@ class Checkout(implicit val driver: WebDriver) extends Page with WebBrowser with
   }
 
   def submit(): Unit = {
+    val selector = cssSelector( """input[type="submit"]""")
+    assert(pageHasElement(selector))
     PersonalDetails.receiveGnmMarketing.select()
-    click.on(cssSelector("""input[type="submit"]"""))
+    click.on(selector)
   }
 }

--- a/test/js/spec/modules/checkout/validatePaymentFormat.spec.js
+++ b/test/js/spec/modules/checkout/validatePaymentFormat.spec.js
@@ -1,6 +1,6 @@
-define(['modules/checkout/validatePayment'], function (validatePayment) {
+define(['modules/checkout/validatePaymentFormat'], function (validatePaymentFormat) {
 
-    describe('#validatePayment', function () {
+    describe('#validatePaymentFormat', function () {
 
         it('should validate account number', function () {
 
@@ -29,10 +29,10 @@ define(['modules/checkout/validatePayment'], function (validatePayment) {
                 detailsConfirmed: false
             };
 
-            expect((validatePayment(tooShort)).accountNumberValid).toBe(false);
-            expect((validatePayment(tooLong)).accountNumberValid).toBe(false);
-            expect((validatePayment(justRightLow)).accountNumberValid).toBe(true);
-            expect((validatePayment(justRightHigh)).accountNumberValid).toBe(true);
+            expect((validatePaymentFormat(tooShort)).accountNumberValid).toBe(false);
+            expect((validatePaymentFormat(tooLong)).accountNumberValid).toBe(false);
+            expect((validatePaymentFormat(justRightLow)).accountNumberValid).toBe(true);
+            expect((validatePaymentFormat(justRightHigh)).accountNumberValid).toBe(true);
         });
 
         it('should validate account holder name', function () {
@@ -48,8 +48,8 @@ define(['modules/checkout/validatePayment'], function (validatePayment) {
                 sortCode: null,
                 detailsConfirmed: false
             };
-            expect((validatePayment(tooLong)).accountHolderNameValid).toBe(false);
-            expect((validatePayment(valid)).accountHolderNameValid).toBe(true);
+            expect((validatePaymentFormat(tooLong)).accountHolderNameValid).toBe(false);
+            expect((validatePaymentFormat(valid)).accountHolderNameValid).toBe(true);
         });
 
         it('should validate sort code', function () {
@@ -73,22 +73,22 @@ define(['modules/checkout/validatePayment'], function (validatePayment) {
                 detailsConfirmed: false
             };
 
-            expect((validatePayment(tooShort)).sortCodeValid).toBe(false);
-            expect((validatePayment(tooLong)).sortCodeValid).toBe(false);
-            expect((validatePayment(justRight)).sortCodeValid).toBe(true);
+            expect((validatePaymentFormat(tooShort)).sortCodeValid).toBe(false);
+            expect((validatePaymentFormat(tooLong)).sortCodeValid).toBe(false);
+            expect((validatePaymentFormat(justRight)).sortCodeValid).toBe(true);
 
         });
 
         it('should validate all details', function () {
 
-            var valid = validatePayment({
+            var valid = validatePaymentFormat({
                 accountNumber: '12346789',
                 accountHolderName: 'Example Name',
                 sortCode: '01-01-01',
                 detailsConfirmed: true
             });
 
-            var invalid = validatePayment({
+            var invalid = validatePaymentFormat({
                 accountNumber: '12346789',
                 accountHolderName: 'This name is longer than 18 characters',
                 sortCode: '01-01-0100',


### PR DESCRIPTION
See ticket:  https://trello.com/c/kIvgLKlv/128-better-user-experience-when-zuora-checkout-transaction-fails

This does an Ajax check between the payment details input and the confirmation. It uses GoCardless API to do the check.

The error message is displayed in relation to the account number field. The error for this field is generic, whether it is due to wrong formatting or invalid account.

![image](https://cloud.githubusercontent.com/assets/1781471/9524126/1aaca2b0-4cd5-11e5-9f44-c87a768e8460.png)

