### PR TITLE
Correct max field lengths

### DIFF
--- a/app/views/fragments/checkout/fieldsPersonal.scala.html
+++ b/app/views/fragments/checkout/fieldsPersonal.scala.html
@@ -5,8 +5,9 @@
 @* ===== Name ===== *@
 <div class="form-field js-checkout-first">
     <label class="label" for="first">First name</label>
+    @* Zuora's PaymentMethod request is the limiting factor for maxlength here *@
     <input type="text" class="input-text js-input" name="personal.first" id="first"
-        value="@form.data.get("personal.first")" maxlength="40" required>
+        value="@form.data.get("personal.first")" maxlength="30" required>
     @fragments.forms.errorMessage("This field is required")
 </div>
 <div class="form-field js-checkout-last">
@@ -37,14 +38,16 @@
 <div class="js-checkout-full-address">
     <div class="form-field js-checkout-house">
         <label class="label" for="address-line-1">Address line 1</label>
+        @* Salesforce accepts up to 255 chars but this field gets concatenated with address line 2 *@
         <input type="text" class="input-text js-input" id="address-line-1" name="personal.address.address1"
-            value="@form.data.get("personal.address.address1")" maxlength="255" required>
+            value="@form.data.get("personal.address.address1")" maxlength="126" required>
         @fragments.forms.errorMessage("This field is required")
     </div>
     <div class="form-field js-checkout-street">
         <label class="label optional-marker" for="address-line-2">Address line 2</label>
+        @* Salesforce accepts up to 255 chars but this field gets concatenated with address line 1 *@
         <input type="text" class="input-text js-input" id="address-line-2" name="personal.address.address2"
-            value="@form.data.get("personal.address.address2")" maxlength="255">
+            value="@form.data.get("personal.address.address2")" maxlength="126">
         @fragments.forms.errorMessage("This field is required")
     </div>
     <div class="form-field js-checkout-town">

--- a/app/views/fragments/checkout/fieldsPersonal.scala.html
+++ b/app/views/fragments/checkout/fieldsPersonal.scala.html
@@ -6,7 +6,7 @@
 <div class="form-field js-checkout-first">
     <label class="label" for="first">First name</label>
     <input type="text" class="input-text js-input" name="personal.first" id="first"
-        value="@form.data.get("personal.first")" maxlength="50" required>
+        value="@form.data.get("personal.first")" maxlength="40" required>
     @fragments.forms.errorMessage("This field is required")
 </div>
 <div class="form-field js-checkout-last">
@@ -20,7 +20,7 @@
 <div class="form-field @if(!userIsSignedIn) {js-checkout-email}">
     <label class="label" for="email">Email address</label>
     <input type="email" class="input-text js-input" name="personal.emailValidation.email" id="email"
-        value="@form.data.get("personal.emailValidation.email")" maxlength="240" @signedInAttrs>
+        value="@form.data.get("personal.emailValidation.email")" maxlength="80" @signedInAttrs>
     @fragments.forms.errorMessage("")
 </div>
 <div class="form-field @if(!userIsSignedIn) {js-checkout-confirm-email}">
@@ -50,7 +50,7 @@
     <div class="form-field js-checkout-town">
         <label class="label" for="address-town">Town/City</label>
         <input type="text" class="input-text js-input" id="address-town" name="personal.address.town"
-            value="@form.data.get("personal.address.town")" maxlength="255" required>
+            value="@form.data.get("personal.address.town")" maxlength="40" required>
         @fragments.forms.errorMessage("This field is required")
     </div>
 </div>


### PR DESCRIPTION
This ensures that for all form fields in subscriptions checkout, the lowest field size limit imposed by any of our third-party services (or our own backend) is enforced by the browser. Here's some info on what the limiting factor is in each case:

**First name:** 30 (Zuora, FirstName in the direct debit PaymentMethod request)
**Last name:** 50 (backend validation in subs)
**Address line 1:** 126 (Salesforce MailingStreet has a 255 limit, but we send address line 1 and 2 concatenated with ', ')
**Address line 2:** 126
**Town:** 40 (Salesforce MailingCity)
**County:** 32 (Zuora County field in Contact object in Subscribe request)
**Postcode:** 10 (Acxiom)