### PR TITLE
Upgrade zxcvbn to 3.5

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,10 +55,10 @@ module.exports = function(grunt) {
                 expand: true
             },
             zxcvbn: {
-              cwd: '<%= dirs.assets.javascripts %>/bower_components/zxcvbn',
-              src: ['zxcvbn.js'],
+              src: '<%= dirs.assets.javascripts %>/bower_components/zxcvbn/dist/zxcvbn.js',
               dest: '<%= dirs.public.javascripts %>/vendor',
-              expand: true
+              expand: true,
+              flatten: true
             },
             images: {
                 cwd: '<%= dirs.assets.images %>',

--- a/assets/javascripts/bower.json
+++ b/assets/javascripts/bower.json
@@ -3,13 +3,13 @@
   "dependencies": {
     "bean": "~1.0.6",
     "bonzo": "~2.0.0",
+    "domready": "~1.0.8",
     "lodash-amd": "~3.10.0",
     "promise-polyfill": "~2.1.0",
     "qwery": "~4.0.0",
     "raven-js": "~1.1.16",
     "requirejs": "~2.1.17",
     "reqwest": "~1.1.0",
-    "zxcvbn": "90b7d2908d1305e0ab9f0fe0d983041e546af760",
-    "domready": "~1.0.8"
+    "zxcvbn": "3.5"
   }
 }

--- a/assets/javascripts/modules/password.js
+++ b/assets/javascripts/modules/password.js
@@ -1,4 +1,3 @@
-/*global zxcvbn */
 define(function () {
     'use strict';
 
@@ -23,7 +22,7 @@ define(function () {
         ]
     };
 
-    var checkStrength = function(strengthIndicator, strengthInput) {
+    var checkStrength = function(zxcvbn, strengthIndicator, strengthInput) {
         var score = zxcvbn(strengthInput.value).score;
         var label = CONFIG.text.passwordLabel + ': ' + CONFIG.passwordLabels[score];
         var strengthLabel = document.querySelector(SELECTORS.strengthLabel);
@@ -42,10 +41,10 @@ define(function () {
         }
     };
 
-    var addListeners = function (strengthIndicator, strengthInput) {
+    var addListeners = function (zxcvbn, strengthIndicator, strengthInput) {
         strengthIndicator.classList.toggle(HIDDEN_CLASS);
         strengthInput.addEventListener('keyup', function() {
-            checkStrength(strengthIndicator, strengthInput);
+            checkStrength(zxcvbn, strengthIndicator, strengthInput);
         });
     };
 
@@ -57,8 +56,12 @@ define(function () {
         var strengthInput = document.querySelector(SELECTORS.strengthInput);
 
         if(strengthIndicator && strengthInput) {
-            require(['js!zxcvbn'], function() {
-                addListeners(strengthIndicator, strengthInput);
+            /**
+             * Async load in zxcvbn lib as it is ~700kb!
+             * Loads as an AMD module as of version ~3.5
+             */
+            require(['zxcvbn'], function(zxcvbn) {
+                addListeners(zxcvbn, strengthIndicator, strengthInput);
             });
         }
     };


### PR DESCRIPTION
See: https://github.com/guardian/membership-frontend/pull/766

- Updates to explicit version number now that `zxcvbn` has stabilised a bit with version 3.5. No longer using git hash
- Allows us to use zxcvbn as an AMD module rather than having to load as a global.

@tudorraul @afiore 