### PR TITLE
Attempt to take payment straightaway on UAT

### DIFF
--- a/conf/touchpoint.UAT.conf
+++ b/conf/touchpoint.UAT.conf
@@ -14,7 +14,7 @@ touchpoint.backend.environments {
             }
         }
         zuora {
-            paymentDelayInDays = 1
+            paymentDelayInDays = 0
             api {
                 url = "https://apisandbox.zuora.com/apps/services/a/58.0"
                 username = ""


### PR DESCRIPTION
There are certain Stripe payment errors that we never see (and therefore can't test) in the frontend if Zuora doesn't attempt to take payment straightaway. Given that we apparently have the scheduled payments turned off in UAT Zuora anyway, I don't think the payment delay in UAT has much value so I propose we remove it.

@rtyley Do you agree?