### PR TITLE
Fix checkout page scroll issue between steps

### DIFF
--- a/assets/javascripts/modules/checkout/paymentDetails.js
+++ b/assets/javascripts/modules/checkout/paymentDetails.js
@@ -33,6 +33,9 @@ define([
         formEls.$FIELDSET_REVIEW
             .removeClass(FIELDSET_COLLAPSED);
 
+        formEls.$FIELDSET_YOUR_DETAILS[0]
+            .scrollIntoView();
+
         tracking.paymentDetailsTracking();
     }
 

--- a/assets/javascripts/modules/checkout/personalDetails.js
+++ b/assets/javascripts/modules/checkout/personalDetails.js
@@ -46,12 +46,13 @@ define([
     }
 
     function nextStep() {
-        formEls.$FIELDSET_YOUR_DETAILS
-            .addClass(FIELDSET_COLLAPSED)
-            .addClass(FIELDSET_COMPLETE);
-
         formEls.$FIELDSET_PAYMENT_DETAILS
             .removeClass(FIELDSET_COLLAPSED);
+
+        formEls.$FIELDSET_YOUR_DETAILS
+            .addClass(FIELDSET_COLLAPSED)
+            .addClass(FIELDSET_COMPLETE)[0]
+            .scrollIntoView();
 
         tracking.personalDetailsTracking();
     }


### PR DESCRIPTION
This PR anchors the checkout form panes to the top of the page between steps so you get a more consistent experience.

_Old :_
![subs_checkout_scroll](https://cloud.githubusercontent.com/assets/1289259/9546153/448897e8-4d88-11e5-9223-d5bf4efa324d.gif)
_New :_
Mobile
![subs_checkout_scroll_new_mob](https://cloud.githubusercontent.com/assets/1289259/9546151/446e0e32-4d88-11e5-885b-f047ad8129f9.gif)
Desktop
![subs_checkout_scroll_new](https://cloud.githubusercontent.com/assets/1289259/9546152/447e955e-4d88-11e5-903e-47b76b46e655.gif)



# QA

I've QA'd on IE9 & 11, chrome, nexus 6, iphone 6, ipad air, firefox, safari latest