### PR TITLE
Fix 404 for international landing page

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -9,6 +9,7 @@ GET         /favicon.ico                     controllers.CacheBustedAssets.at(pa
 GET         /                                controllers.Homepage.index
 GET         /au                              controllers.Homepage.indexAu
 GET         /us                              controllers.Homepage.indexUs
+GET         /int                             controllers.Default.redirect(to = "/us")
 
 # Health check
 GET         /healthcheck                     controllers.Healthcheck.index


### PR DESCRIPTION
Up until last week the international edition on theguardian.com was a pretend edition and reported as UK which meant that the Subscribe link pointed to the UK subscriptions landing page.

Now that the international edition is a real edition the Subscribe link points to https://subscribe.theguardian.com/int which results in a 404.

This PR redirects requests to /int to /us as we want to display the US subscriptions page to international visitors.

@joelochlann 