### PR TITLE
Remove recover combinator from ET service

### DIFF
--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -29,7 +29,7 @@ trait ExactTargetService extends LazyLogging {
       pm <- zuoraService.getDefaultPaymentMethod(acc)
     } yield (acc, pm)
 
-    (for {
+    for {
       subs <- subscription
       rpc <- zuoraService.recurringRatePlanCharge(subs)
       (acc, pm) <- accAndPaymentMethod
@@ -50,8 +50,6 @@ trait ExactTargetService extends LazyLogging {
           logger.error(errorMsg)
           throw new ExactTargetException(errorMsg)
       }
-    }) recover { case err: Throwable =>
-      logger.error(s"Error while trying to send an email to ExactTarget", err)
     }
   }
 }

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -46,9 +46,8 @@ trait ExactTargetService extends LazyLogging {
         case 202 =>
           logger.info(s"Successfully sent an email to confirm the subscription: $subscribeResult")
         case _ =>
-          val errorMsg = s"Failed to send the subscription email $subscribeResult. Code: ${response.code()}, Message: ${response.body.string()}"
-          logger.error(errorMsg)
-          throw new ExactTargetException(errorMsg)
+          logger.error(
+            s"Failed to send the subscription email $subscribeResult. Code: ${response.code()}, Message: ${response.body.string()}")
       }
     }
   }


### PR DESCRIPTION
@joelochlann @afiore 

The recover combinator does not seem to add more value, as the error is already sufficiently logged at line [50](https://github.com/guardian/subscriptions-frontend/compare/fix-superfluous-recover-combinator?expand=1#diff-4b43727a795be0d3aaf5e0d734bb7f44R50).

[Sentry events](https://app.getsentry.com/the-guardian/subscriptions/issues/106183481/events/)