### PR TITLE
Fix Firefox analytics

### DIFF
--- a/assets/javascripts/modules/analytics/analyticsEnabled.js
+++ b/assets/javascripts/modules/analytics/analyticsEnabled.js
@@ -3,9 +3,19 @@ define([
 ], function (cookie) {
     'use strict';
 
+    /*
+    Re: https://bugzilla.mozilla.org/show_bug.cgi?id=1023920#c2
+
+    The landscape at the moment is:
+
+        On navigator [Firefox, Chrome, Opera]
+        On window [IE, Safari]
+    */
+    var isDNT = navigator.doNotTrack == '1' || window.doNotTrack == '1';
+
     var analyticsEnabled = (
         window.guardian.analyticsEnabled &&
-        !navigator.doNotTrack &&
+        !isDNT &&
         !cookie.getCookie('ANALYTICS_OFF_KEY')
     );
 


### PR DESCRIPTION
Fixing bug where analytics did not work on Firefox, because navigator.doNotTrack === "unspecified" so prefixing ! returned true rather than false. Chrome returns 'null' for that value. Also fixed that IE and Safari use window.doNotTrack rather than navigator.