### PR TITLE
Acceptance tests exit code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,17 @@ testOptions in Test ++= Seq(
   Tests.Argument("-oFD") // display full stack errors and execution times in Scalatest output
 )
 
+testResultLogger in Test := new TestResultLogger {
+  import sbt.Tests._
+
+  def run(log: Logger, results: Output, taskName: String): Unit = {
+    results.overall match {
+      case TestResult.Error | TestResult.Failed => sys.exit(1)
+      case _ =>
+    }
+  }
+}
+
 javaOptions in Test += "-Dconfig.file=test/conf/application.conf"
 
 resolvers ++= Seq(

--- a/test/acceptance/DatesSpec.scala
+++ b/test/acceptance/DatesSpec.scala
@@ -5,7 +5,7 @@ import utils.Dates
 
 class DatesSpec extends FeatureSpec {
   feature("Date Formatters") {
-    scenario("Ordinal day formatting", Acceptance) {
+    scenario("Ordinal day formatting") {
       assert(Dates.getOrdinalDay(11) == "11th")
       assert(Dates.getOrdinalDay(12) == "12th")
       assert(Dates.getOrdinalDay(13) == "13th")

--- a/test/utils/DatesSpec.scala
+++ b/test/utils/DatesSpec.scala
@@ -1,11 +1,10 @@
-package acceptance
+package utils
 
-import org.scalatest.FeatureSpec
-import utils.Dates
+import org.scalatest.FreeSpec
 
-class DatesSpec extends FeatureSpec {
-  feature("Date Formatters") {
-    scenario("Ordinal day formatting") {
+class DatesSpec extends FreeSpec {
+  "Date Formatters" - {
+    "Ordinal day formatting" in {
       assert(Dates.getOrdinalDay(11) == "11th")
       assert(Dates.getOrdinalDay(12) == "12th")
       assert(Dates.getOrdinalDay(13) == "13th")


### PR DESCRIPTION
Ensure acceptance tests exit with the correct process exit code. It uses Sbt's  [TestResultLogger](http://www.scala-sbt.org/0.13.7/api/index.html#sbt.TestResultLogger) class to fetch the suite execution outcome and set exit code accordingly. This is required in order for TravisCI to report correctly

@ostapneko @rtyley 