### PR TITLE
Apply a promotion's discount to the rate plan descriptions

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -5,6 +5,7 @@ import com.gocardless.GoCardlessClient
 import com.gocardless.GoCardlessClient.Environment
 import com.gu.cas.PrefixedTokens
 import com.gu.config.{DigitalPackRatePlanIds, DiscountRatePlanIds, MembershipRatePlanIds, ProductFamilyRatePlanIds}
+import com.gu.i18n.{CountryGroup, Country}
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.memsub.auth.common.MemSub.Google._
 import com.gu.memsub.promo.Promotion._
@@ -125,11 +126,11 @@ object Config {
   def discountPromo(env: String): Option[AnyPromotion] = {
     val prpIds = digipackRatePlanIds(env)
     Some(Promotion(
-      appliesTo = AppliesTo.ukOnly(Set(
-        prpIds.digitalPackMonthly,
-        prpIds.digitalPackQuaterly,
-        prpIds.digitalPackYearly
-      )),
+      // TODO - create an AppliesTo.All
+      appliesTo = AppliesTo(
+        prpIds.productRatePlanIds,
+        CountryGroup.countries.toSet
+      ),
       campaignName = s"DigiPack for just £9.99 a month (~17% discount)",
       codes = PromoCodeSet(PromoCode("DPA30")),
       description = "For a limited time you can enjoy the digital pack for just £9.99 a month (usually £11.99). Get every paper delivered to your tablet for less than 35p an edition, plus an ad-free experience on your live news app.",

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -5,7 +5,6 @@ import com.gocardless.GoCardlessClient
 import com.gocardless.GoCardlessClient.Environment
 import com.gu.cas.PrefixedTokens
 import com.gu.config.{DigitalPackRatePlanIds, DiscountRatePlanIds, MembershipRatePlanIds, ProductFamilyRatePlanIds}
-import com.gu.i18n.{CountryGroup, Country}
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.memsub.auth.common.MemSub.Google._
 import com.gu.memsub.promo.Promotion._
@@ -126,11 +125,7 @@ object Config {
   def discountPromo(env: String): Option[AnyPromotion] = {
     val prpIds = digipackRatePlanIds(env)
     Some(Promotion(
-      // TODO - create an AppliesTo.All
-      appliesTo = AppliesTo(
-        prpIds.productRatePlanIds,
-        CountryGroup.countries.toSet
-      ),
+      appliesTo = AppliesTo.all(prpIds.productRatePlanIds),
       campaignName = s"DigiPack for just £9.99 a month (~17% discount)",
       codes = PromoCodeSet(PromoCode("DPA30")),
       description = "For a limited time you can enjoy the digital pack for just £9.99 a month (usually £11.99). Get every paper delivered to your tablet for less than 35p an edition, plus an ad-free experience on your live news app.",

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -176,8 +176,7 @@ object Checkout extends Controller with LazyLogging with ActivityTracking with C
       currency <- Currency.fromString(currencyStr)
     } yield (subsName, ratePlanId, currency)
 
-    // TODO If some pieces of information are missing, redirect to an empty form. Is it the expected behaviour?
-    def redirectToEmptyForm = Redirect(routes.Checkout.renderCheckout(CountryGroup.UK, None))
+    def redirectToEmptyForm = Redirect(routes.Checkout.renderCheckout(CountryGroup.UK, None)).withNewSession
 
     sessionInfo.fold(redirectToEmptyForm) { case (subsName, ratePlanId, currency) =>
       val passwordForm = authenticatedUserFor(request).fold {

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -21,15 +21,19 @@
         <span class="option__input">
             <input
             type="radio" name="ratePlanId"
+            data-option-mirror-label-default="@plan.prettyPricing(currency)"
             data-option-mirror-label="@plan.prettyPricing(currency)"
-            data-amount="@plan.pricing.getPrice(currency).get.amount"
+            data-amount="@plan.gbpPrice.amount"
+            data-amount-in-currency="@plan.pricing.getPrice(currency).get.amount"
+            data-currency-identifier="@currency.identifier"
+            data-frequency="@plan.billingPeriod.frequencyInMonths"
             data-number-of-months="@plan.billingPeriod.numberOfMonths"
             data-currency="@currency"
             value="@plan.productRatePlanId.get"
             @if(plan == defaultPlan){checked}
             >
         </span>
-        <span class="option__label">@plan.prettyPricing(currency)</span>
+        <span class="option__label" id="label-for-@plan.productRatePlanId.get-@currency">@plan.prettyPricing(currency)</span>
     </label>
 }
 

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -1,14 +1,15 @@
+@import com.gu.i18n.Currency
 @import com.gu.memsub.BillingPeriod
-@import com.gu.memsub.promo.{ Promotion, PromotionType }
+@import com.gu.memsub.promo.Promotion.AnyPromotion
 @import com.gu.subscriptions.DigipackPlan
 @import views.support.BillingPeriod._
 @import views.support.Pricing._
-@import com.gu.memsub.promo.Promotion.AnyPromotion
 @(subscriptionName: String,
     guestAccountForm: Option[Form[model.GuestAccountData]] = None,
     touchpointBackendResolution: services.TouchpointBackend.Resolution,
     plan: DigipackPlan[BillingPeriod],
-    promotion: Option[AnyPromotion] = None
+    promotion: Option[AnyPromotion] = None,
+    currency: Currency
 )(implicit request: RequestHeader)
 
 @import configuration.Config.Identity.webAppProfileUrl
@@ -41,7 +42,7 @@
                 </p>
                 <p>Here are the details of your order, if any of these are incorrect please get in touch with us straight away via email at <a href="mailto:@Details.digitalPackEmail">@Details.digitalPackEmail</a> or on <strong>@Details.digitalPackPhone</strong>. Lines are open BST Monday&ndash;Friday 8.00am&ndash;5.30pm. Saturday &amp; Sunday 8.30am&ndash;12.30pm.</p>
             </div>
-            @fragments.checkout.reviewPanel(subscriptionName, plan, promotion)
+            @fragments.checkout.reviewPanel(subscriptionName, plan, promotion, currency)
         </div>
     </section>
 

--- a/app/views/fragments/checkout/reviewPanel.scala.html
+++ b/app/views/fragments/checkout/reviewPanel.scala.html
@@ -1,16 +1,16 @@
+@import com.gu.i18n.Currency
 @import com.gu.memsub.BillingPeriod
-@import com.gu.memsub.promo.Incentive
+@import com.gu.memsub.promo.Promotion.AnyPromotion
 @import com.gu.subscriptions.DigipackPlan
 @import views.support.BillingPeriod._
 @import views.support.Pricing._
-@import com.gu.memsub.promo.Promotion.AnyPromotion
-@(subscriptionId: String, plan: DigipackPlan[BillingPeriod], promotion: Option[AnyPromotion] = None)
+@(subscriptionId: String, plan: DigipackPlan[BillingPeriod], promotion: Option[AnyPromotion] = None, currency: Currency)
 
 <div class="review-panel js-payment-frequency">
     <input type="checkbox" name="subscriptionDetails"
            checked="checked"
            class="u-h"
-           data-amount="@plan.gbpPrice.pretty"
+           data-amount="@plan.gbpPrice.amount"
            data-number-of-months="@plan.billingPeriod.numberOfMonths">
     <div class="review-panel__item">
         <h4 class="review-panel__label">Subscriber ID:</h4>
@@ -24,12 +24,22 @@
             Digital Pack <em>(Daily Edition / Guardian App Premium Tier)</em>
         </div>
     </div>
+    <div class="review-panel__item">
+        <h4 class="review-panel__label">Your payment plan:</h4>
+        <div class="review-panel__details">
+            @promotion.fold {
+                @plan.prettyPricing(currency)
+            } { p =>
+                <span>@p.applyDiscountToPrice(plan.unsafePrice(currency)).pretty @plan.billingPeriod.frequencyInMonths</span>
+            }
+        </div>
+    </div>
     @promotion.map { promo =>
         <div class="review-panel__promotion">
             <h4 class="review-panel__label">✓ Promotion applied:</h4>
             <div class="review-panel__details">
                 <p>@promo.description</p>
-                @promo.whenIncentive.map { p => <p>@Html(p.promotionType.redemptionInstructions)</p> }
+                @promo.whenIncentive.map { p => <p>@p.promotionType.redemptionInstructions</p> }
             </div>
         </div>
     }

--- a/app/views/fragments/checkout/reviewPanel.scala.html
+++ b/app/views/fragments/checkout/reviewPanel.scala.html
@@ -25,7 +25,7 @@
         </div>
     </div>
     <div class="review-panel__item">
-        <h4 class="review-panel__label">Your payment plan:</h4>
+        <h4 class="review-panel__label">Payment frequency:</h4>
         <div class="review-panel__details">
             @promotion.fold {
                 @plan.prettyPricing(currency)

--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -9,10 +9,9 @@ object Pricing {
   implicit class PlanWithPricing(digipackPlan: DigipackPlan[BP]) {
     lazy val gbpPrice = digipackPlan.pricing.getPrice(GBP).get
 
-    private def unsafePrice(currency: Currency) = digipackPlan.pricing.getPrice(currency).getOrElse(
+    def unsafePrice(currency: Currency) = digipackPlan.pricing.getPrice(currency).getOrElse(
       throw new NoSuchElementException(s"Could not find a price in $currency for plan ${digipackPlan.name}")
     )
-
 
     def prettyPricing(currency: Currency) =
       s"${unsafePrice(currency).pretty} ${digipackPlan.billingPeriod.frequencyInMonths}"

--- a/assets/javascripts/modules/checkout/promoCode.js
+++ b/assets/javascripts/modules/checkout/promoCode.js
@@ -23,7 +23,7 @@ define([
         bindExtraKeyListener.alreadyBound = true;
     }
 
-    function unapplyPromotionToRatePlans() {
+    function removePromotionFromRatePlans() {
         $ratePlanFields.each(function(el) {
             var $el = $(el),
                 currency = $el.data('currency'),
@@ -65,7 +65,7 @@ define([
                 }
             });
         } else {
-            unapplyPromotionToRatePlans();
+            removePromotionFromRatePlans();
         }
     }
 
@@ -74,7 +74,7 @@ define([
         $promoCodeSnippet.html('');
         $promoCodeApplied.hide();
         toggleError($promoCodeError.parent(), false);
-        unapplyPromotionToRatePlans();
+        removePromotionFromRatePlans();
     }
 
     function displayError(message) {

--- a/assets/javascripts/modules/checkout/promoCode.js
+++ b/assets/javascripts/modules/checkout/promoCode.js
@@ -9,6 +9,7 @@ define([
     'use strict';
 
     var $inputBox           = formElements.$PROMO_CODE,
+        $ratePlanFields     = $('input[name="ratePlanId"]'),
         $promoCodeSnippet   = $('.js-promo-code-snippet'),
         $promoCodeError     = $('.js-promo-code .js-error-message'),
         $promoCodeApplied   = $('.js-promo-code-applied'),
@@ -22,24 +23,79 @@ define([
         bindExtraKeyListener.alreadyBound = true;
     }
 
-    function displayError(message) {
-        message = message || 'Invalid promo code, please try again.';
+    function unapplyPromotionToRatePlans() {
+        $ratePlanFields.each(function(el) {
+            var $el = $(el),
+                currency = $el.data('currency'),
+                $label = $('#label-for-' + $el.val() + '-' + currency),
+                newDisplayPrice = $el.data('option-mirror-label-default');
+
+            $label.html(newDisplayPrice);
+            $el.attr('data-option-mirror-label', newDisplayPrice);
+            if ($el.attr('checked')) {
+                bean.fire(el, 'change');
+            }
+        });
+    }
+
+    function formatMoney(currencyIdentifier, amount) {
+        // rounds any remainder up tp 1p so we always quote a higher price than the user might eventually get charged.
+        var price2dp = Math.ceil(amount * 100) / 100,
+            priceNoDot00 = price2dp.toFixed(2).replace(/\.00$/, '');
+
+        return currencyIdentifier + priceNoDot00;
+    }
+
+    function applyPromotionToRatePlans(promotion) {
+        if (promotion.promotionType.amount > 0) {
+            $ratePlanFields.each(function(el) {
+                var $el = $(el),
+                    amount = Number($el.data('amount-in-currency')),
+                    currency = $el.data('currency'),
+                    currencyIdentifier = $el.data('currency-identifier'),
+                    discountPercent = promotion.promotionType.amount,
+                    frequency = $el.data('frequency'),
+                    $label = $('#label-for-' + $el.val() + '-' + currency),
+                    newDisplayPrice = formatMoney(currencyIdentifier, amount * (1 - (discountPercent / 100))) + ' ' + frequency;
+
+                $label.html(newDisplayPrice);
+                $el.attr('data-option-mirror-label', newDisplayPrice);
+                if ($el.attr('checked')) {
+                    bean.fire(el, 'change');
+                }
+            });
+        } else {
+            unapplyPromotionToRatePlans();
+        }
+    }
+
+    function clearDown() {
+        $promoCodeError.text('');
         $promoCodeSnippet.html('');
         $promoCodeApplied.hide();
+        toggleError($promoCodeError.parent(), false);
+        unapplyPromotionToRatePlans();
+    }
+
+    function displayError(message) {
+        clearDown();
+        message = message || 'Invalid promo code, please try again.';
         $promoCodeError.text(message);
         toggleError($promoCodeError.parent(), true);
+
     }
 
     function displayPromotion(promotion) {
-        toggleError($promoCodeError.parent(), false);
-        $promoCodeError.text('');
+        clearDown();
         $promoCodeApplied.show();
         $promoCodeSnippet.html(promotion.description);
+        applyPromotionToRatePlans(promotion);
     }
 
     function validate() {
         var promoCode  = $inputBox.val().trim();
         if (promoCode === '') {
+            clearDown();
             return;
         }
 

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.167",
+    "com.gu" %% "membership-common" % "0.169",
     "com.gu" %% "memsub-common-play-auth" % "0.3",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.0.0",


### PR DESCRIPTION
- Applied a promotion's discount to the rate plan descriptions, and to the payment plan on the Thank You page.
- Also fixed bug with analytics amounts not always being GBP when a user changes their currency, and that the promotion was stored int he session if a user made a repeat purchase.
- Also ensured the promotion was available to all currencies and rate plans.

cc @tomverran @joelochlann 

![picture 29](https://cloud.githubusercontent.com/assets/1515970/13571320/186024e4-e46c-11e5-95df-147b5c92b1e3.png)

Now becomes:

![picture 28](https://cloud.githubusercontent.com/assets/1515970/13571303/049b1194-e46c-11e5-8702-862568a60275.png)

when a 16.9% promotion is applied.

![picture 27](https://cloud.githubusercontent.com/assets/1515970/13571287/f483f83e-e46b-11e5-9ae7-a1e2b7fa9dac.png)

The adjusted price also appears on the Thank You page.