### PR TITLE
Log 'X-Forwarded-For' headers to help with diagnosing recorded IPs

### DIFF
--- a/app/controllers/Testing.scala
+++ b/app/controllers/Testing.scala
@@ -3,7 +3,7 @@ package controllers
 import actions.CommonActions._
 import com.typesafe.scalalogging.LazyLogging
 import controllers._
-import play.api.mvc.{Controller, Cookie}
+import play.api.mvc.{Headers, Controller, Cookie}
 import utils.TestUsers.testUsers
 
 object Testing extends Controller with LazyLogging {
@@ -15,6 +15,8 @@ object Testing extends Controller with LazyLogging {
   val PreSigninTestCookieName = "pre-signin-test-user"
 
   def testUser = GoogleAuthenticatedStaffAction { implicit request =>
+    val headers = request.headers
+    logger.info(s"remoteAddress=${request.remoteAddress} $X_FORWARDED_FOR=${headers.getAll(X_FORWARDED_FOR).mkString("_")} $FORWARDED=${headers.getAll(FORWARDED).mkString("_")}")
 
     val testUserString = testUsers.generate()
     logger.info(s"Generated test user string $testUserString")


### PR DESCRIPTION
[Ed Fox](http://spike/content/3433) has noticed that we're actually recording _Fastly's_ IP address for subscribers, rather than the IP of the actual user.

https://trello.com/c/I94f2NAl/284-custom-data-fields-for-2-0-subscriber-ip-address

Fastly is already set up to add the relevant forwarded headers...

https://docs.fastly.com/guides/basic-configuration/manipulating-the-x-forwarded-for-header
https://app.fastly.com/#configure/service/6CcQKlAJNA1HitqjWn4c10/version/23/settings
![image](https://cloud.githubusercontent.com/assets/52038/12196805/a3609660-b5f9-11e5-8c14-9344e0e9c304.png)


...so I'm not sure why this isn't working, adding this debug should help.

cc @tomverran 