### PR TITLE
Simplify JavaScript loading

### DIFF
--- a/app/views/fragments/footerJavaScript.scala.html
+++ b/app/views/fragments/footerJavaScript.scala.html
@@ -1,0 +1,12 @@
+@import controllers.CachedAssets.hashedPathFor
+
+<script id="script-main">
+    /* Only load JS if the browser cuts the mustard */
+    (function(isModern) {
+        if (isModern) {
+            var s = document.createElement('script');
+            s.src = '@hashedPathFor("javascripts/main.min.js")'; s.async = true;
+            document.getElementsByTagName("head")[0].appendChild(s);
+        }
+    })(guardian.isModernBrowser);
+</script>

--- a/app/views/fragments/javascriptLaterSteps.scala.html
+++ b/app/views/fragments/javascriptLaterSteps.scala.html
@@ -1,7 +1,5 @@
 @import controllers.CachedAssets.hashedPathFor
 
-<script src="@hashedPathFor("javascripts/vendor/ready.js")"></script>
-
 @* Scripts that should be executed after CSS is loaded *@
 <script id="script-curl">
     var curl = {
@@ -13,14 +11,3 @@
     };
 </script>
 <script src="@hashedPathFor("javascripts/vendor/curl.js")"></script>
-<script id="script-main">
-    // Only load JS if the browser cuts the mustard
-    function loadJS(a,b){"use strict";var c=window.document.getElementsByTagName("script")[0],d=window.document.createElement("script");return d.src=a,d.async=!0,c.parentNode.insertBefore(d,c),b&&"function"==typeof b&&(d.onload=b),d}
-    (function(isModern) {
-        if (isModern) {
-            domready(function(){
-                loadJS('@hashedPathFor("javascripts/main.min.js")');
-            });
-        }
-    })(guardian.isModernBrowser);
-</script>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -36,5 +36,6 @@
         </div>
 
         @fragments.global.footer(isInternational)
+        @fragments.footerJavaScript()
     </body>
 </html>


### PR DESCRIPTION
This is a slightly simpler approach for the temporary fix in https://github.com/guardian/subscriptions-frontend/pull/209

The reason the original issue happened was because we loaded are main JS in the `<head>`, meaning that the DOM might not be ready in time for our App to have everything it needs.

The solution at the time was to use `domReady`, which does the job but has a couple of side-effects a) required another blocking script call and b) is side-stepping the issue slightly.

Slightly simpler approach is to move the call to `main.js` to the footer (what we do on Membership), by doing this we avoid the issues with DOM readiness.

@chrisjowen @dominickendrick 