### PR TITLE
Acceptance test buy sub

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -6,7 +6,7 @@
             "afterSeen": {
                 "travis": {
                     "config": {
-                        "script": "sbt ++$TRAVIS_SCALA_VERSION acceptance-test"
+                        "script": "sbt ++$TRAVIS_SCALA_VERSION acceptance-test-buy-sub"
                     }
                 }
             }

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ cache:
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete -print
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete -print
-script: sbt ++$TRAVIS_SCALA_VERSION acceptance-test-buy-sub
+script: sbt ++$TRAVIS_SCALA_VERSION fast-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ cache:
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete -print
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete -print
-script: sbt ++$TRAVIS_SCALA_VERSION fast-test
+script: sbt ++$TRAVIS_SCALA_VERSION acceptance-test-buy-sub

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ libraryDependencies ++= Seq(
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
     "org.scalatest" %% "scalatest" % scalatestVersion % "test",
     "org.scalactic" %% "scalactic" % scalatestVersion % "test",
-    "org.seleniumhq.selenium" % "selenium-java" % "2.44.0" % "test",
+    "org.seleniumhq.selenium" % "selenium-java" % "2.48.2" % "test",
     "com.gocardless" % "gocardless-pro" % "1.8.0",
     "com.squareup.okhttp" % "okhttp" % "2.4.0",
     "com.snowplowanalytics" % "snowplow-java-tracker" % "0.5.2-SNAPSHOT",

--- a/build.sbt
+++ b/build.sbt
@@ -66,5 +66,6 @@ resolvers ++= Seq(
 addCommandAlias("devrun", "run -Dconfig.resource=DEV.conf 9200")
 addCommandAlias("fast-test", "testOnly -- -l Acceptance")
 addCommandAlias("acceptance-test", "testOnly acceptance.Main")
+addCommandAlias("acceptance-test-buy-sub", "testOnly acceptance.CheckoutSpec")
 
 playArtifactDistSettings

--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -13,7 +13,7 @@ class CheckoutSpec extends FeatureSpec
   // Before each test ...
   before { resetDriver() }
 
-  // After all tests executes, close all windows, and exit the driver
+  // After all tests execute, close all windows, and exit the driver
   override def afterAll(): Unit = { quit() }
 
   feature("Checkout page") {
@@ -46,22 +46,5 @@ class CheckoutSpec extends FeatureSpec
         assert(cookiesSet.map(_.getName).contains(idCookie))
       }
     }
-
-//    scenario("Guest user supplies invalid details", Acceptance) {
-//      val checkout = new Checkout()
-//      import checkout.PersonalDetails
-//
-//      When("I visit the checkout page")
-//      go.to(checkout)
-//
-//      And("I fill in personal details with inconsistent emails")
-//      PersonalDetails.fillIn()
-//      PersonalDetails.emailConfirmation.value = "non-matching-email@example.com"
-//
-//      PersonalDetails.continue()
-//
-//      Then("The email field should be marked with an error")
-//      assert(PersonalDetails.emailNotValid(), "email confirmation should not be valid")
-//    }
   }
 }

--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -46,5 +46,22 @@ class CheckoutSpec extends FeatureSpec
         assert(cookiesSet.map(_.getName).contains(idCookie))
       }
     }
+
+    scenario("Guest user supplies invalid details", Acceptance) {
+      val checkout = new Checkout()
+      import checkout.PersonalDetails
+
+      When("I visit the checkout page")
+      go.to(checkout)
+
+      And("I fill in personal details with inconsistent emails")
+      PersonalDetails.fillIn()
+      PersonalDetails.emailConfirmation.value = "non-matching-email@example.com"
+
+      PersonalDetails.continue()
+
+      Then("The email field should be marked with an error")
+      assert(PersonalDetails.emailNotValid(), "email confirmation should not be valid")
+    }
   }
 }

--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -3,15 +3,18 @@ package acceptance
 import acceptance.pages.{Checkout, ThankYou}
 import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.WebBrowser
-import org.scalatest.{BeforeAndAfter, FeatureSpec, GivenWhenThen}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfter, FeatureSpec, GivenWhenThen}
 
-class CheckoutSpec extends FeatureSpec with WebBrowser with Util with GivenWhenThen with BeforeAndAfter {
+class CheckoutSpec extends FeatureSpec
+  with WebBrowser with Util with GivenWhenThen with BeforeAndAfter with BeforeAndAfterAll  {
 
   implicit lazy val driver: WebDriver = Config.driver
 
-  before {
-    resetDriver()
-  }
+  // Before each test ...
+  before { resetDriver() }
+
+  // After all tests executes, close all windows, and exit the driver
+  override def afterAll(): Unit = { quit() }
 
   feature("Checkout page") {
     scenario("Guest user completes a checkout and sets an account password", Acceptance) {

--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -47,21 +47,21 @@ class CheckoutSpec extends FeatureSpec
       }
     }
 
-    scenario("Guest user supplies invalid details", Acceptance) {
-      val checkout = new Checkout()
-      import checkout.PersonalDetails
-
-      When("I visit the checkout page")
-      go.to(checkout)
-
-      And("I fill in personal details with inconsistent emails")
-      PersonalDetails.fillIn()
-      PersonalDetails.emailConfirmation.value = "non-matching-email@example.com"
-
-      PersonalDetails.continue()
-
-      Then("The email field should be marked with an error")
-      assert(PersonalDetails.emailNotValid(), "email confirmation should not be valid")
-    }
+//    scenario("Guest user supplies invalid details", Acceptance) {
+//      val checkout = new Checkout()
+//      import checkout.PersonalDetails
+//
+//      When("I visit the checkout page")
+//      go.to(checkout)
+//
+//      And("I fill in personal details with inconsistent emails")
+//      PersonalDetails.fillIn()
+//      PersonalDetails.emailConfirmation.value = "non-matching-email@example.com"
+//
+//      PersonalDetails.continue()
+//
+//      Then("The email field should be marked with an error")
+//      assert(PersonalDetails.emailNotValid(), "email confirmation should not be valid")
+//    }
   }
 }

--- a/test/acceptance/Config.scala
+++ b/test/acceptance/Config.scala
@@ -4,6 +4,7 @@ import java.net.URL
 
 import com.typesafe.config.ConfigFactory
 import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.firefox.FirefoxDriver
 import org.openqa.selenium.remote.{DesiredCapabilities, RemoteWebDriver}
 import org.openqa.selenium.{Platform, WebDriver}
 
@@ -18,7 +19,7 @@ object Config {
     Try { new URL(conf.getString("webDriverRemoteUrl")) }.toOption.map { url =>
       new RemoteWebDriver(url, defaultCapabilities)
     }.getOrElse {
-      new ChromeDriver()
+      new FirefoxDriver()
     }
   }
 

--- a/test/acceptance/Config.scala
+++ b/test/acceptance/Config.scala
@@ -4,7 +4,6 @@ import java.net.URL
 
 import com.typesafe.config.ConfigFactory
 import org.openqa.selenium.chrome.ChromeDriver
-import org.openqa.selenium.firefox.FirefoxDriver
 import org.openqa.selenium.remote.{DesiredCapabilities, RemoteWebDriver}
 import org.openqa.selenium.{Platform, WebDriver}
 

--- a/test/acceptance/Config.scala
+++ b/test/acceptance/Config.scala
@@ -28,4 +28,6 @@ object Config {
     capabilities.setCapability("name", "Subscriptions frontend Acceptance test: https://github.com/guardian/subscriptions-frontend")
     capabilities
   }
+
+  val testUsersSecret = conf.getString("identity.test.users.secret")
 }

--- a/test/acceptance/Config.scala
+++ b/test/acceptance/Config.scala
@@ -19,7 +19,7 @@ object Config {
     Try { new URL(conf.getString("webDriverRemoteUrl")) }.toOption.map { url =>
       new RemoteWebDriver(url, defaultCapabilities)
     }.getOrElse {
-      new FirefoxDriver()
+      new ChromeDriver()
     }
   }
 

--- a/test/acceptance/Util.scala
+++ b/test/acceptance/Util.scala
@@ -32,7 +32,7 @@ trait Util { this: WebBrowser =>
     driver.manage().timeouts().implicitlyWait(60, TimeUnit.SECONDS)
   }
 
-  private val defaultTimeOut = 60
+  private val defaultTimeOut = 90
 
   protected def pageHasText(text: String, timeoutSecs: Int=defaultTimeOut): Boolean = {
     val pred = ExpectedConditions.textToBePresentInElementLocated(By.tagName("body"), text)

--- a/test/acceptance/Util.scala
+++ b/test/acceptance/Util.scala
@@ -34,8 +34,12 @@ trait Util { this: WebBrowser =>
     driver.manage().deleteAllCookies()
     driver.manage().timeouts().implicitlyWait(60, TimeUnit.SECONDS)
 
-    val cookie = new Cookie(qaCookie.name, qaCookie.value)
-    driver.manage().addCookie(cookie)
+    addTestUserCookies()
+  }
+
+  private def addTestUserCookies() = {
+    val passthroughCookie = new Cookie(qaCookie.name, qaCookie.value)
+    driver.manage().addCookie(passthroughCookie)
 
     val analyticsCookie = new Cookie("ANALYTICS_OFF_KEY", "true")
     driver.manage().addCookie(analyticsCookie)

--- a/test/acceptance/Util.scala
+++ b/test/acceptance/Util.scala
@@ -38,9 +38,6 @@ trait Util { this: WebBrowser =>
   }
 
   private def addTestUserCookies() = {
-    val passthroughCookie = new Cookie(qaCookie.name, qaCookie.value)
-    driver.manage().addCookie(passthroughCookie)
-
     val analyticsCookie = new Cookie("ANALYTICS_OFF_KEY", "true")
     driver.manage().addCookie(analyticsCookie)
 

--- a/test/acceptance/Util.scala
+++ b/test/acceptance/Util.scala
@@ -12,6 +12,9 @@ import org.scalatest.selenium.WebBrowser
 import scala.collection.JavaConverters._
 import scala.util.Try
 
+import com.gu.identity.testing.usernames.TestUsernames
+import com.github.nscala_time.time.Imports._
+
 trait Util { this: WebBrowser =>
   implicit val driver: WebDriver
 
@@ -30,6 +33,17 @@ trait Util { this: WebBrowser =>
     go.to(appUrl)
     driver.manage().deleteAllCookies()
     driver.manage().timeouts().implicitlyWait(60, TimeUnit.SECONDS)
+
+    val cookie = new Cookie(qaCookie.name, qaCookie.value)
+    driver.manage().addCookie(cookie)
+
+    val analyticsCookie = new Cookie("ANALYTICS_OFF_KEY", "true")
+    driver.manage().addCookie(analyticsCookie)
+
+    val testUserCookie =
+      new Cookie.Builder("pre-signin-test-user", TestUser.specialString)
+        .isHttpOnly(true).build()
+    driver.manage().addCookie(testUserCookie)
   }
 
   private val defaultTimeOut = 90
@@ -54,9 +68,6 @@ trait Util { this: WebBrowser =>
 }
 
 object TestUser {
-  import com.gu.identity.testing.usernames.TestUsernames
-  import com.github.nscala_time.time.Imports._
-
   private val testUsers = TestUsernames(
     com.gu.identity.testing.usernames.Encoder.withSecret(Config.testUsersSecret),
     recency = 2.days.standardDuration

--- a/test/acceptance/Util.scala
+++ b/test/acceptance/Util.scala
@@ -32,12 +32,14 @@ trait Util { this: WebBrowser =>
     driver.manage().timeouts().implicitlyWait(60, TimeUnit.SECONDS)
   }
 
-  protected def pageHasText(text: String, timeoutSecs: Int=50): Boolean = {
+  private val defaultTimeOut = 60
+
+  protected def pageHasText(text: String, timeoutSecs: Int=defaultTimeOut): Boolean = {
     val pred = ExpectedConditions.textToBePresentInElementLocated(By.tagName("body"), text)
     new WebDriverWait(driver, timeoutSecs).until(pred)
   }
 
-  protected def pageHasElement(q: Query, timeoutSecs: Int=50): Boolean = {
+  protected def pageHasElement(q: Query, timeoutSecs: Int=defaultTimeOut): Boolean = {
     val pred = ExpectedConditions.visibilityOfElementLocated(q.by)
     Try {
       new WebDriverWait(driver, timeoutSecs).until(pred)
@@ -47,4 +49,15 @@ trait Util { this: WebBrowser =>
   protected def currentHost: String = new URL(currentUrl).getHost
 
   def cookiesSet: Set[Cookie] = driver.manage().getCookies.asScala.toSet
+}
+
+object TestUser {
+  import com.gu.identity.testing.usernames.TestUsernames
+  import com.github.nscala_time.time.Imports._
+
+  private val testUsers = TestUsernames(
+    com.gu.identity.testing.usernames.Encoder.withSecret(Config.testUsersSecret),
+    recency = 2.days.standardDuration
+  )
+  val specialString = testUsers.generate()
 }

--- a/test/acceptance/Util.scala
+++ b/test/acceptance/Util.scala
@@ -36,7 +36,9 @@ trait Util { this: WebBrowser =>
 
   protected def pageHasText(text: String, timeoutSecs: Int=defaultTimeOut): Boolean = {
     val pred = ExpectedConditions.textToBePresentInElementLocated(By.tagName("body"), text)
-    new WebDriverWait(driver, timeoutSecs).until(pred)
+    Try {
+      new WebDriverWait(driver, timeoutSecs).until(pred)
+    }.isSuccess
   }
 
   protected def pageHasElement(q: Query, timeoutSecs: Int=defaultTimeOut): Boolean = {

--- a/test/acceptance/pages/Checkout.scala
+++ b/test/acceptance/pages/Checkout.scala
@@ -2,9 +2,11 @@ package acceptance.pages
 
 
 import acceptance.Config.appUrl
-import acceptance.Util
+import acceptance.{Config, Util}
 import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.{WebBrowser, Page}
+
+
 
 class Checkout(implicit val driver: WebDriver) extends Page with WebBrowser with Util {
   val url = s"$appUrl/checkout"
@@ -23,9 +25,19 @@ class Checkout(implicit val driver: WebDriver) extends Page with WebBrowser with
     val receiveGnmMarketing = checkbox(name("personal.receiveGnmMarketing"))
 
     def fillIn(): Unit = {
-      val emailValue = s"test-${System.currentTimeMillis()}@gu.com"
-      firstName.value = "first"
-      lastName.value = "last"
+
+      import com.gu.identity.testing.usernames.TestUsernames
+      import com.github.nscala_time.time.Imports._
+
+      val testUsers = TestUsernames(
+        com.gu.identity.testing.usernames.Encoder.withSecret(Config.testUsersSecret),
+        recency = 2.days.standardDuration
+      )
+      val testUserString = testUsers.generate()
+
+      val emailValue = s"${testUserString}@gu.com"
+      firstName.value = s"${testUserString}"
+      lastName.value = s"${testUserString}"
       email.value = emailValue
       emailConfirmation.value = emailValue
       address1.value = "address 1"
@@ -69,6 +81,11 @@ class Checkout(implicit val driver: WebDriver) extends Page with WebBrowser with
   }
 
   def fillInPersonalDetails(): Unit = {
+    PersonalDetails.fillIn()
+    PersonalDetails.continue()
+  }
+
+  def fillInPersonalDetailsTestUser(): Unit = {
     PersonalDetails.fillIn()
     PersonalDetails.continue()
   }

--- a/test/acceptance/pages/Checkout.scala
+++ b/test/acceptance/pages/Checkout.scala
@@ -1,12 +1,9 @@
 package acceptance.pages
 
-
 import acceptance.Config.appUrl
-import acceptance.{Config, Util}
+import acceptance.{TestUser, Util}
 import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.{WebBrowser, Page}
-
-
 
 class Checkout(implicit val driver: WebDriver) extends Page with WebBrowser with Util {
   val url = s"$appUrl/checkout"
@@ -25,19 +22,11 @@ class Checkout(implicit val driver: WebDriver) extends Page with WebBrowser with
     val receiveGnmMarketing = checkbox(name("personal.receiveGnmMarketing"))
 
     def fillIn(): Unit = {
+      assert(pageHasElement(id("address-postcode")))
 
-      import com.gu.identity.testing.usernames.TestUsernames
-      import com.github.nscala_time.time.Imports._
-
-      val testUsers = TestUsernames(
-        com.gu.identity.testing.usernames.Encoder.withSecret(Config.testUsersSecret),
-        recency = 2.days.standardDuration
-      )
-      val testUserString = testUsers.generate()
-
-      val emailValue = s"${testUserString}@gu.com"
-      firstName.value = s"${testUserString}"
-      lastName.value = s"${testUserString}"
+      val emailValue = s"${TestUser.specialString}@gu.com"
+      firstName.value = s"${TestUser.specialString}"
+      lastName.value = s"${TestUser.specialString}"
       email.value = emailValue
       emailConfirmation.value = emailValue
       address1.value = "address 1"
@@ -50,7 +39,9 @@ class Checkout(implicit val driver: WebDriver) extends Page with WebBrowser with
       fieldHasError(emailConfirmation)
 
     def continue(): Unit = {
-      click.on(cssSelector(".js-checkout-your-details-submit"))
+      val selector = cssSelector(".js-checkout-your-details-submit")
+      assert(pageHasElement(selector))
+      click.on(selector)
     }
   }
 
@@ -61,6 +52,8 @@ class Checkout(implicit val driver: WebDriver) extends Page with WebBrowser with
     val confirm = checkbox(cssSelector(""".js-checkout-confirm-payment input[type="checkbox"]"""))
 
     def fillIn(): Unit = {
+      assert(pageHasElement(id("payment-holder")))
+
       account.value = "55779911"
       sortcode.value = "200000"
       payment.value = "payment"
@@ -69,7 +62,7 @@ class Checkout(implicit val driver: WebDriver) extends Page with WebBrowser with
 
     def continue(): Unit = {
       val selector = cssSelector(".js-checkout-payment-details-submit")
-      pageHasElement(selector)
+      assert(pageHasElement(selector))
       click.on(selector)
     }
   }
@@ -81,11 +74,6 @@ class Checkout(implicit val driver: WebDriver) extends Page with WebBrowser with
   }
 
   def fillInPersonalDetails(): Unit = {
-    PersonalDetails.fillIn()
-    PersonalDetails.continue()
-  }
-
-  def fillInPersonalDetailsTestUser(): Unit = {
     PersonalDetails.fillIn()
     PersonalDetails.continue()
   }

--- a/test/conf/application.conf
+++ b/test/conf/application.conf
@@ -17,3 +17,6 @@ qa {
   passthrough-cookie-value = "qa-passthrough-dev"
   passthrough-cookie-value = ${?PASSTHROUGH_COOKIE_VALUE}
 }
+
+identity.test.users.secret=""
+identity.test.users.secret=${?IDENTITY_TEST_USERS_SECRET}


### PR DESCRIPTION
@afiore @rtyley 

Buy subscription acceptance test (`CheckoutSpec.scala`) has been modified as follows:
* use test-users facility
* expose test-user secret as environmental variable in Travis
* set testing cookies: `ANALYTICS_OFF_KEY`, `pre-signin-test-user`
* set cookie `qa-passthrough` (Is this needed??)
* fix flakiness by waiting for last element in relevant subsection of the page to load before proceeding
* add `acceptance-test-buy-sub` testOnly SBT task, which executes just the buy subscription test
* configure Prout to execute just buy subscription test

The test itself (without build time) completes in around 30 sec.

I have disabled other acceptance tests temporarily to allow for easier monitoring of test stability. Once it seems stable we can gradually re-enable/add other acceptance tests.

Result of testing-in-production:
* [Travis build](https://travis-ci.org/guardian/subscriptions-frontend/builds/87668704)
* [Sauce Labs screencast](https://saucelabs.com/tests/66bac2af77fa47d1a28f68295f417196)
* [Zuora screenshot](https://github.com/guardian/subscriptions-frontend/files/21786/Screen.Shot.2015-10-27.at.14.10.42.pdf)
* [Salesforce screenshot](https://github.com/guardian/subscriptions-frontend/files/21787/Screen.Shot.2015-10-27.at.14.11.23.pdf)

This PR in combination with https://github.com/guardian/prout/pull/27 should implement an end-to-end automated acceptance test with test result feedback to developer as a comment in the original PR.
