### PR TITLE
URI-encode the email address when we check if it's in use

### DIFF
--- a/assets/javascripts/modules/checkout/validatePersonal.js
+++ b/assets/javascripts/modules/checkout/validatePersonal.js
@@ -6,7 +6,7 @@ define([
     'use strict';
 
     function emailCheck(email) {
-        return ajax({ url: '/checkout/check-identity?email=' + email }).then(function (response) {
+        return ajax({ url: '/checkout/check-identity?email=' + encodeURIComponent(email) }).then(function (response) {
             return response.emailInUse;
         }).fail(function (err) {
             Raven.captureException(err);
@@ -54,13 +54,13 @@ define([
                 isEmailInUse: false
             };
 
-            if(hasBasicValidity) {
+            if (hasBasicValidity) {
 
                 /**
                  * If the user is signed in we do not need to
                  * validate their email address
                  */
-                if(isSignedIn) {
+                if (isSignedIn) {
                     validity.allValid = true;
                     resolve(validity);
                 }
@@ -70,7 +70,7 @@ define([
                  * a) validate their email address
                  * b) confirm their email address is not in use
                  */
-                if(!isSignedIn && hasBasicEmailValidity) {
+                if (!isSignedIn && hasBasicEmailValidity) {
                     emailCheck(emailValue).then(function(isEmailInUse) {
                         if(isEmailInUse) {
                             validity.isEmailInUse = true;


### PR DESCRIPTION
Currently when we make an AJAX request to check whether the supplied email address is in use, we don't URI encode the email. This means that, for example, a plus sign in an email address would be seen as a space by the backend, meaning that in-use emails would be treated as available. This breaks the final checkout step, which assumes the email is not taken when it tries to create a guest identity account.