### PR TITLE
Upgrade to latest version of identity-play-auth

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -45,7 +45,7 @@ object Checkout extends Controller with LazyLogging with ActivityTracking {
     val authUserOpt = authenticatedUserFor(request)
 
     def fillForm(): Future[Form[SubscriptionData]] = for {
-      fullUserOpt <- authUserOpt.fold[Future[Option[IdUser]]](Future.successful(None))(au => IdentityService.userLookupByScGuU(AuthCookie(au.authCookie)))
+      fullUserOpt <- authUserOpt.fold[Future[Option[IdUser]]](Future.successful(None))(au => IdentityService.userLookupByCredentials(au.credentials))
     } yield {
         fullUserOpt.map { idUser =>
           SubscriptionsForm().fill(SubscriptionData.fromIdUser(idUser))

--- a/app/services/package.scala
+++ b/app/services/package.scala
@@ -7,8 +7,6 @@ import play.api.libs.json._
 
 package object services {
 
-  case class AuthCookie(value: String)
-
   case class UserId(id: String) {
     override def toString = id
   }

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "membership-common" % "0.98",
     "com.gu" %% "play-googleauth" % "0.3.1",
     "com.gu" %% "identity-test-users" % "0.5",
-    "com.gu.identity" %% "identity-play-auth" % "0.10",
+    "com.gu.identity" %% "identity-play-auth" % "0.12",
     "com.github.nscala-time" %% "nscala-time" % "2.0.0",
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",


### PR DESCRIPTION
See also https://github.com/guardian/identity-play-auth/pull/4

https://trello.com/c/d7jD8CUW/120-members-data-api-enable-access-by-mobile-access-tokens

cc @tomverran @ostapneko @markjamesbutler