### PR TITLE
Point digital pack link to temporary QSS page while normal one is down

### DIFF
--- a/app/model/DigitalEdition.scala
+++ b/app/model/DigitalEdition.scala
@@ -12,7 +12,7 @@ object DigitalEdition {
   def getRedirect(edition: DigitalEdition): String = {
     edition match {
       case UK => "/digital/country"
-      case _ => "https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=dga38&CMP=FAB_3062"
+      case _ => "https://www.myguardianweekly.co.uk/subscribe/?title=GDP&prom=DGA38&CMP=FAB_3062"
     }
   }
 }

--- a/app/views/digitalpack/country.scala.html
+++ b/app/views/digitalpack/country.scala.html
@@ -19,12 +19,12 @@
                     <h3 class="u-pad-bottom">Choose your location</h3>
                     <div class="button-group">
                         <a class="button button--primary button--large js-checkout-link" data-link-tracking
-                           data-previous-href="https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=DGA38&CMP=@edition.campaign"
+                           data-previous-href="https://www.myguardianweekly.co.uk/subscribe/?title=GDP&prom=DGA38&CMP=@edition.campaign"
                            href="@routes.Checkout.renderCheckout()">
                            United Kingdom
                         </a>
                         <a class="button button--secondary button--large" data-link-tracking
-                           href="https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=dga38&amp;CMP=FAB_3062">
+                           href="https://www.myguardianweekly.co.uk/subscribe/?title=GDP&prom=DGA38&CMP=FAB_3062">
                            Rest of the world
                         </a>
                     </div>

--- a/test/model/DigitalEditionTest.scala
+++ b/test/model/DigitalEditionTest.scala
@@ -10,7 +10,7 @@ class DigitalEditionTest extends PlaySpecification {
     }
 
     "go straight to the subscription page for non UK users" in {
-      DigitalEdition.getRedirect(US) mustEqual "https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=dga38&CMP=FAB_3062"
+      DigitalEdition.getRedirect(US) mustEqual "https://www.myguardianweekly.co.uk/subscribe/?title=GDP&prom=DGA38&CMP=FAB_3062"
     }
   }
 }


### PR DESCRIPTION
The QSS page for digital pack signups at https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=DGA38&CMP=dis_2408 is down. While they fix it, we want to direct people to https://www.myguardianweekly.co.uk/subscribe/?title=GDP instead, which will at least allow signup despite the fact it says Guardian Weekly.