### PR TITLE
Turn on Promo Code box for all customers.

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -106,7 +106,7 @@ object Config {
       codes = PromoCodeSet(PromoCode("DGA88"), PromoCode("DGB88")),
       description = "Get £30 to spend with a top retailer of your choice when you subscribe. Use your digital gift card at John Lewis, Amazon, M&S and more. Treat yourself or a friend.",
       expires = new LocalDate(2016,4,1).toDateTime(LocalTime.Midnight, DateTimeZone.forID("Europe/London")),
-      imageUrl = "https://media.guim.co.uk/9ee88fc2f08bc23e69e2e11a4d4964f4120c6725/0_0_850_418/850.jpg",
+      imageUrl = "https://media.guim.co.uk/076bb31be49a31dfe82869ed2937fc8254917361/0_0_850_418/850.jpg",
       promotionType = Incentive,
       redemptionInstructions = "We'll send redemption instructions to your registered email address",
       roundelHtml = "Free <span class='roundel__strong'>£30</span> digital gift card",

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -72,7 +72,7 @@
                         </div>
                     </div>
                 </div>
-                @fragments.checkout.promoCode(form, touchpointBackendResolution)
+                @fragments.checkout.promoCode(form)
             </div>
 
             <div class="checkout-container__form">

--- a/app/views/fragments/checkout/promoCode.scala.html
+++ b/app/views/fragments/checkout/promoCode.scala.html
@@ -3,15 +3,13 @@
 @import com.gu.memsub.promo.PromoCode
 @import controllers.routes.Checkout.validatePromoCode
 @import services.TouchpointBackend
-@(form: Form[model.SubscriptionData], touchpointBackendResolution: TouchpointBackend.Resolution)
+@(form: Form[model.SubscriptionData])
 @defining(
   // use Play reverse routing to get the action request path
   validatePromoCode(
       PromoCode("_"),
       ProductRatePlanId("_"),
       Country.UK).path.replaceFirst("\\?.*", "")) { lookupUrl =>
-
-    @if(touchpointBackendResolution.validTestUserCredentialOpt.isDefined || form.data.get("promoCode").isDefined) {
         <div class="checkout-promo-code js-promo-code">
             <label class="label" for="promo-code">Promo code</label>
             <div class="form-field field-group__item">
@@ -25,5 +23,4 @@
             <div class="js-promo-code-applied promo-code-applied" style="display:none"><strong>✓&nbsp;</strong>Promotion applied</div>
             <div class="promo-code-snippet js-promo-code-snippet"></div>
         </div>
-    }
 }

--- a/app/views/promotion/landingPage_incentive.scala.html
+++ b/app/views/promotion/landingPage_incentive.scala.html
@@ -52,7 +52,7 @@
             <div class="page-slice">
                 <div class="page-slice__content">
                     <h2 class="promo-landing-page__section-head">Discover the Guardian Daily Edition</h2>
-                    <ul class="grid grid--3up grid--bordered grid--flex">
+                    <ul class="grid grid--3up grid--bordered grid--flex grid--no-clearfix-before">
                         <li class="grid__item">
                             @fragments.common.inlineIcon("paper_tablet", Seq("icon--promo"))
                             <h3>If it's in the paper it's on your tablet</h3>
@@ -90,7 +90,7 @@
             <div class="page-container gs-container gs-container--slim page-slice page-slice">
                 <div class="page-slice__content">
                     <h2 class="promo-landing-page__section-head">@promotion.title</h2>
-                    <div class="grid grid--2up-step grid--flex">
+                    <div class="grid grid--2up-step grid--flex grid--no-clearfix-before">
                         <div class="grid__item">
                             <img class="promotion-image" src="@promotion.imageUrl"/>
                         </div>
@@ -109,7 +109,7 @@
             <div class="page-slice">
                 <div class="page-slice__content">
                     <h2 class="promo-landing-page__section-head">Exclusive benefits for Digital Pack subscribers</h2>
-                    <ul class="grid grid--3up grid--bordered grid--flex">
+                    <ul class="grid grid--3up grid--bordered grid--flex grid--no-clearfix-before">
                         <li class="grid__item">
                             @fragments.common.inlineIcon("gifts", Seq("icon--promo"))
                             <h3>Regular gifts and competitions</h3>

--- a/assets/stylesheets/objects/_grid.scss
+++ b/assets/stylesheets/objects/_grid.scss
@@ -25,14 +25,17 @@ $gutter-width-fluid: 2%;
 }
 
 .grid--flex {
-    &:before {
-        display: block;
-    }
     display: flex;
     flex-wrap: wrap;
 
     .grid__item {
         max-width: 100%;
+    }
+}
+
+.grid--no-clearfix-before {
+    &:before {
+        display: block;
     }
 }
 


### PR DESCRIPTION
Turn on Promo Code box for all customers.

Also includes fix for layout issue in mobile Safari when clearfixed & flex-based grids occur after inline elements - the display: table needs to not be there in that instance, but it definitely does when the grid is the first element inside a block. Non-Safari browsers are fine either way!

Switched to use a different promotion graphic from the grid.

/cc @joelochlann @rtyley 