### PR TITLE
Fix styling on paper-digital page

### DIFF
--- a/assets/stylesheets/modules/_packages.scss
+++ b/assets/stylesheets/modules/_packages.scss
@@ -11,6 +11,7 @@
     margin-bottom: $gs-baseline;
     position: relative;
     border: none;
+    color: $c-brand;
 }
 .package:hover,
 .package:active {
@@ -150,21 +151,20 @@ $step-size: 40px;
 $step-size-tablet: 60px;
 
 .steps {
-    @extend .inline-list;
-    counter-reset: li;
-
+    @extend .o-inline-list;
     @include mq(tablet) {
         margin-bottom: $gs-baseline;
     }
 }
 
 .steps__item {
-    @extend .inline-list__item;
+    @extend .o-inline-list__item;
     margin-bottom: $gs-baseline/2;
     min-height: $step-size + $gs-baseline/2;
     padding-left: $step-size + $gs-gutter/2;
     padding-right: $gs-gutter/2;
     position: relative;
+    margin-left: 0;
 
     @include mq(tablet) {
         width: 33%;
@@ -176,8 +176,8 @@ $step-size-tablet: 60px;
     &:before {
         background-color: $c-brand;
         color: $c-white;
-        content: counter(li);
-        counter-increment: li;
+        content: counter(steps);
+        counter-increment: steps;
         display: block;
         float: left;
         font-weight: 500;


### PR DESCRIPTION
- broken includes & counter / margin right introduced to steps__item 0a2ac79099dd59f6ce471152d383a399163c63db
- global link style removed so links were default blue d69be5cb7efae81365a741ac45892f611b62afe4

![image](https://cloud.githubusercontent.com/assets/1388226/10846916/07f6eb36-7f0b-11e5-8184-3882f5ff4982.png)
