### PR TITLE
Postcode optional again

### DIFF
--- a/app/model/AddressValidation.scala
+++ b/app/model/AddressValidation.scala
@@ -6,10 +6,13 @@ object AddressValidation {
   def validateForCountry(address: Address) = {
     val rules = AddressValidationRules(address.country)
 
-    rules.subdivision match {
+    val postcodeValid = rules.postcode == PostcodeOptional || address.postCode.nonEmpty
+    val subdivisionValid = rules.subdivision match {
       case SubdivisionOptional => true
       case SubdivisionRequired => address.countyOrState.nonEmpty
       case SubdivisionList(s) => s.contains(address.countyOrState)
     }
+
+    postcodeValid && subdivisionValid
   }
 }

--- a/app/model/AddressValidationRules.scala
+++ b/app/model/AddressValidationRules.scala
@@ -8,13 +8,18 @@ case object SubdivisionOptional extends SubdivisionRule
 case object SubdivisionRequired extends SubdivisionRule
 case class SubdivisionList(subdivision: Seq[String]) extends SubdivisionRule
 
-case class AddressValidationRules(subdivision: SubdivisionRule)
+sealed trait PostcodeRule
+case object PostcodeOptional extends PostcodeRule
+case object PostcodeRequired extends PostcodeRule
+
+case class AddressValidationRules(postcode: PostcodeRule,
+                                  subdivision: SubdivisionRule)
 
 object AddressValidationRules {
   def apply(country: Country): AddressValidationRules = CountryGroup.byCountryCode(country.alpha2) match {
-    case Some(UK) => AddressValidationRules(SubdivisionOptional)
-    case Some(US) => AddressValidationRules(SubdivisionList(Country.US.states))
-    case Some(Canada) => AddressValidationRules(SubdivisionList(Country.Canada.states))
-    case _ => AddressValidationRules(SubdivisionOptional)
+    case Some(UK) => AddressValidationRules(PostcodeRequired, SubdivisionOptional)
+    case Some(US) => AddressValidationRules(PostcodeRequired, SubdivisionList(Country.US.states))
+    case Some(Canada) => AddressValidationRules(PostcodeRequired, SubdivisionList(Country.Canada.states))
+    case _ => AddressValidationRules(PostcodeOptional, SubdivisionOptional)
   }
 }

--- a/app/views/support/AddressValidationRulesOps.scala
+++ b/app/views/support/AddressValidationRulesOps.scala
@@ -6,14 +6,22 @@ import play.twirl.api.Html
 object AddressValidationRulesOps {
   implicit class ValidationRulesToAttributes(rules: AddressValidationRules) {
     private val toAttributesMap: Map[String, String] = {
+      val postcodeRequiredAttr = "data-postcode-required"
       val subdivisionRequired = "data-subdivision-required"
       val subdivisionList = "data-subdivision-list"
 
-      rules.subdivision match {
+      val postcode = rules.postcode match {
+        case PostcodeRequired => Map(postcodeRequiredAttr -> "true")
+        case _ => Map(postcodeRequiredAttr -> "false")
+      }
+
+      val subdivision = rules.subdivision match {
         case SubdivisionOptional => Map(subdivisionRequired -> "false")
         case SubdivisionRequired => Map(subdivisionRequired -> "true")
         case SubdivisionList(s) => Map(subdivisionRequired -> "true", subdivisionList -> s.mkString(","))
       }
+
+      postcode ++ subdivision
     }
 
     def toAttributes: Html = Html(toAttributesMap.map { case (k, v) => s"""$k="$v"""" }.mkString(" "))

--- a/assets/javascripts/modules/checkout/addressFields.js
+++ b/assets/javascripts/modules/checkout/addressFields.js
@@ -47,10 +47,10 @@ define([], function () {
     };
 
 
-    var postcode = function (text) {
+    var postcode = function (required, text) {
         return {
-            label: label(true, text, 'postcode'),
-            input: textInput(true, 'postcode')
+            label: label(required, text, 'postcode'),
+            input: textInput(required, 'postcode')
         };
     };
 

--- a/assets/javascripts/modules/checkout/countryChoice.js
+++ b/assets/javascripts/modules/checkout/countryChoice.js
@@ -2,6 +2,7 @@ define([], function () {
     'use strict';
 
     var addressRules = function (option) {
+        var postcodeRequired = option.getAttribute('data-postcode-required');
         var postcodeLabel = option.getAttribute('data-postcode-label');
 
         var subdivisionLabel = option.getAttribute('data-subdivision-label');
@@ -10,7 +11,7 @@ define([], function () {
         var subdivisionValues = list ? list.split(',') : [];
 
         return {
-            postcode: {label: postcodeLabel},
+            postcode: {required: postcodeRequired === 'true', label: postcodeLabel},
             subdivision: {required: subdivisionRequired === 'true', values: subdivisionValues, label: subdivisionLabel}
         };
     };

--- a/assets/javascripts/modules/checkout/fieldSwitcher.js
+++ b/assets/javascripts/modules/checkout/fieldSwitcher.js
@@ -33,7 +33,9 @@ define([
     };
 
     var redrawAddressFields = function(model) {
-        var newPostcode = addressFields.postcode(model.postcodeRules.label);
+        var newPostcode = addressFields.postcode(
+            model.postcodeRules.required,
+            model.postcodeRules.label);
 
         var newSubdivision = addressFields.subdivision(
             model.subdivisionRules.required,

--- a/test/js/spec/modules/checkout/AddressFields.spec.js
+++ b/test/js/spec/modules/checkout/AddressFields.spec.js
@@ -11,7 +11,7 @@ define(['modules/checkout/addressFields'], function (addressFields) {
     describe('Address fields generator', function() {
 
         it('should generate a compulsory postcode field with the right label', function () {
-            var output = addressFields.postcode('Postcode');
+            var output = addressFields.postcode(true, 'Postcode');
 
             expect(output.input.isEqualNode(dom(
                 '<input type="text" id="address-postcode" name="personal.address.postcode" class="input-text" required="required">'
@@ -23,13 +23,13 @@ define(['modules/checkout/addressFields'], function (addressFields) {
         });
 
         it('should generate an optional postcode field with the right label', function () {
-            var output = addressFields.postcode('Zipcode');
+            var output = addressFields.postcode(false, 'Zipcode');
             expect(output.input.isEqualNode(dom(
-                '<input type="text" id="address-postcode" class="input-text" name="personal.address.postcode" required="required">'
+                '<input type="text" id="address-postcode" class="input-text" name="personal.address.postcode">'
             ))).toBeTruthy();
 
             expect(output.label.isEqualNode(dom(
-                '<label for="address-postcode" class="label">Zipcode</label>'
+                '<label for="address-postcode" class="optional-marker label">Zipcode</label>'
             ))).toBeTruthy();
         });
 

--- a/test/js/spec/modules/checkout/CountryChoice.spec.js
+++ b/test/js/spec/modules/checkout/CountryChoice.spec.js
@@ -9,12 +9,14 @@ define(['modules/checkout/countryChoice'], function (addressRules) {
             option = document.createElement('option');
         });
 
-        it('should parse data-postcode-label from an element', function () {
+        it('should parse data-postcode-required and data-postcode-label from an element', function () {
+            option.setAttribute('data-postcode-required', true);
             option.setAttribute('data-postcode-label', 'postcode');
-            expect(addressRules.addressRules(option).postcode).toEqual({label: 'postcode'});
+            expect(addressRules.addressRules(option).postcode).toEqual({label: 'postcode', required: true});
 
+            option.setAttribute('data-postcode-required', false);
             option.setAttribute('data-postcode-label', 'zip');
-            expect(addressRules.addressRules(option).postcode).toEqual({label: 'zip'});
+            expect(addressRules.addressRules(option).postcode).toEqual({label: 'zip', required: false});
         });
 
         it('should parse data-subdivision-required and data-subdivision-list from an element', function() {

--- a/test/model/AddressValidationTest.scala
+++ b/test/model/AddressValidationTest.scala
@@ -6,10 +6,15 @@ import com.gu.i18n.Country._
 
 class AddressValidationTest extends Specification {
 
-  "AddressValidationTest" should {
+  "AddressValidation$Test" should {
     val address = Address("lineOne", "lineTwo", "town", "", "", UK.name)
 
     "validateForCountry" should {
+      "checks the postcode if required" in {
+        AddressValidation.validateForCountry(address) should_=== false
+        AddressValidation.validateForCountry(address.copy(postCode = "postcode")) should_=== true
+      }
+
       "checks the subdivision if required" in {
         AddressValidation.validateForCountry(address.copy(postCode = "postcode")) should_=== true
         AddressValidation.validateForCountry(address.copy(postCode = "postcode", countyOrState = "Alaska", countryName = US.name)) should_=== true


### PR DESCRIPTION
- Revert mandatory postcode
- Send a bogus value to Identity when user-supplied postcode is blank