### PR TITLE
Reduce noise with script-loading errors

### DIFF
--- a/assets/javascripts/modules/analytics/affectv.js
+++ b/assets/javascripts/modules/analytics/affectv.js
@@ -1,5 +1,4 @@
-/*global Raven */
-define(function() {
+define(['utils/loadJs'], function(loadJs) {
     'use strict';
 
     var digitalPackId = '546dd61001896028ffd29273';
@@ -12,13 +11,9 @@ define(function() {
 
     function init() {
         var scriptUrl = 'https://go.affec.tv/j/';
-        // Specific page tracking if we match a given path
         var id = urlMapping[window.location.pathname] || false;
-        if(id) {
-            scriptUrl = scriptUrl + id + '?noext';
-            require('js!' + scriptUrl).then(null, function(err) {
-                Raven.captureException(err);
-            });
+        if (id) {
+            loadJs(scriptUrl + id);
         }
     }
 

--- a/assets/javascripts/utils/loadJs.js
+++ b/assets/javascripts/utils/loadJs.js
@@ -1,0 +1,21 @@
+define(function () {
+    'use strict';
+
+    return function(src, cb, errCb) {
+        var ref = window.document.getElementsByTagName('script')[0];
+        var script = window.document.createElement('script');
+
+        script.src = src;
+        script.async = true;
+        ref.parentNode.insertBefore(script, ref);
+
+        if (cb && typeof cb === 'function') {
+            script.onload = cb;
+        }
+        if (errCb && typeof errCb === 'function') {
+            script.onerror = errCb;
+        }
+
+        return script;
+    }
+});


### PR DESCRIPTION
We currently use the requirejs script loader to load our analytics code. However it's a bit of a sledgehammer to crack a nut. As it's intended for loading AMD/application code it throws and Error when a script failed to load.

Sentry catches these and reports them, this is usually a good thing but for some third-party code we don't really care if the script fails (or certainly don't want it throwing an Error).

For non-critical third-party code using a simpler script loading method allows us to fail more gracefully if the script is unavailable.

@rtyley 