### PR TITLE
Allow StatusApp to hit EC2 instances so it can get their version

### DIFF
--- a/cloud-formation/subscriptions-app.cf.json
+++ b/cloud-formation/subscriptions-app.cf.json
@@ -36,6 +36,10 @@
             "Type" : "String",
             "Default" : "0.0.0.0/0"
         },
+        "StatusAppSecurityGroup" : {
+            "Description" : "Security group to add instances to so StatusApp can access management pages - search for 'StatusApp-InstanceSecurityGroup' to find the Security Group",
+            "Type" : "AWS::EC2::SecurityGroup::Id"
+        },
         "InstanceType" : {
             "Type" : "String",
             "Description" : "EC2 instance type",
@@ -222,7 +226,8 @@
                 "SecurityGroupIngress" : [
                     { "IpProtocol": "tcp", "FromPort": "22", "ToPort": "22", "CidrIp": "77.91.248.0/21" },
                     { "IpProtocol": "tcp", "FromPort": "9000", "ToPort": "9000", "CidrIp": "77.91.248.0/21" },
-                    { "IpProtocol": "tcp", "FromPort": "9000", "ToPort": "9000", "SourceSecurityGroupId" : { "Ref" : "LoadBalancerSecurityGroup" } }
+                    { "IpProtocol": "tcp", "FromPort": "9000", "ToPort": "9000", "SourceSecurityGroupId" : { "Ref" : "LoadBalancerSecurityGroup" } },
+                    { "IpProtocol": "tcp", "FromPort": "9000", "ToPort": "9000", "SourceSecurityGroupId" : { "Ref" : "StatusAppSecurityGroup" } }
                 ]
             }
         },


### PR DESCRIPTION
I moaned that version information wasn't showing in Status App, and Phil said:

https://github.com/guardian/subscriptions-frontend/pull/265#issuecomment-152990000

So I copied the tiny bit of CF from Ophan:

https://github.com/guardian/ophan/blob/601868/cloudformation/dashboard.template.yaml#L121

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#parameters-section-structure-syntax

Finally, we can see the machine build version:

![image](https://cloud.githubusercontent.com/assets/52038/10996648/e288fbae-847e-11e5-83b1-0189205c3778.png)

cc @tomverran 