### PR TITLE
Show two payment options to all users

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -111,10 +111,6 @@
                         <div class="field-panel__intro">
                             <div class="field-note field-note--offset">
                                 @fragments.forms.securityNote()
-                                @* This block will be removed once credit/debit card option is visible to real users *@
-                                @if(touchpointBackendResolution.validTestUserCredentialOpt.isEmpty) {
-                                    Payment will be taken by Direct Debit
-                                }
                             </div>
                         </div>
                         <div class="field-panel__edit">

--- a/app/views/fragments/checkout/fieldsPayment.scala.html
+++ b/app/views/fragments/checkout/fieldsPayment.scala.html
@@ -2,11 +2,7 @@
 
 @* ===== Payment type ===== *@
 
-@******************************************************************************************
-    Credit/debit card payment option is currently only exposed to logged-in test users.
-    TODO: remove this condition once Manage My Account functionality is released.
-*******************************************************************************************@
-<div @if(touchpointBackendResolution.validTestUserCredentialOpt.isEmpty){ hidden="true" }>
+<div>
     <div class="label u-margin-bottom">How would you like to pay?</div>
     <div class="field-group js-checkout-payment-method">
         <div class="field-group__item">


### PR DESCRIPTION
**DO NOT MERGE UNTIL WE'RE READY TO GO LIVE WITH CARD PAYMENT**

This exposes the two payment options (direct debit vs card) to all users. Previously only test users had this choice. Normal users just saw direct debit as before.

@tomverran 