### PR TITLE
Add google-site-verification to take control of Google Webmaster Tools

### DIFF
--- a/app/views/fragments/head.scala.html
+++ b/app/views/fragments/head.scala.html
@@ -7,6 +7,7 @@
 
 <title>@title</title>
 
+<meta name="google-site-verification" content="qf7V0ceP_mY_0jTl7R7C1wZSKn2gK7TlharWVLr8Ea0" />
 <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="format-detection" content="telephone=no">


### PR DESCRIPTION
This will 'take ownership' of https://subscribe.theguardian.com in Google Webmaster Tools. I believe we need this in order to allow our Guardian YouTube channels to link to https://subscribe.theguardian.com as an 'Associated website'.

> "Associates are people or accounts that can act on behalf of your site. Unlike site owners and users, associates can't view site data or take any site actions in Search Console, but they are authorized to perform other tasks."

https://support.google.com/webmasters/answer/2368830
https://support.google.com/webmasters/answer/2451999
http://www.dailytechtuts.com/2607/add-website-blog-to-youtube/

https://www.google.com/webmasters/verification/verification?...

Note that this matches the verification code added to Membership with https://github.com/guardian/membership-frontend/commit/0235d75

cc @davidrapson 