### PR TITLE
Allow codes that last a full year in the CAS code generator tool

### DIFF
--- a/app/forms/CASForm.scala
+++ b/app/forms/CASForm.scala
@@ -31,7 +31,7 @@ object CASForm {
 
   val emergencyToken: Form[TokenPayload] = Form(
     "cas" -> mapping(
-      "period" -> number(min = 1, max = 13).transform[Weeks](Weeks.weeks, _.getWeeks),
+      "period" -> number(min = 1, max = 52).transform[Weeks](Weeks.weeks, _.getWeeks),
       "subscriptionCode" -> of[SubscriptionCode]
     )(TokenPayload.apply)(t => Some(t.period, t.subscriptionCode))
   )


### PR DESCRIPTION
Paul Browne (User Help) advised that the old CAS lookup tool allowed us to generate a 52-week token, but the new version only goes up to 13 weeks. This is to extend this to 52 weeks (useful for anyone having trouble getting access to the 6-month Galaxy Gifts offer for the Guardian app or for testing).

@rtyley 