### PR TITLE
Compatibility with membership-common 0.99

### DIFF
--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -56,7 +56,7 @@ object SubscriptionDataExtensionRow {
         "Currency" -> formatCurrency(account.currency),
         //TODO to remove, hardcoded in the template
         "Trial period" -> "14",
-        "MandateID" -> paymentMethod.mandateId,
+        "MandateID" -> paymentMethod.mandateId.mkString,
         "Email" -> personalData.email
       ) ++ paymentFields
     )

--- a/app/services/ZuoraService.scala
+++ b/app/services/ZuoraService.scala
@@ -5,7 +5,7 @@ import com.gu.membership.zuora.soap._
 import com.gu.membership.zuora.soap.actions.subscribe.Subscribe
 import com.gu.membership.zuora.soap.models.Queries._
 import com.gu.membership.zuora.soap.models.Results.SubscribeResult
-import com.gu.membership.zuora.{ZuoraApiConfig, soap}
+import com.gu.membership.zuora.{ZuoraSoapConfig, ZuoraApiConfig, soap}
 import com.gu.monitoring.ServiceMetrics
 import configuration.Config
 import model.zuora.{DigitalProductPlan, SubscriptionProduct}
@@ -30,7 +30,7 @@ trait ZuoraService {
   def paymentDelaysInDays: Period
 }
 
-class ZuoraApiClient(zuoraApiConfig: ZuoraApiConfig,
+class ZuoraApiClient(zuoraApiConfig: ZuoraSoapConfig,
                      digitalProductPlan: DigitalProductPlan,
                      zuoraProperties: ZuoraProperties) extends ZuoraService {
 

--- a/app/touchpoint/TouchpointBackendConfig.scala
+++ b/app/touchpoint/TouchpointBackendConfig.scala
@@ -3,7 +3,7 @@ package touchpoint
 import com.github.nscala_time.time.Imports._
 import com.gu.membership.salesforce.SalesforceConfig
 import com.gu.membership.stripe.StripeApiConfig
-import com.gu.membership.zuora.ZuoraApiConfig
+import com.gu.membership.zuora.{ZuoraSoapConfig, ZuoraApiConfig}
 import com.typesafe.scalalogging.LazyLogging
 import model.zuora.DigitalProductPlan
 import org.joda.time.Period
@@ -11,7 +11,7 @@ import org.joda.time.Period
 case class TouchpointBackendConfig(
   environmentName: String,
   salesforce: SalesforceConfig,
-  zuora: ZuoraApiConfig,
+  zuora: ZuoraSoapConfig,
   zuoraProperties: ZuoraProperties,
   digitalProductPlan: DigitalProductPlan,
   stripe: StripeApiConfig
@@ -47,7 +47,7 @@ object TouchpointBackendConfig extends LazyLogging {
     TouchpointBackendConfig(
       environmentName,
       SalesforceConfig.from(envBackendConf, environmentName),
-      ZuoraApiConfig.from(envBackendConf, environmentName),
+      ZuoraApiConfig.soap(envBackendConf, environmentName),
       ZuoraProperties.from(envBackendConf, environmentName),
       DigitalProductPlan(envBackendConf.getString("zuora.digital")),
       StripeApiConfig.from(envBackendConf, environmentName)

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.88",
+    "com.gu" %% "membership-common" % "0.99",
     "com.gu" %% "play-googleauth" % "0.3.1",
     "com.gu" %% "identity-test-users" % "0.5",
     "com.gu.identity" %% "identity-play-auth" % "0.10",


### PR DESCRIPTION
Soap configs needed updating, also the mandate ID is now an option

@joelochlann do you think we should throw an exception from SubscriptionDataExtensionRow if the mandateId is None at that point? The behaviour in this PR is to default it to "" which is probably wrong