### PR TITLE
Update to latest version of the gocardless-pro client library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % scalatestVersion % "test",
     "org.scalactic" %% "scalactic" % scalatestVersion % "test",
     "org.seleniumhq.selenium" % "selenium-java" % "2.44.0" % "test",
-    "com.gocardless" % "gocardless-pro" % "1.0.0",
+    "com.gocardless" % "gocardless-pro" % "1.8.0",
     "com.squareup.okhttp" % "okhttp" % "2.4.0",
     "com.snowplowanalytics" % "snowplow-java-tracker" % "0.5.2-SNAPSHOT",
     "com.github.t3hnar" %% "scala-bcrypt" % "2.4",


### PR DESCRIPTION
It's worth noting that gocardless-pro client library versions v1.0.0 and v1.8.0 both use GoCardless Version 2015-07-06:

* https://github.com/gocardless/gocardless-pro-java/blob/v1.0.0/src/main/java/com/gocardless/http/HttpClient.java#L39
* https://github.com/gocardless/gocardless-pro-java/blob/v1.8.0/src/main/java/com/gocardless/http/HttpClient.java#L38

So when GoCardless reported that we were using GoCardless Version 2015-07-06, they must have meant Zuora - which must be updated in order to avoid discontinuation of GoCardless service on January 6th 2016:

https://gocardless.com/blog/api-release-2015-07-06/

@blackyjnz @ostapneko 

https://trello.com/c/IMQkTnPA/205-gocardless-api-upgrade-to-v2015-07-06-old-version-to-be-discontined-on-jan-6-2016