### PR TITLE
Direct promotions

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -105,7 +105,7 @@ object Config {
   def demoPromo(env: String) = {
     val jellyFishPromoCode = PromoCode("DGA85")
     val prpIds = digipackRatePlanIds(env)
-    val promoCodes = (Seq(jellyFishPromoCode) /: (88 to 94))((seq, i) =>  seq :+ PromoCode(s"DGA$i") :+ PromoCode(s"DGB$i"))
+    val promoCodes = (88 to 94).foldLeft(Seq(jellyFishPromoCode))((seq, i) =>  seq :+ PromoCode(s"DGA$i") :+ PromoCode(s"DGB$i"))
 
     Promotion(
       appliesTo = AppliesTo.ukOnly(Set(
@@ -129,7 +129,7 @@ object Config {
 
   def discountPromo(env: String): Option[AnyPromotion] = {
     val prpIds = digipackRatePlanIds(env)
-    val promoCodes = (Seq[PromoCode]() /: (13 to 26))((seq, i ) => seq :+ PromoCode(s"DPA$i") :+ PromoCode(s"DPB$i"))
+    val promoCodes = (13 to 26).foldLeft(Seq[PromoCode]())((seq, i ) => seq :+ PromoCode(s"DPA$i") :+ PromoCode(s"DPB$i"))
     Some(Promotion(
       appliesTo = AppliesTo.all(prpIds.productRatePlanIds),
       campaignName = s"DigiPack for just £9.99 a month (~17% discount)",

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -105,7 +105,7 @@ object Config {
   def demoPromo(env: String) = {
     val jellyFishPromoCode = PromoCode("DGA85")
     val prpIds = digipackRatePlanIds(env)
-    val promoCodes = (88 to 94).foldLeft(Seq(jellyFishPromoCode))((seq, i) =>  seq :+ PromoCode(s"DGA$i") :+ PromoCode(s"DGB$i"))
+    val promoCodes = (88 to 94).flatMap(i =>  Seq(PromoCode(s"DGA$i"), PromoCode(s"DGB$i"))) ++ Seq(jellyFishPromoCode)
 
     Promotion(
       appliesTo = AppliesTo.ukOnly(Set(
@@ -129,7 +129,7 @@ object Config {
 
   def discountPromo(env: String): Option[AnyPromotion] = {
     val prpIds = digipackRatePlanIds(env)
-    val promoCodes = (13 to 26).foldLeft(Seq[PromoCode]())((seq, i ) => seq :+ PromoCode(s"DPA$i") :+ PromoCode(s"DPB$i"))
+    val promoCodes = (13 to 26).flatMap(i => Seq(PromoCode(s"DPA$i"), PromoCode(s"DPB$i")))
     Some(Promotion(
       appliesTo = AppliesTo.all(prpIds.productRatePlanIds),
       campaignName = s"DigiPack for just £9.99 a month (~17% discount)",

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -114,7 +114,7 @@ object Config {
         prpIds.digitalPackYearly
       )),
       campaignName = "DigiPack - £30 digital gift card",
-      codes = PromoCodeSet(PromoCode("DGA88"), promoCodes),
+      codes = PromoCodeSet(PromoCode("DGA88"), promoCodes:_*),
       description = "Get £30 to spend with a top retailer of your choice when you subscribe. Use your digital gift card at Amazon.co.uk, M&S and more. Treat yourself or a friend.",
       expires = new LocalDate(2016,4,30).toDateTime(LocalTime.Midnight, timezone),
       imageUrl = Some("https://media.guim.co.uk/b26ecf643d6494d60fc32c94e43d8d1483daadac/0_0_720_418/720.jpg"),
@@ -133,7 +133,7 @@ object Config {
     Some(Promotion(
       appliesTo = AppliesTo.all(prpIds.productRatePlanIds),
       campaignName = s"DigiPack for just £9.99 a month (~17% discount)",
-      codes = PromoCodeSet(PromoCode("DPA13"), promoCodes),
+      codes = PromoCodeSet(PromoCode("DPA13"), promoCodes:_*),
       description = "For a limited time you can enjoy the digital pack for a special discounted price. Get every issue of The Guardian and The Observer newspapers delivered to your tablet, plus an ad-free experience on The Guardian live news app.",
       expires = new LocalDate(2100,4,1).toDateTime(LocalTime.Midnight, timezone), // TODO - change to to Option
       imageUrl = None,
@@ -152,7 +152,7 @@ object Config {
     Some(Promotion(
       appliesTo = AppliesTo.all(prpIds.productRatePlanIds),
       campaignName = s"DigiPack free for 30 Days",
-      codes = PromoCodeSet(PromoCode("DHA22"), promoCodes),
+      codes = PromoCodeSet(PromoCode("DHA22"), promoCodes:_*),
       description = "Enjoy the digital pack for free for 30 days without charge. Get every issue of The Guardian and The Observer newspapers delivered to your tablet, plus an ad-free experience on The Guardian live news app.",
       expires = new LocalDate(2016,6,30).toDateTime(LocalTime.Midnight, timezone),
       imageUrl = None,

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -103,7 +103,10 @@ object Config {
     MembershipRatePlanIds.fromConfig(ProductFamilyRatePlanIds.config(Some(config))(env, Membership))
 
   def demoPromo(env: String) = {
+    val jellyFishPromoCode = PromoCode("DGA85")
     val prpIds = digipackRatePlanIds(env)
+    val promoCodes = (Seq(jellyFishPromoCode) /: (88 to 94))((seq, i) =>  seq :+ PromoCode(s"DGA$i") :+ PromoCode(s"DGB$i"))
+
     Promotion(
       appliesTo = AppliesTo.ukOnly(Set(
         prpIds.digitalPackMonthly,
@@ -111,7 +114,7 @@ object Config {
         prpIds.digitalPackYearly
       )),
       campaignName = "DigiPack - £30 digital gift card",
-      codes = PromoCodeSet(PromoCode("DGA88"), PromoCode("DGB88")),
+      codes = PromoCodeSet(PromoCode("DGA88"), promoCodes),
       description = "Get £30 to spend with a top retailer of your choice when you subscribe. Use your digital gift card at Amazon.co.uk, M&S and more. Treat yourself or a friend.",
       expires = new LocalDate(2016,4,30).toDateTime(LocalTime.Midnight, timezone),
       imageUrl = Some("https://media.guim.co.uk/b26ecf643d6494d60fc32c94e43d8d1483daadac/0_0_720_418/720.jpg"),
@@ -126,12 +129,13 @@ object Config {
 
   def discountPromo(env: String): Option[AnyPromotion] = {
     val prpIds = digipackRatePlanIds(env)
+    val promoCodes = (Seq[PromoCode]() /: (13 to 26))((seq, i ) => seq :+ PromoCode(s"DPA$i") :+ PromoCode(s"DPB$i"))
     Some(Promotion(
       appliesTo = AppliesTo.all(prpIds.productRatePlanIds),
       campaignName = s"DigiPack for just £9.99 a month (~17% discount)",
-      codes = PromoCodeSet(PromoCode("DPA30")),
+      codes = PromoCodeSet(PromoCode("DPA13"), promoCodes),
       description = "For a limited time you can enjoy the digital pack for a special discounted price. Get every issue of The Guardian and The Observer newspapers delivered to your tablet, plus an ad-free experience on The Guardian live news app.",
-      expires = new LocalDate(2016,4,1).toDateTime(LocalTime.Midnight, timezone),
+      expires = new LocalDate(2100,4,1).toDateTime(LocalTime.Midnight, timezone), // TODO - change to to Option
       imageUrl = None,
       roundelHtml = "Only £9.99 a month</span><span class='roundel__byline'>usually £11.99",
       title = "More of the Guardian, for less",
@@ -140,13 +144,17 @@ object Config {
   }
 
   def freeTrialPromo(env: String): Option[AnyPromotion] = {
+    // TODO tag manager
+    // TODO data extension
+    // TODO check we give 16 days to Zuora for normal sub, and 30 days for this and any FreeTrial promotion.
     val prpIds = digipackRatePlanIds(env)
+    val promoCodes = (22 to 25) map { i => PromoCode(s"DHA$i") }
     Some(Promotion(
       appliesTo = AppliesTo.all(prpIds.productRatePlanIds),
       campaignName = s"DigiPack free for 30 Days",
-      codes = PromoCodeSet(PromoCode("DHA22"), PromoCode("DHB22"), PromoCode("DHA23"), PromoCode("DHB23"), PromoCode("DHA25"), PromoCode("DHB25")),
+      codes = PromoCodeSet(PromoCode("DHA22"), promoCodes),
       description = "Enjoy the digital pack for free for 30 days without charge. Get every issue of The Guardian and The Observer newspapers delivered to your tablet, plus an ad-free experience on The Guardian live news app.",
-      expires = new LocalDate(2016,9,1).toDateTime(LocalTime.Midnight, timezone),
+      expires = new LocalDate(2016,6,30).toDateTime(LocalTime.Midnight, timezone),
       imageUrl = None,
       roundelHtml = "<span class='roundel__strong'>FREE</span> DigiPack for 30 days",
       title = "Try the Guardian DigiPack free for 30 Days",


### PR DESCRIPTION
- Confirmed latest changes (from Shane) of which new promotions will be included in our direct marketing URLs.
- Increased end times where necessary.
- Removed DPA30 test promo code.
- Made the (ProNetworks) discount promo last effectively forever.

https://trello.com/c/HlCohHqm/450-review-the-urls-provided-by-shane-to-make-sure-they-are-ok-and-working

https://trello.com/c/VjZ6gZYD/449-create-landing-page-for-jellyfish-orders-split-test-coming-through-the-gnm-flow

cc @tomverran 