### PR TITLE
Apply raven improvement from Membership

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
     },
     "rules": {
         "curly": [2, "all"],
+        "no-console": 0,
         "no-trailing-spaces": 2,
         "quotes": [2, "single"],
         "wrap-iife": 2

--- a/assets/javascripts/main.js
+++ b/assets/javascripts/main.js
@@ -1,5 +1,6 @@
 require([
     'utils/ajax',
+    'modules/raven',
     'modules/analytics/setup',
     'modules/toggle',
     'modules/optionMirror',
@@ -11,33 +12,25 @@ require([
     'modules/confirmation',
     'modules/patterns',
     // Add new dependencies ABOVE this
-    'Promise',
-    'raven'
-], function (ajax,
-             analytics,
-             toggle,
-             appendAround,
-             optionMirror,
-             password,
-             inputMask,
-             checkout,
-             country,
-             confirmation,
-             patterns) {
+    'Promise'
+], function (
+    ajax,
+    raven,
+    analytics,
+    toggle,
+    appendAround,
+    optionMirror,
+    password,
+    inputMask,
+    checkout,
+    country,
+    confirmation,
+    patterns
+) {
     'use strict';
 
-    /**
-     * Set up Raven, which speaks to Sentry to track errors
-     */
-    /*global Raven */
-    Raven.config('https://6dd79da86ec54339b403277d8baac7c8@app.getsentry.com/47380', {
-        whitelistUrls: ['subscribe.theguardian.com/assets/'],
-        tags: {build_number: guardian.buildNumber}
-    }).install();
-
-
     ajax.init({page: {ajaxUrl: ''}});
-
+    raven.init('https://6dd79da86ec54339b403277d8baac7c8@app.getsentry.com/47380');
     analytics.init();
 
     toggle.init();
@@ -45,10 +38,10 @@ require([
     appendAround.init();
     password.init();
 
-        inputMask.init();
-        country.init();
-        checkout.init();
-        confirmation.init();
+    inputMask.init();
+    country.init();
+    checkout.init();
+    confirmation.init();
 
     // Pattern library
     patterns.init();

--- a/assets/javascripts/modules/raven.js
+++ b/assets/javascripts/modules/raven.js
@@ -1,0 +1,29 @@
+define(['raven'], function (raven) {
+    'use strict';
+
+    function init(dsn) {
+        raven.config(dsn, {
+            whitelistUrls: [
+                /subscribe\.theguardian\.com\/assets/,
+                /sub\.thegulocal\.com/,
+                /localhost/
+            ],
+            tags: {
+                build_number: guardian.buildNumber
+            },
+            ignoreErrors: [
+                /duplicate define: jquery/
+            ],
+            shouldSendCallback: function(data) {
+                if(window.guardian.isDev && window.console && window.console.warn) {
+                    console.warn('Raven captured error: ', data);
+                }
+                return !window.guardian.isDev;
+            }
+        }).install();
+    }
+
+    return {
+        init: init
+    };
+});


### PR DESCRIPTION
Applies some of the Raven improvements @tomverran and I worked on for Subscriptions.

- Adds logging in development mode, to give visibility into what Raven is reporting
- Moves raven config into separate module and avoids, implicit require
- Ignore some noisy errors

Once https://github.com/guardian/subscriptions-frontend/pull/241 has gone out we will also be able to record the identity ID for logged in users.

@tomverran 
