### PR TITLE
fix omniture inconsistencies

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -43,7 +43,7 @@
                         Change payment frequency
                     </button>
                 </div>
-                <fieldset class="basket-billing-options is-hidden js-option-mirror-group" id="change-payment-frequency">
+                <fieldset class="basket-billing-options is-hidden js-payment-frequency js-option-mirror-group" id="change-payment-frequency">
                     @products.find(_.frequency == BillingFrequency.Month).map { product =>
                         @priceOption(product, "every month", product.frequency.numberOfMonths, isChecked=true)
                     }

--- a/app/views/fragments/checkout/reviewPanel.scala.html
+++ b/app/views/fragments/checkout/reviewPanel.scala.html
@@ -3,13 +3,12 @@
 
 @(subscriptionId: String, subscriptionProduct: SubscriptionProduct)
 
-<div class="review-panel">
-    <input
-    type="hidden" name="subscriptionDetails"
-    class="js-payment-frequency"
-    data-amount="@subscriptionProduct.price.pretty"
-    data-number-of-months="@subscriptionProduct.frequency.numberOfMonths"
-    >
+<div class="review-panel js-payment-frequency">
+    <input type="checkbox" name="subscriptionDetails"
+           checked="checked"
+           class="u-h"
+           data-amount="@subscriptionProduct.price.pretty"
+           data-number-of-months="@subscriptionProduct.frequency.numberOfMonths">
     <div class="review-panel__item">
         <h4 class="review-panel__label">Subscriber ID:</h4>
         <div class="review-panel__details">

--- a/assets/javascripts/modules/analytics/omniture.js
+++ b/assets/javascripts/modules/analytics/omniture.js
@@ -15,11 +15,7 @@ define([
             if (prop17) {
                 s.prop17 = prop17;
                 s.pageName = pageName;
-            }
-            if (products) {
                 s.products = products;
-            }
-            if (prop17 || products) {
                 s.t();
             }
         });
@@ -32,7 +28,7 @@ define([
                     products = domElem.getAttribute('data-tracking-products');
 
                 bean.on(domElem, 'click', function () {
-                    sendEvent(prop17, products);
+                    sendEvent(prop17, document.title, products);
                 });
             });
         });

--- a/assets/javascripts/modules/checkout/tracking.js
+++ b/assets/javascripts/modules/checkout/tracking.js
@@ -31,8 +31,9 @@ define(['$', 'modules/analytics/omniture'], function ($, omniture) {
 
     function paymentSubmissionTracking(){
         var prop17 = 'GuardianDigiPack:Review and confirm',
-            pageName = 'Payment submission/signup | Digital | Subscriptions | The Guardian';
-        trackEvent(prop17, pageName, 'scCheckout');
+            pageName = 'Payment submission/signup | Digital | Subscriptions | The Guardian',
+            eventName = 'scCheckout';
+        trackEvent(prop17, pageName, eventName);
     }
 
     function subscriptionCompleteTracking(){

--- a/assets/javascripts/modules/checkout/tracking.js
+++ b/assets/javascripts/modules/checkout/tracking.js
@@ -1,35 +1,45 @@
 define(['$', 'modules/analytics/omniture'], function ($, omniture) {
     'use strict';
 
-    function subscriptionProducts(){
+    function subscriptionProducts(eventName){
         var selectedFrequency = $('.js-payment-frequency input:checked');
-        if (selectedFrequency.length) {
+        if (selectedFrequency.length && eventName) {
             var amount = selectedFrequency[0].getAttribute('data-amount'),
                 qty = selectedFrequency[0].getAttribute('data-number-of-months');
-            return 'Subscriptions and Membership;GUARDIAN_DIGIPACK;' + qty + ';' + amount + ';scOpen';
+            return 'Subscriptions and Membership;GUARDIAN_DIGIPACK;' + qty + ';' + amount + ';' + eventName;
         }
-        return false;
+        return undefined;
     }
 
-    function trackEvent(prop17, pageName) {
-        var products = subscriptionProducts();
+    function trackEvent(prop17, pageName, eventName) {
+        var products = subscriptionProducts(eventName);
         omniture.sendEvent(prop17, pageName, products);
     }
 
-    function personalDetailsTracking(){
-        trackEvent('GuardianDigiPack:Name and address', 'Details - name and address | Digital | Subscriptions | The Guardian');
+    function personalDetailsTracking() {
+        var prop17 = 'GuardianDigiPack:Name and address',
+            pageName = 'Details - name and address | Digital | Subscriptions | The Guardian',
+            eventName = 'scOpen';
+        trackEvent(prop17, pageName, eventName);
     }
 
     function paymentDetailsTracking(){
-        trackEvent('GuardianDigiPack:Payment Details', 'Details - payment details | Digital | Subscriptions | The Guardian');
+        var prop17 = 'GuardianDigiPack:Payment Details',
+            pageName = 'Details - payment details | Digital | Subscriptions | The Guardian';
+        trackEvent(prop17, pageName);
     }
 
     function paymentSubmissionTracking(){
-        trackEvent('GuardianDigiPack:Review and confirm', 'Payment submission/signup | Digital | Subscriptions | The Guardian');
+        var prop17 = 'GuardianDigiPack:Review and confirm',
+            pageName = 'Payment submission/signup | Digital | Subscriptions | The Guardian';
+        trackEvent(prop17, pageName, 'scCheckout');
     }
 
     function subscriptionCompleteTracking(){
-        trackEvent('GuardianDigiPack:Order Complete', 'Confirmation | Digital | Subscriptions | The Guardian');
+        var prop17 = 'GuardianDigiPack:Order Complete',
+            pageName = 'Confirmation | Digital | Subscriptions | The Guardian',
+            eventName = 'purchase';
+        trackEvent(prop17, pageName, eventName);
     }
 
     return {


### PR DESCRIPTION
fix for https://github.com/guardian/subscriptions-frontend/issues/234

- `pageName` contained `products` data on country selection page
- `products` data not populated on checkout and confirmation pages