### PR TITLE
Link tracking between new subs site and QSS

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -5,6 +5,7 @@ import com.gu.identity.play.IdUser
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config.Identity.webAppProfileUrl
 import forms.{FinishAccountForm, SubscriptionsForm}
+import model.zuora.BillingFrequency
 import model.{PaymentData, SubscriptionData, SubscriptionRequestData}
 import play.api.data.Form
 import play.api.libs.json._
@@ -50,8 +51,9 @@ object Checkout extends Controller with LazyLogging {
     for {
       filledForm <- fillForm()
       products <- zuoraService.products
+      selectedProduct = products.find(p=> p.frequency==BillingFrequency.Month).get
     } yield {
-      Ok(views.html.checkout.payment(filledForm, userIsSignedIn = authUserOpt.isDefined, products, touchpointBackend))
+      Ok(views.html.checkout.payment(filledForm, userIsSignedIn = authUserOpt.isDefined, products, selectedProduct, touchpointBackend))
     }
   }
 

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -2,7 +2,11 @@
 @import model.JsVars
 @import configuration.Config.Identity._
 
-@(form: Form[model.SubscriptionData], userIsSignedIn: Boolean, products: Seq[SubscriptionProduct], touchpointBackendResolution: services.TouchpointBackend.Resolution)(implicit request: RequestHeader)
+@(form: Form[model.SubscriptionData],
+    userIsSignedIn: Boolean,
+    products: Seq[SubscriptionProduct],
+    selectedProduct : SubscriptionProduct,
+    touchpointBackendResolution: services.TouchpointBackend.Resolution)(implicit request: RequestHeader)
 
 @import model.zuora.BillingFrequency
 @import utils.Prices._
@@ -23,12 +27,14 @@
 }
 
 @main(
-    title = "Checkout | Subscriptions | The Guardian",
+    title = "Details - name and address | Subscriptions | The Guardian",
     jsVars = JsVars.default.copy(userIsSignedIn = userIsSignedIn),
     bodyClasses = List("is-wide"),
     touchpointBackendResolutionOpt = Some(touchpointBackendResolution)
 ) {
-<main class="page-container gs-container">
+<main class="page-container gs-container"
+      data-tracking-prop17="GuardianDigiPack:Name and address"
+      data-tracking-products="Subscriptions and Membership;GUARDIAN_DIGIPACK;@{selectedProduct.frequency.numberOfMonths};@{selectedProduct.price};scOpen">
 
     <section class="checkout-container">
         <form class="form js-checkout-form" action="@routes.Checkout.renderCheckout().toString()" method="POST">

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -11,9 +11,12 @@
 @import services.IdentityToken.{paramName => identityTokenParam}
 @import services.UserId.{paramName => userIdParam}
 
-@main("Thank you | Subscriptions | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
+@main("Confirmation | Digital | Subscriptions | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
-<main class="page-container gs-container gs-container--slim">
+<main class="page-container gs-container gs-container--slim"
+data-tracking-prop17="GuardianDigiPack:Order Complete"
+data-tracking-products="Subscriptions and Membership;GUARDIAN_DIGIPACK;@{subscriptionProduct.frequency.numberOfMonths};@{subscriptionProduct.price};purchase">
+>
 
     @fragments.page.header("Thank you for your order", None, List("l-padded"))
 

--- a/app/views/digitalpack/country.scala.html
+++ b/app/views/digitalpack/country.scala.html
@@ -1,8 +1,7 @@
 @(edition: DigitalEdition, subscriptionNumberOfMonths: Int = 1)
 
 @main("Select your country | Digital | Subscriptions | The Guardian", bodyClasses = List("is-wide")) {
-
-<main class="page-container gs-container">
+    <main class="page-container gs-container" data-tracking-prop17="GuardianDigiPack:Select Country" data-tracking-products="Subscriptions and Membership;GUARDIAN_DIGIPACK;@subscriptionNumberOfMonths;@edition.price;prodView">
 
     <section class="checkout-container">
 
@@ -18,10 +17,7 @@
                 <div class="country-select__content">
                     <h3 class="u-pad-bottom">Choose your location</h3>
                     <div class="button-group">
-                        <a class="button button--primary button--large js-checkout-link"
-                           data-tracking
-                           data-tracking-prop17="GuardianDigiPack:Select Country"
-                           data-tracking-products="Subscriptions and Membership;GUARDIAN_DIGIPACK;@subscriptionNumberOfMonths;@edition.price;prodView"
+                        <a class="button button--primary button--large js-checkout-link" data-link-tracking
                            data-previous-href="https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=DGA38&CMP=@edition.cmp"
                            href="@routes.Checkout.renderCheckout()">
                            United Kingdom

--- a/app/views/digitalpack/country.scala.html
+++ b/app/views/digitalpack/country.scala.html
@@ -1,7 +1,9 @@
 @(edition: DigitalEdition, subscriptionNumberOfMonths: Int = 1)
 
 @main("Select your country | Digital | Subscriptions | The Guardian", bodyClasses = List("is-wide")) {
-    <main class="page-container gs-container" data-tracking-prop17="GuardianDigiPack:Select Country" data-tracking-products="Subscriptions and Membership;GUARDIAN_DIGIPACK;@subscriptionNumberOfMonths;@edition.price;prodView">
+    <main class="page-container gs-container"
+          data-tracking-prop17="GuardianDigiPack:Select Country"
+          data-tracking-products="Subscriptions and Membership;GUARDIAN_DIGIPACK;@subscriptionNumberOfMonths;@edition.price;prodView">
 
     <section class="checkout-container">
 

--- a/assets/javascripts/modules/analytics/omniture.js
+++ b/assets/javascripts/modules/analytics/omniture.js
@@ -85,6 +85,6 @@ define([
 
     return {
         init: init,
-        sendEvent: trackEvent
+        trackEvent: trackEvent
     };
 });

--- a/assets/javascripts/modules/analytics/omniture.js
+++ b/assets/javascripts/modules/analytics/omniture.js
@@ -54,10 +54,10 @@ define([
         s.prop42 = 'Subscriber';
         s.prop47 = 'UK';
 
-        var main = $('main')[0];
+        var main = document.querySelector('main');
         if(main) {
             var attributes = [].slice.call(main.attributes);
-            attributes.map(function(attr){
+            attributes.forEach(function(attr){
                 if(attr.name.indexOf('data-tracking-')>-1){
                     var prop = attr.name.replace('data-tracking-','');
                     s[prop] = attr.nodeValue;

--- a/assets/javascripts/modules/analytics/omniture.js
+++ b/assets/javascripts/modules/analytics/omniture.js
@@ -5,10 +5,25 @@ define([
 ], function ($, bean) {
     'use strict';
 
-    var dataTrackingClickableElements = ['a', 'button', 'input'],
-        omniture, s;
+    var omniture, s;
 
-    function sendEvent(prop17, pageName, products) {
+
+    function bindLinkTracking() {
+        $('a[data-link-tracking]').each(function (domElem) {
+            bean.on(domElem, 'click', function () {
+                trackLink($(this).attr('href'));
+            });
+        });
+    }
+
+    function trackLink(link) {
+        omniture = omniture || init();
+        omniture.then(function(){
+            s.tl(true, 'o', link);
+        });
+    }
+
+    function trackEvent(prop17, pageName, products) {
         omniture = omniture || init();
 
         omniture.then(function(){
@@ -18,19 +33,6 @@ define([
                 s.products = products;
                 s.t();
             }
-        });
-    }
-
-    function bindDataTracking() {
-        dataTrackingClickableElements.forEach(function (elem) {
-            $(elem + '[data-tracking]').each(function (domElem) {
-                var prop17 = domElem.getAttribute('data-tracking-prop17'),
-                    products = domElem.getAttribute('data-tracking-products');
-
-                bean.on(domElem, 'click', function () {
-                    sendEvent(prop17, document.title, products);
-                });
-            });
         });
     }
 
@@ -51,6 +53,18 @@ define([
         s.eVar19 = 'D=c19';
         s.prop42 = 'Subscriber';
         s.prop47 = 'UK';
+
+        var main = $('main')[0];
+        if(main) {
+            var attributes = [].slice.call(main.attributes);
+            attributes.map(function(attr){
+                if(attr.name.indexOf('data-tracking-')>-1){
+                    var prop = attr.name.replace('data-tracking-','');
+                    s[prop] = attr.nodeValue;
+                }
+            });
+        }
+
         s_code = s.t();
 
         if (s_code) {
@@ -58,7 +72,7 @@ define([
             document.write(s_code);
         }
 
-        bindDataTracking();
+        bindLinkTracking();
     }
 
     function init() {
@@ -71,6 +85,6 @@ define([
 
     return {
         init: init,
-        sendEvent: sendEvent
+        sendEvent: trackEvent
     };
 });

--- a/assets/javascripts/modules/checkout/paymentDetails.js
+++ b/assets/javascripts/modules/checkout/paymentDetails.js
@@ -36,7 +36,7 @@ define([
         formEls.$FIELDSET_YOUR_DETAILS[0]
             .scrollIntoView();
 
-        tracking.paymentDetailsTracking();
+        tracking.paymentReviewTracking();
     }
 
     function handleValidation() {

--- a/assets/javascripts/modules/checkout/personalDetails.js
+++ b/assets/javascripts/modules/checkout/personalDetails.js
@@ -54,7 +54,7 @@ define([
             .addClass(FIELDSET_COMPLETE)[0]
             .scrollIntoView();
 
-        tracking.personalDetailsTracking();
+        tracking.paymentDetailsTracking();
     }
 
     function handleValidation(personalDetails) {

--- a/assets/javascripts/modules/checkout/reviewDetails.js
+++ b/assets/javascripts/modules/checkout/reviewDetails.js
@@ -3,15 +3,13 @@ define([
     'utils/ajax',
     'utils/text',
     'modules/forms/loader',
-    'modules/checkout/formElements',
-    'modules/checkout/tracking'
+    'modules/checkout/formElements'
 ], function (
     bean,
     ajax,
     textUtils,
     loader,
-    formEls,
-    tracking
+    formEls
 ) {
     'use strict';
 
@@ -60,9 +58,6 @@ define([
         var submitEl;
         if(formEls.$CHECKOUT_SUBMIT.length) {
             submitEl = formEls.$CHECKOUT_SUBMIT[0];
-            bean.on(submitEl, 'click', function () {
-                tracking.paymentSubmissionTracking();
-            });
 
             var form = formEls.$CHECKOUT_FORM[0];
             form.addEventListener('submit', function() {

--- a/assets/javascripts/modules/checkout/tracking.js
+++ b/assets/javascripts/modules/checkout/tracking.js
@@ -16,38 +16,24 @@ define(['$', 'modules/analytics/omniture'], function ($, omniture) {
         omniture.trackEvent(prop17, pageName, products);
     }
 
-    function personalDetailsTracking() {
-        var prop17 = 'GuardianDigiPack:Name and address',
-            pageName = 'Details - name and address | Digital | Subscriptions | The Guardian',
+    function paymentDetailsTracking(){
+        var prop17 = 'GuardianDigiPack:Payment Details',
+            pageName = 'Details - payment details | Digital | Subscriptions | The Guardian',
             eventName = 'scOpen';
         trackEvent(prop17, pageName, eventName);
     }
 
-    function paymentDetailsTracking(){
-        var prop17 = 'GuardianDigiPack:Payment Details',
-            pageName = 'Details - payment details | Digital | Subscriptions | The Guardian';
-        trackEvent(prop17, pageName);
-    }
-
-    function paymentSubmissionTracking(){
+    function paymentReviewTracking(){
         var prop17 = 'GuardianDigiPack:Review and confirm',
             pageName = 'Payment submission/signup | Digital | Subscriptions | The Guardian',
             eventName = 'scCheckout';
         trackEvent(prop17, pageName, eventName);
     }
 
-    function subscriptionCompleteTracking(){
-        var prop17 = 'GuardianDigiPack:Order Complete',
-            pageName = 'Confirmation | Digital | Subscriptions | The Guardian',
-            eventName = 'purchase';
-        trackEvent(prop17, pageName, eventName);
-    }
 
     return {
-        personalDetailsTracking: personalDetailsTracking,
         paymentDetailsTracking: paymentDetailsTracking,
-        paymentSubmissionTracking: paymentSubmissionTracking,
-        subscriptionCompleteTracking: subscriptionCompleteTracking
+        paymentReviewTracking: paymentReviewTracking
     };
 
 });

--- a/assets/javascripts/modules/checkout/tracking.js
+++ b/assets/javascripts/modules/checkout/tracking.js
@@ -13,7 +13,7 @@ define(['$', 'modules/analytics/omniture'], function ($, omniture) {
 
     function trackEvent(prop17, pageName, eventName) {
         var products = subscriptionProducts(eventName);
-        omniture.sendEvent(prop17, pageName, products);
+        omniture.trackEvent(prop17, pageName, products);
     }
 
     function personalDetailsTracking() {


### PR DESCRIPTION
After investigation there were several problems with out omniture implementation. From the emit point of view we are sending "s.t()" tracking calls to omniture on every page load. This I have determined is a representation (as least in our case) of a page load event. 

Previously when clicking the checkout link we were calling this "s.t()" method twice, once on the click and once again on the page load. What was required was a call to "s.tl()" which means to track a link and to ensure that our page load tracking can contain additional tracking properties if required. 

Update
----------

Unfortunately in order to get accurate link tracking between QSS and the new subs page there were several errors that needed addressing with the current tracking in our checkout page. Namely:

- Country select page needed to broadcast products on load
- Checkout page needed to broadcast products on load (and not after submitting personal details)
- Checkout - Personal details submitted -  We should send the payment details page info, because this represents that the payment details section is open
- Checkout - Payment details submitted - We should sent the confirmation page details
- Checkout - Confirmation details submitted - We should not broadcast anything because this info will be sent on load of the ThankYou page. 
- Thank you - include product information