### PR TITLE
Adding Google Tag Manager to the checkout and thank you subs pages.

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -43,6 +43,9 @@
     bodyClasses = List("is-wide"),
     touchpointBackendResolutionOpt = Some(touchpointBackendResolution)
 ) {
+
+    @fragments.analytics.tagmanager()
+
 <main class="page-container gs-container">
 
     <section class="checkout-container">

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -19,6 +19,8 @@
 
 @main("Confirmation | Digital | Subscriptions | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
+    @fragments.analytics.tagmanager()
+
 <script type="text/javascript">
     guardian.pageInfo.slug="GuardianDigiPack:Order Complete";
     guardian.pageInfo.productData = {

--- a/app/views/fragments/analytics/jellyfish/remarketing.scala.html
+++ b/app/views/fragments/analytics/jellyfish/remarketing.scala.html
@@ -48,8 +48,8 @@
                 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-            ga('create', 'UA-44575989-1', 'auto');
-            ga('send', 'pageview');
+            ga('create', 'UA-44575989-1', 'auto', 'jellyfishGA');
+            ga('jellyfishGA.send', 'pageview');
 
         </script>
     </div>

--- a/app/views/fragments/analytics/tagmanager.scala.html
+++ b/app/views/fragments/analytics/tagmanager.scala.html
@@ -1,0 +1,10 @@
+@()
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-PX73D2"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-PX73D2');</script>
+<!-- End Google Tag Manager -->

--- a/app/views/fragments/analytics/tagmanager.scala.html
+++ b/app/views/fragments/analytics/tagmanager.scala.html
@@ -1,10 +1,14 @@
 @()
-<!-- Google Tag Manager -->
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-PX73D2"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-PX73D2');</script>
-<!-- End Google Tag Manager -->
+@import configuration.Config
+
+@if(Config.stage == "PROD") {
+    <!-- Google Tag Manager -->
+    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-PX73D2"
+    height="0" width="0" style="display:none ; visibility:hidden"></iframe></noscript>
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-PX73D2');</script>
+        <!-- End Google Tag Manager -->
+}


### PR DESCRIPTION
Adding Google Tag Manager to the checkout and thank you subs pages.
As per: https://trello.com/c/V2sQ9n9O/432-support-30-day-free-trial
Shane confirmed that the tags only need go on the /checkout and /thankyou page. The tags he'll be loading are for Pangea and soon, TTP.

Namespaced the JellyFish Google Analytics tag as per the instructions here: https://support.google.com/tagmanager/answer/6103696?hl=en


cc @rtyley @AWare 