### PR TITLE
Make postcode always mandatory

### DIFF
--- a/app/model/AddressValidation.scala
+++ b/app/model/AddressValidation.scala
@@ -6,13 +6,10 @@ object AddressValidation {
   def validateForCountry(address: Address) = {
     val rules = AddressValidationRules(address.country)
 
-    val postcodeValid = rules.postcode == PostcodeOptional || address.postCode.nonEmpty
-    val subdivisionValid = rules.subdivision match {
+    rules.subdivision match {
       case SubdivisionOptional => true
       case SubdivisionRequired => address.countyOrState.nonEmpty
       case SubdivisionList(s) => s.contains(address.countyOrState)
     }
-
-    postcodeValid && subdivisionValid
   }
 }

--- a/app/model/AddressValidationRules.scala
+++ b/app/model/AddressValidationRules.scala
@@ -8,18 +8,13 @@ case object SubdivisionOptional extends SubdivisionRule
 case object SubdivisionRequired extends SubdivisionRule
 case class SubdivisionList(subdivision: Seq[String]) extends SubdivisionRule
 
-sealed trait PostcodeRule
-case object PostcodeOptional extends PostcodeRule
-case object PostcodeRequired extends PostcodeRule
-
-case class AddressValidationRules(postcode: PostcodeRule,
-                                  subdivision: SubdivisionRule)
+case class AddressValidationRules(subdivision: SubdivisionRule)
 
 object AddressValidationRules {
   def apply(country: Country): AddressValidationRules = CountryGroup.byCountryCode(country.alpha2) match {
-    case Some(UK) => AddressValidationRules(PostcodeRequired, SubdivisionOptional)
-    case Some(US) => AddressValidationRules(PostcodeRequired, SubdivisionList(Country.US.states))
-    case Some(Canada) => AddressValidationRules(PostcodeRequired, SubdivisionList(Country.Canada.states))
-    case _ => AddressValidationRules(PostcodeOptional, SubdivisionOptional)
+    case Some(UK) => AddressValidationRules(SubdivisionOptional)
+    case Some(US) => AddressValidationRules(SubdivisionList(Country.US.states))
+    case Some(Canada) => AddressValidationRules(SubdivisionList(Country.Canada.states))
+    case _ => AddressValidationRules(SubdivisionOptional)
   }
 }

--- a/app/model/IdUserOps.scala
+++ b/app/model/IdUserOps.scala
@@ -1,0 +1,40 @@
+package model
+
+import com.gu.identity.play.PrivateFields
+import com.gu.identity.play.IdUser
+import com.gu.memsub.Address
+
+object IdUserOps {
+  implicit class IdUserWithAddress(u: IdUser) {
+    def address = {
+      val pf = u.privateFields.getOrElse(PrivateFields())
+
+      val billingAddressDefined =
+        (pf.billingCountry orElse
+         pf.billingAddress1 orElse
+         pf.billingAddress2 orElse
+         pf.billingAddress3 orElse
+         pf.billingAddress4 orElse
+         pf.billingPostcode).isDefined
+
+      if (billingAddressDefined)
+        Address(
+          lineOne = pf.billingAddress1.getOrElse(""),
+          lineTwo = pf.billingAddress2.getOrElse(""),
+          town = pf.billingAddress3.getOrElse(""),
+          countyOrState = pf.billingAddress4.getOrElse(""),
+          postCode = pf.billingPostcode.getOrElse(""),
+          countryName = pf.billingCountry.getOrElse("")
+        )
+      else
+        Address(
+          lineOne = pf.address1.getOrElse(""),
+          lineTwo = pf.address2.getOrElse(""),
+          town = pf.address3.getOrElse(""),
+          countyOrState = pf.address4.getOrElse(""),
+          postCode = pf.postcode.getOrElse(""),
+          countryName = pf.country.getOrElse("")
+        )
+    }
+  }
+}

--- a/app/model/SubscriptionData.scala
+++ b/app/model/SubscriptionData.scala
@@ -4,6 +4,7 @@ import com.gu.i18n.{Country, CountryGroup}
 import com.gu.identity.play.IdUser
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.{Address, FullName}
+import IdUserOps._
 
 sealed trait PaymentType {
   def toKey: String
@@ -60,31 +61,12 @@ case class SubscriptionData(personalData: PersonalData, paymentData: PaymentData
 
 object SubscriptionData {
   def fromIdUser(u: IdUser) = {
-    implicit class OptField[A](opt: Option[A]) {
-      def getOrDefault[B](get: A => Option[B], orElse: A => Option[B], default: B): B =
-        (for {
-          fieldOpt <- opt
-          fieldValue <- get(fieldOpt) orElse orElse(fieldOpt)
-        } yield fieldValue) getOrElse default
-      def getOrBlank(get: A => Option[String]): String = getOrDefault(get, _ => None, "")
-      def getOrBlank(get: A => Option[String], orElse: A => Option[String]): String = getOrDefault(get, orElse, "")
-    }
-
-    val addressData = Address(
-      lineOne = u.privateFields.getOrBlank(_.billingAddress1, _.address1),
-      lineTwo = u.privateFields.getOrBlank(_.billingAddress2, _.address2),
-      town = u.privateFields.getOrBlank(_.billingAddress3, _.address3),
-      postCode = u.privateFields.getOrBlank(_.postcode),
-      countyOrState = u.privateFields.getOrBlank(_.billingAddress4, _.address4),
-      countryName = u.privateFields.getOrBlank(_.country)
-    )
-
     val personalData = PersonalData(
-      u.privateFields.getOrBlank(_.firstName),
-      u.privateFields.getOrBlank(_.secondName),
-      u.primaryEmailAddress,
-      u.statusFields.getOrDefault(_.receiveGnmMarketing, _ => None, false),
-      addressData
+      first = u.privateFields.flatMap(_.firstName).getOrElse(""),
+      last = u.privateFields.flatMap(_.secondName).getOrElse(""),
+      email = u.primaryEmailAddress,
+      receiveGnmMarketing = u.statusFields.flatMap(_.receiveGnmMarketing).getOrElse(false),
+      address = u.address
     )
 
     val blankPaymentData = DirectDebitData("", "", "")

--- a/app/views/support/AddressValidationRulesOps.scala
+++ b/app/views/support/AddressValidationRulesOps.scala
@@ -6,22 +6,14 @@ import play.twirl.api.Html
 object AddressValidationRulesOps {
   implicit class ValidationRulesToAttributes(rules: AddressValidationRules) {
     private val toAttributesMap: Map[String, String] = {
-      val postcodeRequiredAttr = "data-postcode-required"
       val subdivisionRequired = "data-subdivision-required"
       val subdivisionList = "data-subdivision-list"
 
-      val postcode = rules.postcode match {
-        case PostcodeRequired => Map(postcodeRequiredAttr -> "true")
-        case _ => Map(postcodeRequiredAttr -> "false")
-      }
-
-      val subdivision = rules.subdivision match {
+      rules.subdivision match {
         case SubdivisionOptional => Map(subdivisionRequired -> "false")
         case SubdivisionRequired => Map(subdivisionRequired -> "true")
         case SubdivisionList(s) => Map(subdivisionRequired -> "true", subdivisionList -> s.mkString(","))
       }
-
-      postcode ++ subdivision
     }
 
     def toAttributes: Html = Html(toAttributesMap.map { case (k, v) => s"""$k="$v"""" }.mkString(" "))

--- a/assets/javascripts/modules/checkout/addressFields.js
+++ b/assets/javascripts/modules/checkout/addressFields.js
@@ -47,10 +47,10 @@ define([], function () {
     };
 
 
-    var postcode = function (required, text) {
+    var postcode = function (text) {
         return {
-            label: label(required, text, 'postcode'),
-            input: textInput(required, 'postcode')
+            label: label(true, text, 'postcode'),
+            input: textInput(true, 'postcode')
         };
     };
 

--- a/assets/javascripts/modules/checkout/countryChoice.js
+++ b/assets/javascripts/modules/checkout/countryChoice.js
@@ -2,7 +2,6 @@ define([], function () {
     'use strict';
 
     var addressRules = function (option) {
-        var postcodeRequired = option.getAttribute('data-postcode-required');
         var postcodeLabel = option.getAttribute('data-postcode-label');
 
         var subdivisionLabel = option.getAttribute('data-subdivision-label');
@@ -11,7 +10,7 @@ define([], function () {
         var subdivisionValues = list ? list.split(',') : [];
 
         return {
-            postcode: {required: postcodeRequired === 'true', label: postcodeLabel},
+            postcode: {label: postcodeLabel},
             subdivision: {required: subdivisionRequired === 'true', values: subdivisionValues, label: subdivisionLabel}
         };
     };

--- a/assets/javascripts/modules/checkout/fieldSwitcher.js
+++ b/assets/javascripts/modules/checkout/fieldSwitcher.js
@@ -33,9 +33,7 @@ define([
     };
 
     var redrawAddressFields = function(model) {
-        var newPostcode = addressFields.postcode(
-            model.postcodeRules.required,
-            model.postcodeRules.label);
+        var newPostcode = addressFields.postcode(model.postcodeRules.label);
 
         var newSubdivision = addressFields.subdivision(
             model.subdivisionRules.required,

--- a/test/js/spec/modules/checkout/AddressFields.spec.js
+++ b/test/js/spec/modules/checkout/AddressFields.spec.js
@@ -11,7 +11,7 @@ define(['modules/checkout/addressFields'], function (addressFields) {
     describe('Address fields generator', function() {
 
         it('should generate a compulsory postcode field with the right label', function () {
-            var output = addressFields.postcode(true, 'Postcode');
+            var output = addressFields.postcode('Postcode');
 
             expect(output.input.isEqualNode(dom(
                 '<input type="text" id="address-postcode" name="personal.address.postcode" class="input-text" required="required">'
@@ -23,13 +23,13 @@ define(['modules/checkout/addressFields'], function (addressFields) {
         });
 
         it('should generate an optional postcode field with the right label', function () {
-            var output = addressFields.postcode(false, 'Zipcode');
+            var output = addressFields.postcode('Zipcode');
             expect(output.input.isEqualNode(dom(
-                '<input type="text" id="address-postcode" class="input-text" name="personal.address.postcode">'
+                '<input type="text" id="address-postcode" class="input-text" name="personal.address.postcode" required="required">'
             ))).toBeTruthy();
 
             expect(output.label.isEqualNode(dom(
-                '<label for="address-postcode" class="optional-marker label">Zipcode</label>'
+                '<label for="address-postcode" class="label">Zipcode</label>'
             ))).toBeTruthy();
         });
 

--- a/test/js/spec/modules/checkout/CountryChoice.spec.js
+++ b/test/js/spec/modules/checkout/CountryChoice.spec.js
@@ -9,14 +9,12 @@ define(['modules/checkout/countryChoice'], function (addressRules) {
             option = document.createElement('option');
         });
 
-        it('should parse data-postcode-required and data-postcode-label from an element', function () {
-            option.setAttribute('data-postcode-required', true);
+        it('should parse data-postcode-label from an element', function () {
             option.setAttribute('data-postcode-label', 'postcode');
-            expect(addressRules.addressRules(option).postcode).toEqual({label: 'postcode', required: true});
+            expect(addressRules.addressRules(option).postcode).toEqual({label: 'postcode'});
 
-            option.setAttribute('data-postcode-required', false);
             option.setAttribute('data-postcode-label', 'zip');
-            expect(addressRules.addressRules(option).postcode).toEqual({label: 'zip', required: false});
+            expect(addressRules.addressRules(option).postcode).toEqual({label: 'zip'});
         });
 
         it('should parse data-subdivision-required and data-subdivision-list from an element', function() {

--- a/test/model/AddressValidationTest.scala
+++ b/test/model/AddressValidationTest.scala
@@ -6,15 +6,10 @@ import com.gu.i18n.Country._
 
 class AddressValidationTest extends Specification {
 
-  "AddressValidation$Test" should {
+  "AddressValidationTest" should {
     val address = Address("lineOne", "lineTwo", "town", "", "", UK.name)
 
     "validateForCountry" should {
-      "checks the postcode if required" in {
-        AddressValidation.validateForCountry(address) should_=== false
-        AddressValidation.validateForCountry(address.copy(postCode = "postcode")) should_=== true
-      }
-
       "checks the subdivision if required" in {
         AddressValidation.validateForCountry(address.copy(postCode = "postcode")) should_=== true
         AddressValidation.validateForCountry(address.copy(postCode = "postcode", countyOrState = "Alaska", countryName = US.name)) should_=== true

--- a/test/model/IdUserOpsTest.scala
+++ b/test/model/IdUserOpsTest.scala
@@ -1,0 +1,62 @@
+package model
+
+import com.gu.memsub.Address
+import com.gu.identity.play.{PublicFields, PrivateFields, IdUser}
+import org.specs2.mutable.Specification
+import IdUserOps._
+
+class IdUserOpsTest extends Specification {
+  "address" should {
+
+    def idUser(fields: PrivateFields): IdUser =
+      IdUser(
+        id = "id",
+        primaryEmailAddress = "email",
+        publicFields = PublicFields(None),
+        privateFields = Some(fields),
+        statusFields = None)
+
+    val billingAddress = PrivateFields(
+      billingAddress1 = Some("billingAddress1"),
+      billingAddress2 = Some("billingAddress2"),
+      billingAddress3 = Some("billingAddress3"),
+      billingAddress4 = Some("billingAddress4"),
+      billingCountry = Some("billingCountry"),
+      billingPostcode = Some("billingPostcode"),
+      country = Some("country"))
+
+     val deliveryAddress = PrivateFields(
+      address1 = Some("address1"),
+      address2 = Some("address2"),
+      address3 = Some("address3"),
+      address4 = Some("address4"),
+      country = Some("country"),
+      postcode = Some("postcode"))
+
+    val withBillingAddress = idUser(billingAddress)
+    val withoutBillingAddress = idUser(deliveryAddress)
+
+    "use the billing address if at least one of its fields is present" in {
+      withBillingAddress.address.should_===(Address(
+        billingAddress.billingAddress1.get,
+        billingAddress.billingAddress2.get,
+        billingAddress.billingAddress3.get,
+        billingAddress.billingAddress4.get,
+        billingAddress.billingPostcode.get,
+        billingAddress.billingCountry.get
+      ))
+    }
+
+    "use the delivery address otherwise" in {
+      withoutBillingAddress.address.should_===(Address(
+        deliveryAddress.address1.get,
+        deliveryAddress.address2.get,
+        deliveryAddress.address3.get,
+        deliveryAddress.address4.get,
+        deliveryAddress.postcode.get,
+        deliveryAddress.country.get
+      ))
+    }
+  }
+
+}


### PR DESCRIPTION
The creation of a guest user in Identity requires us to supply a postcode; so we are making postcode mandatory, even if in some countries this is not ideal 