### PR TITLE
Sbt exitcode redux

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import play.sbt.PlayImport
 
+import scala.util.Try
+
 name := "subscriptions-frontend"
 
 version := "1.0-SNAPSHOT"
@@ -45,16 +47,7 @@ testOptions in Test ++= Seq(
   Tests.Argument("-oFD") // display full stack errors and execution times in Scalatest output
 )
 
-testResultLogger in Test := new TestResultLogger {
-  import sbt.Tests._
-
-  def run(log: Logger, results: Output, taskName: String): Unit = {
-    results.overall match {
-      case TestResult.Error | TestResult.Failed => sys.exit(1)
-      case _ =>
-    }
-  }
-}
+testResultLogger in Test := new ScalaTestWithExitCode
 
 javaOptions in Test += "-Dconfig.file=test/conf/application.conf"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,5 @@
 import play.sbt.PlayImport
 
-import scala.util.Try
-
 name := "subscriptions-frontend"
 
 version := "1.0-SNAPSHOT"

--- a/project/ScalaTestWithExitcode.scala
+++ b/project/ScalaTestWithExitcode.scala
@@ -1,0 +1,46 @@
+import sbt._
+
+import scala.util.Try
+
+class ScalaTestWithExitCode extends TestResultLogger {
+  import sbt.Tests._
+
+  override def run(log: Logger, results: Output, taskName: String): Unit = {
+    results.overall match {
+      case TestResult.Error | TestResult.Failed => sys.exit(1)
+      case _ =>
+        val summary = findScalatestSummary(results.summaries)
+                        .fold[Map[String, Int]](Map.empty)(parseScalatestSummary)
+
+        if (summary.exists(t => t._1 == "failed" && t._2 > 0))
+          logWarnings(log, results)
+          sys.exit(1)
+    }
+  }
+
+  private def logWarnings(log: Logger, results: Output) = {
+    log.warn("SBT test result doesn't match the test summary provided by ScalaTest:")
+    log.warn(s"results.overall: ${results.overall}")
+    log.warn(s"results.events: ${results.events.values.toList.head}")
+    log.warn(s"results.summaries: ${results.summaries}")
+  }
+
+  private def findScalatestSummary(summaries: Iterable[Summary]): Option[String] = for {
+    scalatestSummary <- summaries.find(_.name == "ScalaTest")
+    lines = scalatestSummary.summaryText.split("\n")
+    line <- lines.find(_.contains("Tests:"))
+  } yield line
+
+  private def parseScalatestSummary(summary: String): Map[String, Int] = {
+    """\[\d\dmTests:""".r.replaceAllIn(summary, "").split(", ")
+      .foldLeft(Map.empty[String, Int]) { case (acc, token) =>
+        token.trim.split(" ") match {
+          case Array(attr, ns) if Try(ns.toInt).isSuccess =>
+            acc + (attr -> ns.toInt)
+          case _ =>
+            acc
+        }
+    }
+  }
+
+}

--- a/project/ScalaTestWithExitcode.scala
+++ b/project/ScalaTestWithExitcode.scala
@@ -12,9 +12,10 @@ class ScalaTestWithExitCode extends TestResultLogger {
         val summary = findScalatestSummary(results.summaries)
                         .fold[Map[String, Int]](Map.empty)(parseScalatestSummary)
 
-        if (summary.exists(t => t._1 == "failed" && t._2 > 0))
+        if (summary.exists(t => t._1 == "failed" && t._2 > 0)) {
           logWarnings(log, results)
           sys.exit(1)
+        }
     }
   }
 


### PR DESCRIPTION
Looks like the test-suite run [Output](https://github.com/sbt/sbt/blob/1.0.x/main/actions/src/main/scala/sbt/Tests.scala#L31) value parsed by sbt and passed on to `TestResultLogger` is not always correct, and might not match the string-based report produced by the underlying test framework. If Sbt fails to detect an error, we manually parse the string returned by the test framework (scalatest) and use that information to decide whether we should set set an non-zero exit code and mark the build as failed. 