### PR TITLE
Be more defensive with country metrics code

### DIFF
--- a/assets/javascripts/modules/country.js
+++ b/assets/javascripts/modules/country.js
@@ -22,6 +22,15 @@ define([
         elements.$CHECKOUT_LINK.attr('href', elements.$CHECKOUT_LINK.attr('data-previous-href'));
     }
 
+    function recordRedirect() {
+        var link = elements.$CHECKOUT_LINK[0];
+        if (link) {
+            bean.on(link, 'click', function () {
+                snowplow.trackActivity('redirectedToQss');
+            });
+        }
+    }
+
     function init() {
         guardian.pageInfo.productData = {
             source: 'Subscriptions and Membership',
@@ -35,11 +44,9 @@ define([
             cookieInfo = {switchUrl: shouldSwitch(50)};
             cookie.setCookie(COUNTRY_FLOW_COOKIE_NAME, JSON.stringify(cookieInfo));
         }
-        if (cookieInfo.switchUrl) {
+        if (cookieInfo && cookieInfo.switchUrl) {
             switchUrl();
-            bean.on(elements.$CHECKOUT_LINK[0], 'click', function () {
-                snowplow.trackActivity('redirectedToQss');
-            });
+            recordRedirect();
         }
     }
 


### PR DESCRIPTION
Avoids errors when `COUNTRY_FLOW` is set but not on country select page as code gets called on any page. This PR updates the JS to be a bit more defensive as to when it runs.

<img width="497" alt="screen shot 2015-10-13 at 17 33 46" src="https://cloud.githubusercontent.com/assets/123386/10461517/9c96a0b6-71d1-11e5-9ec7-33767f3f2943.png">

@chrisjowen 