### PR TITLE
Add clarification to post-subs purchase "Register for an account"

### DIFF
--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -45,7 +45,7 @@
 
                 <h3 class="section-divider">Register for an account</h3>
                 <div class="prose prose--full">
-                    <p>Some features of your subscription require you to be signed in before you can make use of them.</p>
+                    <p>Some features of your subscription require you to be signed in to theguardian.com before you can make use of them.</p>
                 </div>
 
                 <form action="@routes.Checkout.processFinishAccount" method="POST" class="form js-finish-account" autocomplete="off">


### PR DESCRIPTION
This was requested by Gill Crew on the subs team - to make it clearer to the user what is that they are signing in _to_.

I haven't made the text of 'theguardian.com' a link, because I fear that would lead users away from completing the password entry.

**Before**

![image](https://cloud.githubusercontent.com/assets/52038/9760554/063bab0a-56ee-11e5-945c-38b77026d5b8.png)

**After**

![image](https://cloud.githubusercontent.com/assets/52038/9760573/2d966686-56ee-11e5-901b-10dce23c09ea.png)


cc @davidmcdowell @davidrapson 


> ---------- Forwarded message ----------
> From: Suzanne O'Brien
> Date: 7 September 2015 at 11:00
> Subject: Text Update - nice to have but not a blocker
> 
> ...
> 
> secondly - Gill has requested an small update to the wording used under Register for an account and would like the link to the guardian to be included.
> 
> Think it might be useful to mention theguardian.com in there somewhere there's no mention of where they are actually creating an account for. Would it be possible to change the copy to read:
> 
> Some features of your subscription require you to be signed in to theguardian.com before you can make use of them.

https://trello.com/c/LvOwH2B3/157-small-update-to-the-wording-on-the-thank-you-page