### PR TITLE
Omniture tracking only happens in one place and is mapped to a decent…

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -32,9 +32,7 @@
     bodyClasses = List("is-wide"),
     touchpointBackendResolutionOpt = Some(touchpointBackendResolution)
 ) {
-<main class="page-container gs-container"
-      data-tracking-prop17="GuardianDigiPack:Name and address"
-      data-tracking-products="Subscriptions and Membership;GUARDIAN_DIGIPACK;@{selectedProduct.frequency.numberOfMonths};@{selectedProduct.price};scOpen">
+<main class="page-container gs-container" data-no-page-load-tracking >
 
     <section class="checkout-container">
         <form class="form js-checkout-form" action="@routes.Checkout.renderCheckout().toString()" method="POST">

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -13,11 +13,18 @@
 
 @main("Confirmation | Digital | Subscriptions | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
-<main class="page-container gs-container gs-container--slim"
-data-tracking-prop17="GuardianDigiPack:Order Complete"
-data-tracking-products="Subscriptions and Membership;GUARDIAN_DIGIPACK;@{subscriptionProduct.frequency.numberOfMonths};@{subscriptionProduct.price};purchase">
->
+<script type="text/javascript">
+    guardian.slug="GuardianDigiPack:Order Complete";
+    guardian.product = {
+        source: 'Subscriptions and Membership',
+        type: 'GUARDIAN_DIGIPACK',
+        eventName: 'purchase',
+        amount: @{subscriptionProduct.price},
+        frequency: @{subscriptionProduct.frequency.numberOfMonths}
+    };
+</script>
 
+<main class="page-container gs-container gs-container--slim">
     @fragments.page.header("Thank you for your order", None, List("l-padded"))
 
     <section class="section-slice section-slice--bleed section-slice--limited">

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -14,8 +14,8 @@
 @main("Confirmation | Digital | Subscriptions | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
 <script type="text/javascript">
-    guardian.slug="GuardianDigiPack:Order Complete";
-    guardian.product = {
+    guardian.pageInfo.slug="GuardianDigiPack:Order Complete";
+    guardian.pageInfo.productData = {
         source: 'Subscriptions and Membership',
         type: 'GUARDIAN_DIGIPACK',
         eventName: 'purchase',

--- a/app/views/digitalpack/country.scala.html
+++ b/app/views/digitalpack/country.scala.html
@@ -1,9 +1,7 @@
 @(edition: DigitalEdition, subscriptionNumberOfMonths: Int = 1)
 
 @main("Select your country | Digital | Subscriptions | The Guardian", bodyClasses = List("is-wide")) {
-    <main class="page-container gs-container"
-          data-tracking-prop17="GuardianDigiPack:Select Country"
-          data-tracking-products="Subscriptions and Membership;GUARDIAN_DIGIPACK;@subscriptionNumberOfMonths;@edition.price;prodView">
+    <main class="page-container gs-container">
 
     <section class="checkout-container">
 

--- a/app/views/fragments/javascriptFirstSteps.scala.html
+++ b/app/views/fragments/javascriptFirstSteps.scala.html
@@ -25,6 +25,16 @@
         && 'bind' in Function
         && (('XMLHttpRequest' in window && 'withCredentials' in new XMLHttpRequest()) || 'XDomainRequest' in window)
     );
+    guardian.pageInfo = {
+        channel: 'Subscriber',
+        slug: null,
+        name: document.title,
+        publication: 'GU.co.uk',
+        commissioningDesk: 'Subscriber',
+        product: 'Subscriber',
+        edition: 'UK',
+        productData: null
+    };
 
     (function(isModern) {
         // We want to add/remove classes to HTML ASAP to avoid FOUC
@@ -97,17 +107,4 @@
     })(guardian.isModernBrowser);
 </script>
 
-
-<script id="gu_page_info">
-    guardian.pageInfo = {
-        channel: 'Subscriber',
-        slug: null,
-        name: document.title,
-        publication: 'GU.co.uk',
-        commissioningDesk: 'Subscriber',
-        product: 'Subscriber',
-        edition: 'UK',
-        productData: null
-    };
-</script>
 

--- a/app/views/fragments/javascriptFirstSteps.scala.html
+++ b/app/views/fragments/javascriptFirstSteps.scala.html
@@ -96,3 +96,18 @@
         }
     })(guardian.isModernBrowser);
 </script>
+
+
+<script id="gu_page_info">
+    guardian.pageInfo = {
+        channel: 'Subscriber',
+        slug: null,
+        name: document.title,
+        publication: 'GU.co.uk',
+        commissioningDesk: 'Subscriber',
+        product: 'Subscriber',
+        edition: 'UK',
+        productData: null
+    };
+</script>
+

--- a/assets/javascripts/modules/analytics/omniture.js
+++ b/assets/javascripts/modules/analytics/omniture.js
@@ -24,7 +24,7 @@ define([
 
     function setTracker(s) {
         var pageInfo = guardian.pageInfo,
-            productData = guardian.productData;
+            productData = guardian.pageInfo.productData;
 
         s.pageName = pageInfo.name;
         s.channel = pageInfo.channel;
@@ -46,7 +46,7 @@ define([
                 productData.eventName
             ].join(';');
         }
-        if (guardian.slug) {
+        if (guardian.pageInfo.slug) {
             s.prop17 = guardian.slug;
         }
     }
@@ -58,7 +58,6 @@ define([
             var s_code = s.t();
             setTracker(s);
             if (s_code) {
-                /*jslint evil: true */
                 document.write(s_code);
             }
         });

--- a/assets/javascripts/modules/checkout/personalDetails.js
+++ b/assets/javascripts/modules/checkout/personalDetails.js
@@ -72,6 +72,8 @@ define([
     function init() {
         var $actionEl = formEls.$YOUR_DETAILS_SUBMIT;
         var actionEl = $actionEl[0];
+        tracking.personalDetailsTracking();
+
 
         if($actionEl.length) {
             actionEl.addEventListener('click', function(e) {

--- a/assets/javascripts/modules/checkout/tracking.js
+++ b/assets/javascripts/modules/checkout/tracking.js
@@ -6,32 +6,40 @@ define(['$', 'modules/analytics/omniture'], function ($, omniture) {
         if (selectedFrequency.length && eventName) {
             var amount = selectedFrequency[0].getAttribute('data-amount'),
                 qty = selectedFrequency[0].getAttribute('data-number-of-months');
-            return 'Subscriptions and Membership;GUARDIAN_DIGIPACK;' + qty + ';' + amount + ';' + eventName;
+            return {
+                source: 'Subscriptions and Membership',
+                type: 'GUARDIAN_DIGIPACK',
+                eventName: eventName,
+                amount: amount,
+                frequency: qty
+            };
         }
         return undefined;
     }
 
-    function trackEvent(prop17, pageName, eventName) {
-        var products = subscriptionProducts(eventName);
-        omniture.trackEvent(prop17, pageName, products);
+    function personalDetailsTracking() {
+        guardian.slug = 'GuardianDigiPack:Name and address';
+        guardian.productData = subscriptionProducts('scOpen');
+        omniture.triggerPageLoadEvent();
     }
 
     function paymentDetailsTracking(){
-        var prop17 = 'GuardianDigiPack:Payment Details',
-            pageName = 'Details - payment details | Digital | Subscriptions | The Guardian',
-            eventName = 'scOpen';
-        trackEvent(prop17, pageName, eventName);
+        guardian.slug = 'GuardianDigiPack:Payment Details';
+        guardian.pageName = 'Details - payment details | Digital | Subscriptions | The Guardian';
+        guardian.productData = subscriptionProducts('scOpen');
+        omniture.triggerPageLoadEvent();
     }
 
     function paymentReviewTracking(){
-        var prop17 = 'GuardianDigiPack:Review and confirm',
-            pageName = 'Payment submission/signup | Digital | Subscriptions | The Guardian',
-            eventName = 'scCheckout';
-        trackEvent(prop17, pageName, eventName);
+        guardian.slug = 'GuardianDigiPack:Review and confirm';
+        guardian.pageName ='Payment submission/signup | Digital | Subscriptions | The Guardian';
+        guardian.productData =  subscriptionProducts('scCheckout');
+        omniture.triggerPageLoadEvent();
     }
 
 
     return {
+        personalDetailsTracking: personalDetailsTracking,
         paymentDetailsTracking: paymentDetailsTracking,
         paymentReviewTracking: paymentReviewTracking
     };

--- a/assets/javascripts/modules/checkout/tracking.js
+++ b/assets/javascripts/modules/checkout/tracking.js
@@ -18,22 +18,22 @@ define(['$', 'modules/analytics/omniture'], function ($, omniture) {
     }
 
     function personalDetailsTracking() {
-        guardian.slug = 'GuardianDigiPack:Name and address';
-        guardian.productData = subscriptionProducts('scOpen');
+        guardian.pageInfo.slug = 'GuardianDigiPack:Name and address';
+        guardian.pageInfo.productData = subscriptionProducts('scOpen');
         omniture.triggerPageLoadEvent();
     }
 
     function paymentDetailsTracking(){
-        guardian.slug = 'GuardianDigiPack:Payment Details';
+        guardian.pageInfo.slug = 'GuardianDigiPack:Payment Details';
         guardian.pageName = 'Details - payment details | Digital | Subscriptions | The Guardian';
-        guardian.productData = subscriptionProducts('scOpen');
+        guardian.pageInfo.productData = subscriptionProducts('scOpen');
         omniture.triggerPageLoadEvent();
     }
 
     function paymentReviewTracking(){
-        guardian.slug = 'GuardianDigiPack:Review and confirm';
+        guardian.pageInfo.slug = 'GuardianDigiPack:Review and confirm';
         guardian.pageName ='Payment submission/signup | Digital | Subscriptions | The Guardian';
-        guardian.productData =  subscriptionProducts('scCheckout');
+        guardian.pageInfo.productData =  subscriptionProducts('scCheckout');
         omniture.triggerPageLoadEvent();
     }
 

--- a/assets/javascripts/modules/country.js
+++ b/assets/javascripts/modules/country.js
@@ -1,3 +1,4 @@
+/*global guardian */
 define([
     'modules/country/elements',
     'utils/cookie'
@@ -20,6 +21,13 @@ define([
     }
 
     function init() {
+        guardian.productData = {
+            source: 'Subscriptions and Membership',
+            type: 'GUARDIAN_DIGIPACK',
+            eventName: 'prodView'
+        };
+        guardian.slug = 'GuardianDigiPack:Select Country';
+
         var cookieInfo = loadCountryInfo();
         if (!cookieInfo) {
             cookieInfo = {switchUrl: shouldSwitch(50)};

--- a/assets/javascripts/modules/country.js
+++ b/assets/javascripts/modules/country.js
@@ -21,12 +21,12 @@ define([
     }
 
     function init() {
-        guardian.productData = {
+        guardian.pageInfo.productData = {
             source: 'Subscriptions and Membership',
             type: 'GUARDIAN_DIGIPACK',
             eventName: 'prodView'
         };
-        guardian.slug = 'GuardianDigiPack:Select Country';
+        guardian.pageInfo.slug = 'GuardianDigiPack:Select Country';
 
         var cookieInfo = loadCountryInfo();
         if (!cookieInfo) {


### PR DESCRIPTION
In order to proceed with dashboard tracking we needed to clean up some of the ways that omniture tracking ocured. Now instead of magik propx we update a js object on guardian.pageInfo and the mapping occurs once in omniture.js