### PR TITLE
Show verbose compiler warnings when running sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ lazy val root = (project in file(".")).enablePlugins(
 )
 
 scalaVersion := "2.11.6"
+scalacOptions ++= Seq("-feature")
 
 val scalatestVersion = "2.2.4"
 


### PR DESCRIPTION
Tiny PR just to enable -feature when compiling with SBT so warnings get displayed in full