### PR TITLE
Removed domready from the main script required modules. Side effect i…

### DIFF
--- a/app/views/fragments/javascriptLaterSteps.scala.html
+++ b/app/views/fragments/javascriptLaterSteps.scala.html
@@ -1,5 +1,7 @@
 @import controllers.CachedAssets.hashedPathFor
 
+<script src="@hashedPathFor("javascripts/vendor/ready.js")"></script>
+
 @* Scripts that should be executed after CSS is loaded *@
 <script id="script-curl">
     var curl = {
@@ -16,7 +18,9 @@
     function loadJS(a,b){"use strict";var c=window.document.getElementsByTagName("script")[0],d=window.document.createElement("script");return d.src=a,d.async=!0,c.parentNode.insertBefore(d,c),b&&"function"==typeof b&&(d.onload=b),d}
     (function(isModern) {
         if (isModern) {
-            loadJS('@hashedPathFor("javascripts/main.min.js")');
+            domready(function(){
+                loadJS('@hashedPathFor("javascripts/main.min.js")');
+            });
         }
     })(guardian.isModernBrowser);
 </script>

--- a/assets/javascripts/main.js
+++ b/assets/javascripts/main.js
@@ -10,22 +10,18 @@ require([
     'modules/confirmation',
     'modules/patterns',
     // Add new dependencies ABOVE this
-    'domready',
     'Promise',
     'raven'
-], function(
-    ajax,
-    analytics,
-    toggle,
-    appendAround,
-    optionMirror,
-    password,
-    inputMask,
-    checkout,
-    confirmation,
-    patterns,
-    domready
-) {
+], function (ajax,
+             analytics,
+             toggle,
+             appendAround,
+             optionMirror,
+             password,
+             inputMask,
+             checkout,
+             confirmation,
+             patterns) {
     'use strict';
 
     /**
@@ -34,26 +30,24 @@ require([
     /*global Raven */
     Raven.config('https://6dd79da86ec54339b403277d8baac7c8@app.getsentry.com/47380', {
         whitelistUrls: ['subscribe.theguardian.com/assets/'],
-        tags: { build_number: guardian.buildNumber }
+        tags: {build_number: guardian.buildNumber}
     }).install();
 
 
-    domready(function() {
-        ajax.init({page: {ajaxUrl: ''}});
+    ajax.init({page: {ajaxUrl: ''}});
 
-        analytics.init();
+    analytics.init();
 
-        toggle.init();
-        optionMirror.init();
-        appendAround.init();
-        password.init();
+    toggle.init();
+    optionMirror.init();
+    appendAround.init();
+    password.init();
 
-        inputMask.init();
-        checkout.init();
-        confirmation.init();
+    inputMask.init();
+    checkout.init();
+    confirmation.init();
 
-        // Pattern library
-        patterns.init();
-    });
+    // Pattern library
+    patterns.init();
 
 });

--- a/assets/javascripts/vendor/ready.js
+++ b/assets/javascripts/vendor/ready.js
@@ -1,0 +1,4 @@
+/*!
+  * domready (c) Dustin Diaz 2014 - License MIT
+  */
+!function(e,t){typeof module!="undefined"?module.exports=t():typeof define=="function"&&typeof define.amd=="object"?define(t):this[e]=t()}("domready",function(){var e=[],t,n=document,r=n.documentElement.doScroll,i="DOMContentLoaded",s=(r?/^loaded|^c/:/^loaded|^i|^c/).test(n.readyState);return s||n.addEventListener(i,t=function(){n.removeEventListener(i,t),s=1;while(t=e.shift())t()}),function(t){s?setTimeout(t,0):e.push(t)}})


### PR DESCRIPTION
…s that domready is global but main script loadeder for cut the mustard script will only load when dom is ready for it.

Note this is due to the fact that the pull request from https://github.com/guardian/subscriptions-frontend/pull/205 will not fix the issue found in trello https://trello.com/c/jSUOXoK3/152-continue-button-on-checkout-page-does-not-open-payment-details this willl

#QA 
- [ ] Load the checkout page, hitting the continue button should cause a validation error, NOT just anchor you to the link in the page
