### PR TITLE
Use a separate domain for Identity cookies

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -32,8 +32,6 @@ object Config {
   val stage = config.getString("stage")
   val stageProd: Boolean = stage == "PROD"
 
-  lazy val sessionDomain = config.getString("session.domain")
-
   object Identity {
     private val idConfig = config.getConfig("identity")
 
@@ -47,6 +45,8 @@ object Config {
     val webAppUrl = idConfig.getString("webapp.url")
 
     val webAppProfileUrl = webAppUrl / "account" / "edit"
+
+    val sessionDomain = idConfig.getString("sessionDomain")
 
     def idWebAppSigninUrl(returnTo: Call)(implicit request: RequestHeader) = idWebAppUrl("signin", returnTo)
 

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -36,7 +36,7 @@ class IdentityService(identityApiClient: => IdentityApiClient) extends LazyLoggi
   def convertGuest(password: String, token: IdentityToken): Future[Seq[Cookie]] = {
     IdentityApiClient.convertGuest(password, token).map { r =>
       if (r.status == Status.OK) {
-        CookieBuilder.fromGuestConversion(r.json, Some(Config.sessionDomain)).fold({ err =>
+        CookieBuilder.fromGuestConversion(r.json, Some(Config.Identity.sessionDomain)).fold({ err =>
           logger.error(s"Error while parsing the identity cookies: $err")
           Seq.empty // Worst case the user is not automatically logged in
         }, identity)

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -9,6 +9,7 @@ identity {
   production.keys=false
   webapp.url="https://profile.thegulocal.com"
   test.users.secret="a-non-secure-key-for-our-dev-env-only"
+  sessionDomain=".thegulocal.com"
 }
 
 subscriptions.url="https://sub.thegulocal.com"
@@ -17,8 +18,6 @@ play.ws.acceptAnyCertificate=true
 
 touchpoint.backend.default=DEV
 touchpoint.backend.test=UAT
-
-session.domain=".thegulocal.com"
 
 sentry.dsn = ""
 

--- a/conf/PROD.conf
+++ b/conf/PROD.conf
@@ -8,10 +8,10 @@ identity {
   baseUri = "https://idapi.theguardian.com/"
   production.keys=true
   webapp.url="https://profile.theguardian.com"
+  sessionDomain=".theguardian.com"
 }
 
 subscriptions.url="https://subscribe.theguardian.com"
-session.domain=".theguardian.com"
 
 touchpoint.backend.default=PROD
 touchpoint.backend.test=UAT

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,7 +17,7 @@ application.langs="en"
 # Enable cookie-based session for HTTPS only
 play.http.session.secure=true
 
-session.domain=""
+identity.sessionDomain=""
 
 google.oauth {
   // https://console.developers.google.com/project/guardian-subscriptions/apiui/credential?authuser=1


### PR DESCRIPTION
This should fix the problem highlighted in https://github.com/guardian/subscriptions-frontend/pull/236

@rtyley 