### PR TITLE
Tracking for Jellyfish

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -157,4 +157,6 @@
     </section>
 
 </main>
+
+    @fragments.analytics.jellyfish.remarketing()
 }

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -104,4 +104,7 @@
         </div>
     </section>
 </main>
+
+    @fragments.analytics.jellyfish.remarketing()
+    @fragments.analytics.jellyfish.conversion()
 }

--- a/app/views/fragments/analytics/jellyfish/conversion.scala.html
+++ b/app/views/fragments/analytics/jellyfish/conversion.scala.html
@@ -1,0 +1,76 @@
+@()
+
+@import configuration.Config
+
+@if(Config.stage == "PROD") {
+    <div class="is-hidden">
+        <!-- Bing -->
+        <script type="text/javascript"> if (!window.mstag) mstag = {loadTag : function(){},time : (new Date()).getTime()};</script> <script id="mstag_tops" type="text/javascript" src="//flex.msn.com/mstag/site/687362ae-0a07-42ce-9bb7-b8b05da3cfbe/mstag.js"></script> <script type="text/javascript"> mstag.loadTag("analytics", {dedup:"1",domainId:"2657927",type:"1",actionid:"180590"})</script> <noscript> <iframe src="//flex.msn.com/mstag/tag/687362ae-0a07-42ce-9bb7-b8b05da3cfbe/analytics.html?dedup=1&domainId=2657927&type=1&actionid=180590" frameborder="0" scrolling="no" width="1" height="1" style="visibility:hidden;display:none"> </iframe> </noscript>
+
+        <!-- Facebook Pixel Code -->
+        <script>
+            !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+                n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+                n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+                t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+                document,'script','//connect.facebook.net/en_US/fbevents.js');
+
+            fbq('init', '558147917626730');
+            fbq('track', "PageView");</script>
+        <noscript><img height="1" width="1" style="display:none"
+        src="https://www.facebook.com/tr?id=558147917626730&ev=PageView&noscript=1"
+        /></noscript>
+        <!-- End Facebook Pixel Code -->
+
+        <!-- Google Code for Subscription Conversion Page -->
+        <script type="text/javascript">
+            /* <![CDATA[ */
+            var google_conversion_id = 995657703;
+            var google_conversion_language = "en";
+            var google_conversion_format = "2";
+            var google_conversion_color = "ffffff";
+            var google_conversion_label = "YvsQCPmSwwcQ54_i2gM";
+            var google_conversion_value = 1.00;
+            var google_conversion_currency = "GBP";
+            var google_remarketing_only = false;
+            /* ]]> */
+        </script>
+        <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+        </script>
+        <noscript>
+            <div style="display:inline;">
+                <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/995657703/?value=1.00&amp;currency_code=GBP&amp;label=YvsQCPmSwwcQ54_i2gM&amp;guid=ON&amp;script=0"/>
+            </div>
+        </noscript>
+
+        <!-- Google Code for Subscription Conversion Page -->
+        <script type="text/javascript">
+            /* <![CDATA[ */
+            var google_conversion_id = 1008644981;
+            var google_conversion_language = "en";
+            var google_conversion_format = "3";
+            var google_conversion_color = "ffffff";
+            var google_conversion_label = "rdY3CPjQllcQ9eb64AM";
+            var google_conversion_value = 1.00;
+            var google_conversion_currency = "GBP";
+            var google_remarketing_only = false;
+            /* ]]> */
+        </script>
+        <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+        </script>
+        <noscript>
+            <div style="display:inline;">
+                <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/1008644981/?value=1.00&amp;currency_code=GBP&amp;label=rdY3CPjQllcQ9eb64AM&amp;guid=ON&amp;script=0"/>
+            </div>
+        </noscript>
+
+        <!-- Twitter single-event website tag code -->
+        <script src="//platform.twitter.com/oct.js" type="text/javascript"></script>
+        <script type="text/javascript">twttr.conversion.trackPid('nu3k4', { tw_sale_amount: 0, tw_order_quantity: 0 });</script>
+        <noscript>
+            <img height="1" width="1" style="display:none;" alt="" src="https://analytics.twitter.com/i/adsct?txn_id=nu3k4&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0" />
+            <img height="1" width="1" style="display:none;" alt="" src="//t.co/i/adsct?txn_id=nu3k4&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0" />
+        </noscript>
+        <!-- End Twitter single-event website tag code -->
+    </div>
+}

--- a/app/views/fragments/analytics/jellyfish/remarketing.scala.html
+++ b/app/views/fragments/analytics/jellyfish/remarketing.scala.html
@@ -1,0 +1,54 @@
+@()
+
+@import configuration.Config
+
+@if(Config.stage == "PROD") {
+    <div class="is-hidden">
+        <!-- Google Code for Remarketing Tag -->
+        <!--------------------------------------------------
+    Remarketing tags may not be associated with personally identifiable information or placed on pages related to sensitive categories. See more information and instructions on how to setup the tag on: http://google.com/ads/remarketingsetup
+    --------------------------------------------------->
+        <script type="text/javascript">
+            /* <![CDATA[ */
+            var google_conversion_id = 995657703;
+            var google_custom_params = window.google_tag_params;
+            var google_remarketing_only = true;
+            /* ]]> */
+        </script>
+        <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+        </script>
+        <noscript>
+            <div style="display:inline;">
+                <img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/995657703/?value=0&amp;guid=ON&amp;script=0"/>
+            </div>
+        </noscript>
+
+        <!-- Google Code for Remarketing Tag -->
+        <!--------------------------------------------------
+    Remarketing tags may not be associated with personally identifiable information or placed on pages related to sensitive categories. See more information and instructions on how to setup the tag on: http://google.com/ads/remarketingsetup
+    --------------------------------------------------->
+        <script type="text/javascript">
+            /* <![CDATA[ */
+            var google_conversion_id = 1008644981;
+            var google_custom_params = window.google_tag_params;
+            var google_remarketing_only = true;
+            /* ]]> */
+        </script>
+        <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+        </script>
+        <noscript>
+            <div style="display:inline;">
+                <img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/1008644981/?value=0&amp;guid=ON&amp;script=0"/>
+            </div>
+        </noscript>
+
+        <!-- Twitter single-event website tag code -->
+        <script src="//platform.twitter.com/oct.js" type="text/javascript"></script>
+        <script type="text/javascript">twttr.conversion.trackPid('nu3k4', { tw_sale_amount: 0, tw_order_quantity: 0 });</script>
+        <noscript>
+            <img height="1" width="1" style="display:none;" alt="" src="https://analytics.twitter.com/i/adsct?txn_id=nu3k4&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0" />
+            <img height="1" width="1" style="display:none;" alt="" src="//t.co/i/adsct?txn_id=nu3k4&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0" />
+        </noscript>
+        <!-- End Twitter single-event website tag code -->
+    </div>
+}

--- a/app/views/promotion/landingPage.scala.html
+++ b/app/views/promotion/landingPage.scala.html
@@ -73,4 +73,6 @@
             </div>
         </section>
     </main>
+
+    @fragments.analytics.jellyfish.remarketing()
 }


### PR DESCRIPTION
[Jellyfish](http://www.jellyfish.co.uk/seo-social/) will no longer have their own landing pages for Subscriptions, but will instead send users directly to our pages. They have the job of showing appropriate online marketing to drive people to our site.

From Jellyfish:

> the codes that have been labelled as ‘Remarketing’ allow us to re-target to visitors who have come to our various 3rd Party campaigns (Facebook, Gmail Sponsored Promotions, Google) and not gone on to convert directly. We re-target this traffic through the same channel, and we remove any subscribers from these remarketing lists (which is why we require for the Remarketing codes to be added to the confirmation page as well as all other pages in the payment funnel so we can remove anyone that sees this page from being served an ad).
>
> The codes labelled as ‘Conversion’ we require on the confirmation page only of the payment funnel so that we can track all conversions in our respective channel reporting.

The codes were delivered to us by Jellyfish in a zip file: [GOBS_-_Tracking_Codes_For_New_Funnel.zip](https://github.com/guardian/subscriptions-frontend/files/186360/GOBS_-_Tracking_Codes_For_New_Funnel.zip)

https://trello.com/c/2vIHfmAR/426-promo-codes-jellyfish-tracking-pixels-to-support-migration

See further discussion at:

https://groups.google.com/a/guardian.co.uk/d/msg/subscriptions.dev/j3bAshulM-M/PDJYtyWSCwAJ

cc @paulbrown1982 