### PR TITLE
Only display payment notices once you get to the payment details section

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -58,7 +58,7 @@
                         @priceOption(product, "every 12 months", product.frequency.numberOfMonths)
                     }
                 </fieldset>
-                <div class="u-display-from-tablet" data-set="checkout-notices">
+                <div class="js-checkout-notices notices-container" data-set="checkout-notices" hidden="true">
                     <div class="js-append">
                         <div class="js-payment-type-direct-debit">
                             @fragments.checkout.noticesDirectDebit()

--- a/assets/javascripts/modules/checkout/editFieldsets.js
+++ b/assets/javascripts/modules/checkout/editFieldsets.js
@@ -11,40 +11,40 @@ define([
     var FIELDSET_COMPLETE = 'is-complete';
     var FIELDSET_COLLAPSED = 'is-collapsed';
 
-    function collapseFieldsets(extra) {
+    function collapseFieldsetsExcept(leaveOpen) {
         [
             formEls.$FIELDSET_YOUR_DETAILS,
             formEls.$FIELDSET_PAYMENT_DETAILS,
             formEls.$FIELDSET_REVIEW
         ].forEach(function(item) {
-            item.addClass(FIELDSET_COLLAPSED);
+            if (item === leaveOpen) {
+                item.removeClass(FIELDSET_COLLAPSED);
+            } else {
+                item.addClass(FIELDSET_COLLAPSED);
+            }
         });
-        if(extra) {
-            extra.removeClass(FIELDSET_COLLAPSED);
-        }
     }
 
     function init() {
         var $editDetails = formEls.$EDIT_YOUR_DETAILS;
         var $editPayment = formEls.$EDIT_PAYMENT_DETAILS;
 
-        if($editDetails.length && $editPayment.length){
-
-            bean.on($editDetails[0], 'click', function (e) {
+        if ($editDetails.length && $editPayment.length) {
+            bean.on($editDetails[0], 'click', function(e) {
                 e.preventDefault();
-                collapseFieldsets(formEls.$FIELDSET_YOUR_DETAILS);
+                collapseFieldsetsExcept(formEls.$FIELDSET_YOUR_DETAILS);
                 formEls.$FIELDSET_YOUR_DETAILS.removeClass(FIELDSET_COMPLETE);
                 formEls.$FIELDSET_PAYMENT_DETAILS.removeClass(FIELDSET_COMPLETE);
+                formEls.$NOTICES.attr('hidden', true);
                 tracking.personalDetailsTracking();
             });
 
-            bean.on($editPayment[0], 'click', function (e) {
+            bean.on($editPayment[0], 'click', function(e) {
                 e.preventDefault();
-                collapseFieldsets(formEls.$FIELDSET_PAYMENT_DETAILS);
+                collapseFieldsetsExcept(formEls.$FIELDSET_PAYMENT_DETAILS);
                 formEls.$FIELDSET_PAYMENT_DETAILS.removeClass(FIELDSET_COMPLETE);
                 tracking.paymentDetailsTracking();
             });
-
         }
     }
 

--- a/assets/javascripts/modules/checkout/formElements.js
+++ b/assets/javascripts/modules/checkout/formElements.js
@@ -4,6 +4,8 @@ define(['$'], function ($) {
     return {
         $CHECKOUT_FORM: $('.js-checkout-form'),
 
+        $NOTICES: $('.js-checkout-notices'),
+
         $FIRST_NAME: $('.js-checkout-first .js-input'),
         $LAST_NAME: $('.js-checkout-last .js-input'),
         $EMAIL: $('.js-checkout-email .js-input'),

--- a/assets/javascripts/modules/checkout/personalDetails.js
+++ b/assets/javascripts/modules/checkout/personalDetails.js
@@ -55,6 +55,8 @@ define([
             .addClass(FIELDSET_COMPLETE)[0]
             .scrollIntoView();
 
+        formEls.$NOTICES.removeAttr('hidden');
+
         tracking.paymentDetailsTracking();
     }
 

--- a/assets/stylesheets/modules/_checkout.scss
+++ b/assets/stylesheets/modules/_checkout.scss
@@ -75,6 +75,12 @@
 /* Notice
    ========================================================================== */
 
+.notices-container {
+    display: none;
+    @include mq(tablet) {
+        display: block;
+    }
+}
 .notice {
     @include fs-textSans(2);
     border-top: 1px dotted $c-neutral5;


### PR DESCRIPTION
The payment notices on the right-hand side should not be visible when the user is on the Personal Details section.

![picture 53](https://cloud.githubusercontent.com/assets/5122968/11340674/e30448d8-91f6-11e5-8033-68c9f2f724ac.png)

then:

![picture 54](https://cloud.githubusercontent.com/assets/5122968/11340673/e2ff1e30-91f6-11e5-9ee1-a07cd83902ba.png)

then:

![picture 55](https://cloud.githubusercontent.com/assets/5122968/11340672/e2eb2448-91f6-11e5-8eca-d0e8a947681d.png)
