### PR TITLE
Refresh ExactTarget access token more frequently

### DIFF
--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -95,7 +95,7 @@ object ETClient extends ETClient with LazyLogging {
     (Json.parse(respBody) \ "accessToken").as[String]
   }
 
-  Akka.system.scheduler.schedule(initialDelay = 55.minutes, interval = 55.minutes) {
+  Akka.system.scheduler.schedule(initialDelay = 30.minutes, interval = 30.minutes) {
     accessToken send getAccessToken
   }
 


### PR DESCRIPTION
Occasionally we get 401 Unauthorized errors back from ExactTarget which is most likely due to an expired token: https://code.exacttarget.com/apis-sdks/rest-api/using-the-api-key-to-authenticate-api-calls.html

Reducing the delay between token refreshes to see if this helps.

@ostapneko 