### PR TITLE
Analytics should not fire if using test users 

### DIFF
--- a/assets/javascripts/modules/analytics/affectv.js
+++ b/assets/javascripts/modules/analytics/affectv.js
@@ -1,4 +1,6 @@
-define(['utils/loadJs'], function(loadJs) {
+define(['utils/loadJs',
+        'modules/analytics/analyticsEnabled'
+], function(loadJs, analyticsEnabled) {
     'use strict';
 
     var digitalPackId = '546dd61001896028ffd29273';
@@ -18,6 +20,6 @@ define(['utils/loadJs'], function(loadJs) {
     }
 
     return {
-        init: init
+        init: analyticsEnabled(init)
     };
 });

--- a/assets/javascripts/modules/analytics/analyticsEnabled.js
+++ b/assets/javascripts/modules/analytics/analyticsEnabled.js
@@ -1,0 +1,19 @@
+define([
+    'utils/cookie'
+], function (cookie) {
+    'use strict';
+
+    var analyticsEnabled = (
+        window.guardian.analyticsEnabled &&
+        !navigator.doNotTrack &&
+        !cookie.getCookie('ANALYTICS_OFF_KEY')
+    );
+
+    return function(cb){
+        return function() {
+            if (analyticsEnabled) {
+                return cb()
+            }
+        }
+    }
+});

--- a/assets/javascripts/modules/analytics/ga.js
+++ b/assets/javascripts/modules/analytics/ga.js
@@ -1,25 +1,29 @@
 /* global ga */
-define(['utils/cookie'], function(cookie) {
+define(['utils/cookie',
+        'modules/analytics/analyticsEnabled'
+    ], function(cookie, analyticsEnabled) {
     'use strict';
+    function init() {
+
+        var identitySignedIn = !!cookie.getCookie('GU_U');
+        var identitySignedOut = !!cookie.getCookie('GU_SO') && !identitySignedIn;
+
+        /* Google analytics snippet */
+        /*eslint-disable */
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        /*eslint-enable */
+
+        ga('create', 'UA-51507017-5', 'auto');
+        ga('set', 'dimension1', identitySignedIn.toString());
+        ga('set', 'dimension2', identitySignedOut.toString());
+        ga('send', 'pageview');
+    }
+
 
     return {
-        init: function() {
-
-            var identitySignedIn = !!cookie.getCookie('GU_U');
-            var identitySignedOut = !!cookie.getCookie('GU_SO') && !identitySignedIn;
-
-            /* Google analytics snippet */
-            /*eslint-disable */
-            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-            /*eslint-enable */
-
-            ga('create', 'UA-51507017-5', 'auto');
-            ga('set', 'dimension1', identitySignedIn.toString());
-            ga('set', 'dimension2', identitySignedOut.toString());
-            ga('send', 'pageview');
-        }
+        init: analyticsEnabled(init)
     };
 });

--- a/assets/javascripts/modules/analytics/krux.js
+++ b/assets/javascripts/modules/analytics/krux.js
@@ -1,5 +1,5 @@
 /*global Raven */
-define(function() {
+define(['modules/analytics/analyticsEnabled'], function(analyticsEnabled) {
     'use strict';
 
     var KRUX_ID = 'Jglpp88U';
@@ -11,6 +11,6 @@ define(function() {
     }
 
     return {
-        init: init
+        init: analyticsEnabled(init)
     };
 });

--- a/assets/javascripts/modules/analytics/omniture.js
+++ b/assets/javascripts/modules/analytics/omniture.js
@@ -1,8 +1,9 @@
 /*global Raven, s_gi, guardian */
 define([
     '$',
-    'bean'
-], function ($, bean) {
+    'bean',
+    'modules/analytics/analyticsEnabled'
+], function ($, bean, analyticsEnabled) {
     'use strict';
 
     var omniture, s;
@@ -75,7 +76,7 @@ define([
     }
 
     return {
-        init: init,
-        triggerPageLoadEvent: triggerPageLoadEvent
+        init: analyticsEnabled(init),
+        triggerPageLoadEvent: analyticsEnabled(triggerPageLoadEvent)
     };
 });

--- a/assets/javascripts/modules/analytics/remarketing.js
+++ b/assets/javascripts/modules/analytics/remarketing.js
@@ -1,4 +1,4 @@
-define(function () {
+define(['modules/analytics/analyticsEnabled'], function(analyticsEnabled) {
     'use strict';
 
     var remarketingUrl = 'https://www.googleadservices.com/pagead/conversion_async.js';
@@ -14,6 +14,6 @@ define(function () {
     }
 
     return {
-        init: init
+        init: analyticsEnabled(init)
     };
 });

--- a/assets/javascripts/modules/analytics/setup.js
+++ b/assets/javascripts/modules/analytics/setup.js
@@ -1,13 +1,10 @@
-define([
-    'utils/cookie',
-    'modules/analytics/ga',
-    'modules/analytics/omniture',
-    'modules/analytics/remarketing',
-    'modules/analytics/krux',
-    'modules/analytics/affectv',
-    'modules/analytics/snowplow'
-], function (cookie,
-             ga,
+define(['modules/analytics/ga',
+        'modules/analytics/omniture',
+        'modules/analytics/remarketing',
+        'modules/analytics/krux',
+        'modules/analytics/affectv',
+        'modules/analytics/snowplow'
+], function (ga,
              omniture,
              remarketing,
              krux,
@@ -16,22 +13,14 @@ define([
     'use strict';
 
     function init() {
-        var analyticsEnabled = (
-            window.guardian.analyticsEnabled &&
-            !navigator.doNotTrack &&
-            !cookie.getCookie('ANALYTICS_OFF_KEY')
-        );
+        snowplow.init();
+        ga.init();
+        omniture.init();
 
-        if (analyticsEnabled) {
-            snowplow.init();
-            ga.init();
-            omniture.init();
-
-            if (!window.guardian.isDev) {
-                remarketing.init();
-                krux.init();
-                affectv.init();
-            }
+        if (!window.guardian.isDev) {
+            remarketing.init();
+            krux.init();
+            affectv.init();
         }
     }
 

--- a/assets/javascripts/modules/analytics/snowplow.js
+++ b/assets/javascripts/modules/analytics/snowplow.js
@@ -1,5 +1,5 @@
 /*global snowplow, guardian */
-define(['lodash/object/merge'], function (merge) {
+define(['lodash/object/merge','modules/analytics/analyticsEnabled'], function (merge, analyticsEnabled) {
     'use strict';
 
     function loadSnowPlow() {
@@ -55,8 +55,8 @@ define(['lodash/object/merge'], function (merge) {
     }
 
     return {
-        init: init,
-        trackActivity: trackActivity,
-        trackPageLoad: trackPageLoad
+        init: analyticsEnabled(init),
+        trackActivity: analyticsEnabled(trackActivity),
+        trackPageLoad: analyticsEnabled(trackPageLoad)
     }
 });

--- a/assets/javascripts/modules/country.js
+++ b/assets/javascripts/modules/country.js
@@ -23,9 +23,8 @@ define([
     }
 
     function recordRedirect() {
-        var link = elements.$CHECKOUT_LINK[0];
-        if (link) {
-            bean.on(link, 'click', function () {
+        if (elements.$CHECKOUT_LINK && elements.$CHECKOUT_LINK.length==1) {
+            bean.on(elements.$CHECKOUT_LINK[0], 'click', function () {
                 snowplow.trackActivity('redirectedToQss');
             });
         }


### PR DESCRIPTION
Currently the analytics setup component was guarding on initialisation of the various analytics components we used. However, there were other entry points exposed to call analytics which made the data we were getting a little off. This PR adds the additional guards around those exposed calls. 

See https://trello.com/c/lshDPxMa/213-ensure-analytics-always-respect-analytics-off-key-cookie for more informaiton