### PR TITLE
Upgrading to latest membership-common

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -7,6 +7,7 @@ import com.gu.cas.PrefixedTokens
 import com.gu.config.{DigitalPackRatePlanIds, MembershipRatePlanIds, ProductFamilyRatePlanIds}
 import com.gu.googleauth.GoogleAuthConfig
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
+import com.gu.memsub.promo.{AppliesTo, PromoCode, Promotion}
 import com.gu.memsub.{Digipack, Membership}
 import com.gu.monitoring.StatusMetrics
 import com.gu.salesforce.SalesforceConfig
@@ -100,6 +101,20 @@ object Config {
 
   def membershipRatePlanIds(env: String) =
     MembershipRatePlanIds.fromConfig(ProductFamilyRatePlanIds.config(Some(config))(env, Membership))
+
+  def demoPromo(env: String) = {
+    val prpIds = digipackRatePlanIds(env)
+    Promotion(
+      codes = Set(PromoCode("sub-01")),
+      appliesTo = AppliesTo.ukOnly(Set(
+        prpIds.digitalPackMonthly,
+        prpIds.digitalPackQuaterly,
+        prpIds.digitalPackYearly
+      )),
+      thumbnailUrl = "http://lorempixel.com/400/200/abstract",
+      description = "You'll get a complimentary John Lewis digital gift card worth £25",
+      redemptionInstructions = "We'll send redemption instructions to your registered email address")
+  }
 
   object CAS {
     lazy val casConf = config.getConfig("cas")

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -98,7 +98,7 @@ object Checkout extends Controller with LazyLogging with ActivityTracking with C
     checkoutResult.map { result =>
 
       val productData = Seq(
-        SessionKeys.SubsName -> result.subscribeResult.name,
+        SessionKeys.SubsName -> result.subscribeResult.subscriptionName,
         SessionKeys.RatePlanId -> formData.productRatePlanId.get
       )
 

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -22,7 +22,7 @@ trait ExactTargetService extends LazyLogging {
   def zuoraService: ZuoraService
 
   def sendETDataExtensionRow(subscribeResult: SubscribeResult, subscriptionData: SubscriptionData): Future[Unit] = {
-    val subscription = zuoraService.getSubscription(Subscription.Name(subscribeResult.name))
+    val subscription = zuoraService.getSubscription(Subscription.Name(subscribeResult.subscriptionName))
 
     val accAndPaymentMethod = for {
       subs <- subscription

--- a/app/services/TouchpointBackend.scala
+++ b/app/services/TouchpointBackend.scala
@@ -8,6 +8,7 @@ import com.gu.stripe.StripeService
 import com.gu.zuora
 import com.gu.zuora.{rest, soap}
 import configuration.Config
+import configuration.Config._
 import monitoring.TouchpointBackendMetrics
 import play.api.Play.current
 import play.api.libs.concurrent.Akka
@@ -33,7 +34,7 @@ object TouchpointBackend {
     val membershipRatePlanIds = Config.membershipRatePlanIds(config.environmentName)
     val catalogService = CatalogService(restClient, membershipRatePlanIds, digipackRatePlanIds, config.environmentName)
     val zuoraService = new zuora.ZuoraService(soapClient, restClient, digipackRatePlanIds)
-    val promoService = new PromoService(digipackConfig)
+    val promoService = new PromoService(Seq(demoPromo("UAT")))
     val _stripeService = new StripeService(config.stripe, new TouchpointBackendMetrics with StatusMetrics {
       val backendEnv = config.stripe.envName
       val service = "Stripe"

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ libraryDependencies ++= Seq(
     filters,
     PlayImport.specs2,
     "com.gu" %% "play-googleauth" % "0.3.3",
-    "com.gu" %% "membership-common" % "0.146",
+    "com.gu" %% "membership-common" % "0.149",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.gu" %% "identity-test-users" % "0.5",
     "com.gu.identity" %% "identity-play-auth" % "0.14",


### PR DESCRIPTION
Membership common was upgraded in version 1.4.9 to remove the list of promotions, and instead require the apps to inject the list of their applicable ones.
