### PR TITLE
Updating date formatting

### DIFF
--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -52,7 +52,7 @@ object SubscriptionDataExtensionRow {
       "Email" -> personalData.email
     )
   }
-  
+
   private def formatDate(dateTime: DateTime) = {
     val day = dateTime.dayOfMonth.get
 

--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -4,6 +4,7 @@ import com.gu.membership.zuora.soap.Zuora._
 import model.SubscriptionData
 import org.joda.time.DateTime
 import scala.math.BigDecimal.decimal
+import utils.Dates
 
 object SubscriptionDataExtensionRow {
   def apply(
@@ -51,20 +52,17 @@ object SubscriptionDataExtensionRow {
       "Email" -> personalData.email
     )
   }
-
+  
   private def formatDate(dateTime: DateTime) = {
-    val day = dateTime.dayOfMonth.getAsString
-    val daySuffix = day.last match {
-      case '1' => "st"
-      case '2' => "nd"
-      case '3' => "rd"
-      case _   => "th"
-    }
+    val day = dateTime.dayOfMonth.get
+
+    val dayWithSuffix = Dates.getOrdinalDay(day)
+
     val month = dateTime.monthOfYear.getAsText
 
     val year = dateTime.year.getAsString
 
-    s"$day$daySuffix $month $year"
+    s"$dayWithSuffix $month $year"
   }
 
   private def formatPrice(price: Float): String = {

--- a/app/utils/Dates.scala
+++ b/app/utils/Dates.scala
@@ -1,0 +1,16 @@
+package utils
+
+object Dates {
+  def getOrdinalDay(day: Int): String = {
+    val last = day % 10
+
+    val suffix = day match {
+      case teens if 11 to 13 contains teens => "th"
+      case x if last equals 1 => "st"
+      case x if last equals 2 => "nd"
+      case x if last equals 3 => "rd"
+      case _ => "th"
+    }
+    s"$day$suffix"
+  }
+}

--- a/app/utils/Dates.scala
+++ b/app/utils/Dates.scala
@@ -1,16 +1,20 @@
 package utils
 
 object Dates {
-  def getOrdinalDay(day: Int): String = {
-    val last = day % 10
-
-    val suffix = day match {
-      case teens if 11 to 13 contains teens => "th"
-      case x if last equals 1 => "st"
-      case x if last equals 2 => "nd"
-      case x if last equals 3 => "rd"
-      case _ => "th"
-    }
+  
+  def getOrdinalDay(day: Int):String = {
+    val suffix = daySuffix(day)
     s"$day$suffix"
   }
+
+  def daySuffix(day: Int):String = day match {
+    case 11 | 12 | 13 => "th"
+    case _ => day % 10 match {
+      case 1 => "st"
+      case 2 => "nd"
+      case 3 => "rd"
+      case _ => "th"
+    }
+  }
+
 }

--- a/test/acceptance/DatesSpec.scala
+++ b/test/acceptance/DatesSpec.scala
@@ -1,0 +1,19 @@
+package acceptance
+
+import org.scalatest.FeatureSpec
+import utils.Dates
+
+class DatesSpec extends FeatureSpec {
+  feature("Date Formatters") {
+    scenario("Ordinal day formatting", Acceptance) {
+      assert(Dates.getOrdinalDay(11) == "11th")
+      assert(Dates.getOrdinalDay(12) == "12th")
+      assert(Dates.getOrdinalDay(13) == "13th")
+      assert(Dates.getOrdinalDay(21) == "21st")
+      assert(Dates.getOrdinalDay(7) == "7th")
+      assert(Dates.getOrdinalDay(1) == "1st")
+      assert(Dates.getOrdinalDay(2) == "2nd")
+      assert(Dates.getOrdinalDay(3) == "3rd")
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes a bug in date formatting that renderer `12th` as `12nd`

<img width="486" alt="screen shot 2015-08-28 at 10 38 18" src="https://cloud.githubusercontent.com/assets/1289259/9543451/df7a40f2-4d70-11e5-8879-8fdf6501a0f3.png">