### PR TITLE
Take 2: allow codes that last a full year in the CAS code generator tool

### DIFF
--- a/app/views/staff/cas.scala.html
+++ b/app/views/staff/cas.scala.html
@@ -46,7 +46,7 @@
                     <div class="form-field">
                         <label class="label" for="cas.period">Validity period (weeks)</label>
                         <select required name="cas.period" >
-                        @for(w <- Range(1, 14)) {
+                        @for(w <- Range(1, 53)) {
                             <option value="@w">@w</option>
                         })
                         </select>


### PR DESCRIPTION
Paul Browne (User Help) advised that the old CAS lookup tool allowed us to generate a 52-week token, but the new version only goes up to 13 weeks. This is to extend this to 52 weeks (useful for anyone having trouble getting access to the 6-month Galaxy Gifts offer for the Guardian app or for testing).
@rtyley 