### PR TITLE
Add manifest endpoint so status app knows our build version

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -11,7 +11,7 @@ GET         /au                              controllers.Homepage.indexAu
 GET         /us                              controllers.Homepage.indexUs
 
 # Health check
-GET         /healthcheck                     controllers.Healthcheck.index
+GET         /healthcheck                     controllers.Management.healthcheck
 
 # Digital pack
 GET         /digital/country                 controllers.DigitalPack.selectUk


### PR DESCRIPTION
So that we can have build version numbers here:

http://status.membership.guardianapis.com/PROD

![image](https://cloud.githubusercontent.com/assets/52038/10826442/c338de36-7e61-11e5-96e8-bac84f6ee219.png)


The Status App reads those version numbers:

https://github.com/guardian/status-app/blob/0a77637/app/model/Instance.scala#L163

Implementation mostly stolen from:

https://github.com/guardian/status-app/blob/0a7763/app/controllers/Management.scala

cc @philwills 