### PR TITLE
ELB for OSSEC --- CF template change request

### DIFF
--- a/cloud-formation/subscriptions-app.cf.json
+++ b/cloud-formation/subscriptions-app.cf.json
@@ -195,6 +195,12 @@
                     "Interval" : "10",
                     "Timeout" : "5"
                 },
+                "AccessLog": {
+                  "Enabled": true,
+                  "S3BucketName" :  { "Fn::Join" : [ "subscriptions-elb-logs/", [ { "Ref" : "Stage" }, "/AWSLogs/", {"Ref":"AWS::AccountId"}, "/elasticloadbalancing/", { "Ref": "AWS::Region" } ] ] },
+                  "EmitInterval": 60,
+                  "S3BucketPrefix": ""
+                },
                 "ConnectionDrainingPolicy": {
                     "Enabled" : "true",
                     "Timeout" : "60"


### PR DESCRIPTION
Jonathan Westlake (@westy4096) provided this change to support INFOSec requirements.

https://trello.com/c/Xg4wF7IO/114-ossec-will-need-elb-monitoring-to-be-logged-to-an-s3-bucket-so-that-monitoring-can-be-enabled-for-infosec