### PR TITLE
Fixed code typo where analytics prop17 was always being set to null

### DIFF
--- a/assets/javascripts/modules/analytics/omniture.js
+++ b/assets/javascripts/modules/analytics/omniture.js
@@ -42,7 +42,7 @@ define([
             ].join(';');
         }
         if (guardian.pageInfo.slug) {
-            s.prop17 = guardian.slug;
+            s.prop17 = guardian.pageInfo.slug;
         }
     }
 


### PR DESCRIPTION
[Trello ticket 320](https://trello.com/c/ZfS7hMa7/320-adobe-analytics-missing-data-for-prop17) Fixed a typo where the Adobe analytics prop17 tag was always being set to null