### PR TITLE
Make subscriptions postcode max length the same as membership

### DIFF
--- a/app/views/fragments/checkout/fieldsPersonal.scala.html
+++ b/app/views/fragments/checkout/fieldsPersonal.scala.html
@@ -61,6 +61,6 @@
     <label class="label" for="address-postcode">Postcode</label>
     <input type="text" class="input-text js-input input-text input-text--small"
         id="address-postcode" name="personal.address.postcode"
-        value="@form.data.get("personal.address.postcode")" maxlength="8" required>
+        value="@form.data.get("personal.address.postcode")" maxlength="10" required>
     @fragments.forms.errorMessage("Please enter a valid postal code")
 </div>


### PR DESCRIPTION
The max length of postcode was 8 on subscriptions but 10 on membership. This caused issues if you had the subscription fields pre-populated with membership details (e.g. you're logged into an account which already has some level of membership set up, then you go to subscribe), and your pre-populated postcode exceeds the subscriptions max length.

I'm actually starting to wonder if these max lengths should just be factored out into the common library and then used across mem & subs, frontend and backend. Any thoughts @davidrapson?

Also, @davidrapson I seem to be assigning all my PRs to you at the moment so let me know if some of these are more appropriate for someone else