### PR TITLE
Tweaked cloud-formation user data script

### DIFF
--- a/cloud-formation/subscriptions-app.cf.json
+++ b/cloud-formation/subscriptions-app.cf.json
@@ -88,19 +88,20 @@
 
                         "CONF_DIR=/subscriptions/subscriptions-frontend-1.0-SNAPSHOT/conf",
 
-                        {"Fn::Join":["", ["wget -N --directory-prefix=/home/ubuntu/.ssh https://s3-eu-west-1.amazonaws.com/subscriptions-dist/", { "Ref" : "Stack" }, "/authorized_keys &"]]},
+                        {"Fn::Join":["", ["aws --region ", { "Ref": "AWS::Region" }, " s3 cp s3://subscriptions-dist/", { "Ref" : "Stack" }, "/authorized_keys /home/ubuntu/.ssh"]]},
+
                         "apt-get -y update",
                         {"Fn::Join":["", ["echo https://s3-eu-west-1.amazonaws.com/subscriptions-dist/", { "Ref" : "Stack" }, "/", { "Ref" : "Stage" }, "/frontend/app.zip > /etc/gu-artifact-url" ]]},
 
                         "adduser --system --home /subscriptions --disabled-password subscriptions",
 
-                        "wget -i /etc/gu-artifact-url --directory-prefix=/tmp",
+                        {"Fn::Join":["", ["aws --region ", { "Ref": "AWS::Region" }, " s3 cp s3://subscriptions-dist/", { "Ref" : "Stack" }, "/", { "Ref" : "Stage" }, "/frontend/app.zip /tmp"]]},
 
                         "unzip -d /subscriptions /tmp/app.zip",
 
                         "mkdir /etc/gu",
 
-                        {"Fn::Join":["", ["aws --debug --region ", { "Ref": "AWS::Region" }, " s3 cp s3://subscriptions-private/", { "Ref" : "Stage" }, "/subscriptions-frontend.conf /etc/gu"]]},
+                        {"Fn::Join":["", ["aws --region ", { "Ref": "AWS::Region" }, " s3 cp s3://subscriptions-private/", { "Ref" : "Stage" }, "/subscriptions-frontend.conf /etc/gu"]]},
                         "chown subscriptions /etc/gu/subscriptions-frontend.conf",
                         "chmod 0600 /etc/gu/subscriptions-frontend.conf",
 

--- a/cloud-formation/subscriptions-app.cf.json
+++ b/cloud-formation/subscriptions-app.cf.json
@@ -90,9 +90,6 @@
 
                         {"Fn::Join":["", ["aws --region ", { "Ref": "AWS::Region" }, " s3 cp s3://subscriptions-dist/", { "Ref" : "Stack" }, "/authorized_keys /home/ubuntu/.ssh"]]},
 
-                        "apt-get -y update",
-                        {"Fn::Join":["", ["echo https://s3-eu-west-1.amazonaws.com/subscriptions-dist/", { "Ref" : "Stack" }, "/", { "Ref" : "Stage" }, "/frontend/app.zip > /etc/gu-artifact-url" ]]},
-
                         "adduser --system --home /subscriptions --disabled-password subscriptions",
 
                         {"Fn::Join":["", ["aws --region ", { "Ref": "AWS::Region" }, " s3 cp s3://subscriptions-dist/", { "Ref" : "Stack" }, "/", { "Ref" : "Stage" }, "/frontend/app.zip /tmp"]]},


### PR DESCRIPTION
Tweaked cloud-init recipe so that it downloads the keys and app.zip via the aws s3 client rather than wget. This should speed up deployments and hopefully prime the s3 client in an attempt to alleviate the issues with the .conf file download...

Also removed the aws cli debug for now. Will re-instate if we get issues.

/cc @rtyley 