### PR TITLE
Allow Dig-Dev QA to access the CAS tool

### DIFF
--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -34,6 +34,7 @@ object CommonActions {
     "customer.experience@guardian.co.uk",
     "directteam@guardian.co.uk",
     "userhelp@guardian.co.uk",
+    "dig.qa@guardian.co.uk",
     "subscriptions.dev@guardian.co.uk"
   ))
 


### PR DESCRIPTION
@TormodMacLean & @glockett asked for this, I believe they want the CAS-code-generation functionality for testing in mobile apps.

This is the location of the new CAS tool: https://subscribe.theguardian.com/staff/cas

cc @joelochlann  