### PR TITLE
Disable Analytics for Test Users

### DIFF
--- a/app/controllers/Testing.scala
+++ b/app/controllers/Testing.scala
@@ -2,20 +2,28 @@ package controllers
 
 import actions.CommonActions._
 import com.typesafe.scalalogging.LazyLogging
+import controllers._
 import play.api.mvc.{Controller, Cookie}
 import utils.TestUsers.testUsers
 
 object Testing extends Controller with LazyLogging {
+
+  val AnalyticsCookieName = "ANALYTICS_OFF_KEY"
+
+  val analyticsOffCookie = Cookie(AnalyticsCookieName, "true", httpOnly = false)
 
   val PreSigninTestCookieName = "pre-signin-test-user"
 
   def testUser = GoogleAuthenticatedStaffAction { implicit request =>
 
     val testUserString = testUsers.generate()
-
     logger.info(s"Generated test user string $testUserString")
-
     val testUserCookie = new Cookie(PreSigninTestCookieName, testUserString, Some(30 * 60), httpOnly = true)
-    Ok(views.html.testing.testUsers(testUserString)).withCookies(testUserCookie)
+    Ok(views.html.testing.testUsers(testUserString)).withCookies(testUserCookie, analyticsOffCookie)
   }
+
+  def analyticsOff = CachedAction {
+    Ok(s"${analyticsOffCookie.name} cookie dropped").withCookies(analyticsOffCookie)
+  }
+
 }


### PR DESCRIPTION
Disable Analytics for Test Users by dropping a Cookie ANALYTICS_OFF_KEY. It seems to work only on the Second Request to https://sub.thegulocal.com/test-users# after the PLAY_SESSION Cookie is set

The JS changes were made as part of this commit

https://github.com/guardian/subscriptions-frontend/commit/8a187ad4abb8782fcb251b207f094e4f18cf8616

@davidrapson 