### PR TITLE
Making failed /p/ codes go to digipack homepage rather than 404

### DIFF
--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -1,15 +1,12 @@
 package controllers
 
-import java.net.URLEncoder
-
 import actions.CommonActions._
 import com.gu.memsub.promo._
+import com.netaporter.uri.dsl._
 import configuration.Config
 import model.DigitalEdition
 import play.api.mvc._
 import services.TouchpointBackend
-import com.netaporter.uri.dsl._
-import com.netaporter.uri.Uri
 
 object PromoLandingPage extends Controller {
 

--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -8,6 +8,8 @@ import configuration.Config
 import model.DigitalEdition
 import play.api.mvc._
 import services.TouchpointBackend
+import com.netaporter.uri.dsl._
+import com.netaporter.uri.Uri
 
 object PromoLandingPage extends Controller {
 
@@ -20,6 +22,6 @@ object PromoLandingPage extends Controller {
     (for {
       promotion <- tpBackend.promoService.findPromotion(promoCode)
       html <- if (promotion.expires.isBeforeNow) None else Some(views.html.promotion.landingPage(edition, catalog, promoCode, promotion, Config.Zuora.paymentDelay))
-    } yield Ok(html)).getOrElse(Redirect(s"/digital?INTCMP=FROM_P_${URLEncoder.encode(promoCode.get, "UTF-8")}"))
+    } yield Ok(html)).getOrElse(Redirect("/digital" ? ("INTCMP" -> s"FROM_P_${promoCode.get}")))
   }
 }

--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -1,12 +1,13 @@
 package controllers
 
+import java.net.URLEncoder
+
 import actions.CommonActions._
 import com.gu.memsub.promo._
 import configuration.Config
 import model.DigitalEdition
 import play.api.mvc._
 import services.TouchpointBackend
-import touchpoint.ZuoraProperties
 
 object PromoLandingPage extends Controller {
 
@@ -19,6 +20,6 @@ object PromoLandingPage extends Controller {
     (for {
       promotion <- tpBackend.promoService.findPromotion(promoCode)
       html <- if (promotion.expires.isBeforeNow) None else Some(views.html.promotion.landingPage(edition, catalog, promoCode, promotion, Config.Zuora.paymentDelay))
-    } yield Ok(html)).getOrElse(NotFound(views.html.error404()))
+    } yield Ok(html)).getOrElse(Redirect(s"/digital?INTCMP=FROM_P_${URLEncoder.encode(promoCode.get, "UTF-8")}"))
   }
 }


### PR DESCRIPTION
- Changed logic so that uknown/expired/invalid /p/ promo codes redirect to the digipack UK homepage rather than show a 404 response. This is to encourage any links on the web to go somewhere useful.
- Added an INTCMP campaign code on the redirect so we can track these.

cc @tomverran @AWare 