### PR TITLE
Correct X-Frame-Options value

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -8,7 +8,7 @@ import play.filters.headers.{SecurityHeadersConfig, SecurityHeadersFilter}
 object Global extends WithFilters(
   CheckCacheHeadersFilter,
   SecurityHeadersFilter(SecurityHeadersConfig(
-    frameOptions=Some("SAME-ORIGIN"),
+    frameOptions=Some("SAMEORIGIN"),
     permittedCrossDomainPolicies = None,
     contentSecurityPolicy = None
   )),


### PR DESCRIPTION
Minor correction to https://github.com/guardian/subscriptions-frontend/pull/199, the `X-Frame-Options` header value should be  `SAMEORIGIN` not `SAME-ORIGIN`

@rtyley 