### PR TITLE
Don't doubly hyphenate a sort code

### DIFF
--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -105,7 +105,7 @@ object SubscriptionDataExtensionRow extends LazyLogging{
   }
 
   private def formatSortCode(sortCode: String): String = {
-    sortCode.grouped(2).mkString("-")
+    sortCode.filter(_.isDigit).grouped(2).mkString("-")
   }
 
   private def formatCurrency(currency: String): String = {


### PR DESCRIPTION
We end up passing an already-hyphenated sortcode (e.g. `20-00-00`) to this function before sending the sortcode to ExactTarget. This results in `20--0-0--0` appearing in the email. So I opted to filter out the non-digits before hyphenating.