### PR TITLE
Revert temporary QSS page

### DIFF
--- a/app/model/DigitalEdition.scala
+++ b/app/model/DigitalEdition.scala
@@ -12,7 +12,7 @@ object DigitalEdition {
   def getRedirect(edition: DigitalEdition): String = {
     edition match {
       case UK => "/digital/country"
-      case _ => "https://www.myguardianweekly.co.uk/subscribe/?title=GDP&prom=DGA38&CMP=FAB_3062"
+      case _ => "https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=dga38&CMP=FAB_3062"
     }
   }
 }

--- a/app/views/digitalpack/country.scala.html
+++ b/app/views/digitalpack/country.scala.html
@@ -19,12 +19,12 @@
                     <h3 class="u-pad-bottom">Choose your location</h3>
                     <div class="button-group">
                         <a class="button button--primary button--large js-checkout-link" data-link-tracking
-                           data-previous-href="https://www.myguardianweekly.co.uk/subscribe/?title=GDP&prom=DGA38&CMP=@edition.campaign"
+                           data-previous-href="https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=DGA38&CMP=@edition.campaign"
                            href="@routes.Checkout.renderCheckout()">
                            United Kingdom
                         </a>
                         <a class="button button--secondary button--large" data-link-tracking
-                           href="https://www.myguardianweekly.co.uk/subscribe/?title=GDP&prom=DGA38&CMP=FAB_3062">
+                           href="https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=dga38&amp;CMP=FAB_3062">
                            Rest of the world
                         </a>
                     </div>

--- a/test/model/DigitalEditionTest.scala
+++ b/test/model/DigitalEditionTest.scala
@@ -10,7 +10,7 @@ class DigitalEditionTest extends PlaySpecification {
     }
 
     "go straight to the subscription page for non UK users" in {
-      DigitalEdition.getRedirect(US) mustEqual "https://www.myguardianweekly.co.uk/subscribe/?title=GDP&prom=DGA38&CMP=FAB_3062"
+      DigitalEdition.getRedirect(US) mustEqual "https://www.guardiansubscriptions.co.uk/digitalsubscriptions/?prom=dga38&CMP=FAB_3062"
     }
   }
 }


### PR DESCRIPTION
Reverts guardian/subscriptions-frontend#261 - the old url is working again!

https://trello.com/c/9tl46lUZ/223-update-the-url-to-the-qss-digital-pack-site

cc @joelochlann 