### PR TITLE
Fix Google-Groups-authenticated pages by making private key available

### DIFF
--- a/cloud-formation/subscriptions-app.cf.json
+++ b/cloud-formation/subscriptions-app.cf.json
@@ -140,6 +140,11 @@
                                 "Effect": "Allow",
                                 "Action": "s3:GetObject",
                                 "Resource": "arn:aws:s3:::subscriptions-private/*"
+                            },
+                            {
+                                "Effect": "Allow",
+                                "Action": "s3:GetObject",
+                                "Resource": "arn:aws:s3:::membership-private/membership_directory_cert.p12"
                             }
                         ]
                     }


### PR DESCRIPTION
https://github.com/guardian/subscriptions-frontend/pull/358 introduced Google-Groups-authenticated pages, but authenticating to the Google Directroy API requires a private key, which lives in an S3 bucket that subscriptions was not able to access, giving this error:

https://app.getsentry.com/the-guardian/subscriptions/issues/112657261/

The location of the Google Service Account private key is hard-coded in [memsub-common-play-auth](https://github.com/guardian/memsub-common-play-auth/blob/v0.2/src/main/scala/com/gu/memsub/auth/common/MemSub.scala#L21), which I think is fine, the library is only meant to be used by Mem & Subs.

I've already deployed this cloudformation, and have validated that it works with:

* https://subscribe.theguardian.com/test-users
* https://subscribe.theguardian.com/staff/cas

cc @paulbrown1982 