### PR TITLE
Revert "Simplify JSON serialisation"

### DIFF
--- a/app/model/JsVars.scala
+++ b/app/model/JsVars.scala
@@ -3,18 +3,33 @@ package model
 import play.api.libs.json._
 
 object JsVars {
-  def default = JsVars()
+  def default = JsVars(
+    userIsSignedIn = false,
+    ignorePageLoadTracking = false,
+    stripePublicKey = None
+  )
 
   implicit val jsVarsWrites = new Writes[JsVars] {
-    private val innerWrites = Json.writes[JsVars]
-    def writes(jsVars: JsVars) = Json.obj(
-      "user" -> Json.toJson(jsVars)(innerWrites)
-    )
+    def writes(jsVars: JsVars) = {
+      val mandatory = Json.obj(
+        "user" -> Json.obj(
+          "isSignedIn" -> jsVars.userIsSignedIn,
+          "ignorePageLoadTracking" -> jsVars.ignorePageLoadTracking
+        )
+      )
+
+      val optional = jsVars.stripePublicKey match {
+        case Some(stripePublicKey) => Json.obj("stripePublicKey" -> stripePublicKey)
+        case None => Json.obj()
+      }
+
+      mandatory ++ optional
+    }
   }
 }
 
 case class JsVars(
-  userIsSignedIn: Boolean = false,
-  ignorePageLoadTracking: Boolean = false,
-  stripePublicKey: Option[String] = None
+  userIsSignedIn: Boolean,
+  ignorePageLoadTracking: Boolean,
+  stripePublicKey: Option[String]
 )


### PR DESCRIPTION
This tidy-up actually broke the checkout flow for signed-in users. The frontend expects the variable to be named `guardian.user.isSignedIn` but because we do a straight serialisation it's now called `guardian.user.userIsSignedIn`. This means user cannot get past the Personal Details section - it thinks the user is not signed in, so it tries to validate the email but can't find it (because a necessary class is omitted from the template for signed-in users), so passes `null` which always fails validation.

Reverting so we can get the checkout flow on PROD working again!

@ostapneko 