### PR TITLE
Prepopulate international country from identity

### DIFF
--- a/app/model/AddressValidation.scala
+++ b/app/model/AddressValidation.scala
@@ -1,10 +1,11 @@
 package model
 
+import com.gu.i18n.Country
 import com.gu.memsub.Address
 
 object AddressValidation {
   def validateForCountry(address: Address) = {
-    val rules = AddressValidationRules(address.country)
+    val rules = AddressValidationRules(address.country.getOrElse(Country.UK))
 
     val postcodeValid = rules.postcode == PostcodeOptional || address.postCode.nonEmpty
     val subdivisionValid = rules.subdivision match {

--- a/app/model/JsVars.scala
+++ b/app/model/JsVars.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.i18n.{GBP, Currency, CountryGroup}
+import com.gu.i18n.{GBP, Currency, Country, CountryGroup}
 import play.api.libs.json._
 
 object JsVars {
@@ -11,16 +11,17 @@ object JsVars {
           "isSignedIn" -> jsVars.userIsSignedIn,
           "ignorePageLoadTracking" -> jsVars.ignorePageLoadTracking
         ),
-        "currency" -> jsVars.currency.toString,
-        "country" -> jsVars.countryGroup.defaultCountry.map(_.alpha2)
+        "currency" -> jsVars.currency.toString
       )
 
-      val optional = jsVars.stripePublicKey match {
+      val optionalCountry = Json.obj("country" -> jsVars.country.map(_.alpha2))
+
+      val optionalStripe = jsVars.stripePublicKey match {
         case Some(stripePublicKey) => Json.obj("stripePublicKey" -> stripePublicKey)
         case None => Json.obj()
       }
 
-      mandatory ++ optional
+      mandatory ++ optionalCountry ++ optionalStripe
     }
   }
 }
@@ -30,5 +31,6 @@ case class JsVars(
   ignorePageLoadTracking: Boolean = false,
   stripePublicKey: Option[String] = None,
   countryGroup: CountryGroup = CountryGroup.UK,
-  currency: Currency = GBP
+  currency: Currency = GBP,
+  country: Option[Country] = None
 )

--- a/app/model/PaymentValidation.scala
+++ b/app/model/PaymentValidation.scala
@@ -6,7 +6,7 @@ object PaymentValidation {
   def validateDirectDebit(subscriptionData: SubscriptionData): Boolean = {
     subscriptionData.paymentData match {
       case _: DirectDebitData =>
-        subscriptionData.personalData.country == Country.UK
+        subscriptionData.personalData.address.country.contains(Country.UK)
       case _ => true
     }
   }

--- a/app/model/SubscriptionData.scala
+++ b/app/model/SubscriptionData.scala
@@ -1,5 +1,6 @@
 package model
 
+import com.gu.i18n.Country.UK
 import com.gu.i18n.{Country, CountryGroup}
 import com.gu.identity.play.IdUser
 import com.gu.memsub.Subscription.ProductRatePlanId
@@ -43,20 +44,9 @@ case class PersonalData(first: String,
                         ) extends FullName {
   def fullName = s"$first $last"
 
-  private lazy val countryName = address.countryName
+  private lazy val countryGroup = CountryGroup.byCountryNameOrCode(address.country.fold(UK.alpha2)(c => c.alpha2))
 
-  private lazy val notFound =
-    throw new NoSuchElementException(s"Could not find a country group for country with name $countryName")
-
-  private lazy val countryGroup: CountryGroup =
-    CountryGroup.byCountryNameOrCode(countryName)
-      .getOrElse(notFound)
-
-  lazy val currency = countryGroup.currency
-
-  lazy val country: Country =
-    CountryGroup.countryByNameOrCode(countryName)
-      .getOrElse(notFound)
+  lazy val currency = countryGroup.fold(CountryGroup.UK.currency)(_.currency)
 }
 
 

--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -49,7 +49,7 @@ object SubscriptionDataExtensionRow extends LazyLogging {
         "Address 2" -> address.lineTwo,
         "City" -> address.town,
         "Post Code" -> address.postCode,
-        "Country" -> address.country.name,
+        "Country" -> address.country.fold(address.countryName)(_.name),
         "Date of first payment" -> formatDate(subscription.firstPaymentDate),
         "Currency" -> personalData.currency.glyph,
         "Trial period" -> paymentDelay.getDays.toString,

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -113,7 +113,7 @@ object PersonalDataJsonSerialiser {
         "billingAddress3" -> personalData.address.town,
         "billingAddress4" -> personalData.address.countyOrState,
         "billingPostcode" -> personalData.address.postCode,
-        "billingCountry"  -> personalData.country.name
+        "billingCountry"  -> personalData.address.country.fold(personalData.address.countryName)(_.name)
       ).++(
          telephoneNumber.fold[JsObject](Json.obj()){t =>
            Json.obj(

--- a/app/services/PaymentService.scala
+++ b/app/services/PaymentService.scala
@@ -1,6 +1,7 @@
 package services
 
-import com.gu.i18n.{Country, Currency, GBP}
+import com.gu.i18n.Country.UK
+import com.gu.i18n.{Currency, GBP}
 import com.gu.memsub.BillingPeriod
 import com.gu.salesforce.ContactId
 import com.gu.stripe.StripeService
@@ -29,7 +30,7 @@ trait PaymentService {
         accountHolderName = paymentData.holder,
         firstName = personalData.first,
         lastName = personalData.last,
-        countryCode = Country.UK.alpha2
+        countryCode = UK.alpha2
       ))
   }
 
@@ -42,7 +43,7 @@ trait PaymentService {
   }
 
   def makeDirectDebitPayment(paymentData: DirectDebitData, personalData: PersonalData, memberId: ContactId) = {
-    require(personalData.country == Country.UK, "Direct Debit payment only works in the UK right now")
+    require(personalData.address.country.contains(UK), "Direct Debit payment only works in the UK right now")
     new DirectDebitPayment(paymentData, personalData, memberId)
   }
 

--- a/app/tracking/activities/SubscriptionRegistrationActivity.scala
+++ b/app/tracking/activities/SubscriptionRegistrationActivity.scala
@@ -15,7 +15,7 @@ object MemberData {
   def apply(checkoutResult: CheckoutSuccess, subscriptionData: SubscriptionData, billingPeriod: BillingPeriod): MemberData = {
     val address: Address = subscriptionData.personalData.address
     MemberData(address.town,
-      address.country.name,
+      address.country.fold(address.countryName)(_.name),
       address.postCode,
       billingPeriod,
       subscriptionData.personalData.receiveGnmMarketing,

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -1,4 +1,4 @@
-@import com.gu.i18n.{CountryGroup, Currency}
+@import com.gu.i18n.{Country, CountryGroup, Currency}
 @import com.gu.memsub.{BillingPeriod, Month}
 @import com.gu.subscriptions.DigipackPlan
 @import configuration.Config.Identity._
@@ -10,8 +10,9 @@
     userIsSignedIn: Boolean,
     plans: Seq[DigipackPlan[BillingPeriod]],
     defaultPlan : DigipackPlan[Month],
+    country: Option[Country],
     countryGroup: CountryGroup,
-    currency: Currency,
+    defaultCurrency: Currency,
     countriesWithCurrency: List[CountryWithCurrency],
     touchpointBackendResolution: services.TouchpointBackend.Resolution)(implicit request: RequestHeader)
 
@@ -30,7 +31,7 @@
             data-number-of-months="@plan.billingPeriod.numberOfMonths"
             data-currency="@currency"
             value="@plan.productRatePlanId.get"
-            @if(plan == defaultPlan){checked}
+            @if(plan == defaultPlan && currency == defaultCurrency){checked}
             >
         </span>
         <span class="option__label" id="label-for-@plan.productRatePlanId.get-@currency">@plan.prettyPricing(currency)</span>
@@ -39,7 +40,7 @@
 
 @main(
     title = "Details - name and address | Subscriptions | The Guardian",
-    jsVars = JsVars(userIsSignedIn = userIsSignedIn, ignorePageLoadTracking = true, countryGroup = countryGroup, currency = currency),
+    jsVars = JsVars(userIsSignedIn = userIsSignedIn, ignorePageLoadTracking = true, countryGroup = countryGroup, currency = defaultCurrency, country = country),
     bodyClasses = List("is-wide"),
     touchpointBackendResolutionOpt = Some(touchpointBackendResolution)
 ) {

--- a/app/views/fragments/checkout/fieldsPersonal.scala.html
+++ b/app/views/fragments/checkout/fieldsPersonal.scala.html
@@ -52,7 +52,7 @@
     <div class="form-field">
         <label class="label" for="country">Country</label>
         <select name="personal.address.country" class=" select select--wide js-country">
-            <option></option>
+            <option data-currency-choice="USD"></option>
             @for(c <- countriesWithCurrency) {
                 <option value="@c.alpha2" @c.country.validationRules.toAttributes @c.country.addressLabels data-currency-choice="@c.currency">@c.name</option>
             }

--- a/app/views/fragments/javascriptLaterSteps.scala.html
+++ b/app/views/fragments/javascriptLaterSteps.scala.html
@@ -1,4 +1,4 @@
-F@import controllers.CachedAssets.hashedPathFor
+@import controllers.CachedAssets.hashedPathFor
 
 @* Scripts that should be executed after CSS is loaded *@
 <script id="script-curl">

--- a/app/views/fragments/javascriptLaterSteps.scala.html
+++ b/app/views/fragments/javascriptLaterSteps.scala.html
@@ -1,4 +1,4 @@
-@import controllers.CachedAssets.hashedPathFor
+F@import controllers.CachedAssets.hashedPathFor
 
 @* Scripts that should be executed after CSS is loaded *@
 <script id="script-curl">

--- a/assets/javascripts/modules/checkout/fieldSwitcher.js
+++ b/assets/javascripts/modules/checkout/fieldSwitcher.js
@@ -47,7 +47,7 @@ define([
     // Change the payment method to Direct Debit for UK users,
     // Credit Card for international users
     var selectPaymentMethod = function (country) {
-        if (country == 'GB') {
+        if (country === 'GB') {
             check(formElements.$DIRECT_DEBIT_TYPE[0]);
         } else {
             check(formElements.$CARD_TYPE[0]);

--- a/assets/javascripts/modules/checkout/localizationSwitcher.js
+++ b/assets/javascripts/modules/checkout/localizationSwitcher.js
@@ -1,13 +1,9 @@
 define(['$'], function ($) {
+    'use strict';
+
     var model = {
        currency: null,
        country: null
-    };
-
-    var set = function (currency, country) {
-        model.currency = currency;
-        model.country = country;
-        refresh();
     };
 
     var refresh = function () {
@@ -28,7 +24,13 @@ define(['$'], function ($) {
 
     };
 
+    var set = function (currency, country) {
+        model.currency = currency;
+        model.country = country;
+        refresh();
+    };
+
     return {
         set: set
-    }
+    };
 });

--- a/assets/javascripts/modules/checkout/promoCode.js
+++ b/assets/javascripts/modules/checkout/promoCode.js
@@ -93,8 +93,10 @@ define([
     }
 
     function validate() {
-        var promoCode  = $inputBox.val().trim();
-        if (promoCode === '' || countryChoice.getCurrentCountryOption().value === '') {
+        var country = countryChoice.getCurrentCountryOption().value.trim(),
+            promoCode  = $inputBox.val().trim();
+
+        if (country === '' || promoCode === '') {
             clearDown();
             return;
         }
@@ -106,7 +108,7 @@ define([
             data: {
                 promoCode: promoCode,
                 productRatePlanId: formElements.getRatePlanId(),
-                country: countryChoice.getCurrentCountryOption().value
+                country: country
             }
         }).then(function (a) {
             if (a.isValid) {

--- a/assets/javascripts/modules/checkout/promoCode.js
+++ b/assets/javascripts/modules/checkout/promoCode.js
@@ -94,7 +94,7 @@ define([
 
     function validate() {
         var promoCode  = $inputBox.val().trim();
-        if (promoCode === '') {
+        if (promoCode === '' || countryChoice.getCurrentCountryOption().value === '') {
             clearDown();
             return;
         }

--- a/assets/javascripts/modules/optionMirror.js
+++ b/assets/javascripts/modules/optionMirror.js
@@ -23,6 +23,9 @@ define(['$'], function ($) {
                 option.addEventListener('change', function(e) {
                     mirror(valueElems, e.target);
                 });
+                if (option.checked) {
+                    mirror(valueElems, option);
+                }
             });
         }
     };

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.188",
+    "com.gu" %% "membership-common" % "0.192",
     "com.gu" %% "memsub-common-play-auth" % "0.5",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.0.0",


### PR DESCRIPTION
Fixed issue where an Identity user had a None country, we weren't correctly setting the country dropdown or checking the set of rate plans. Most of the rest of the code was collateral from changing Address.country to an Option[Country].

Fixes: https://trello.com/c/lOdZUGdi/486-checkout-failure-for-existing-eu-identity-user-subscribing-to-the-digital-pack

And indirectly fixes: https://trello.com/c/yt3TSe0Z/465-eu-and-international-members-cannot-subscribe

As well as: https://app.getsentry.com/the-guardian/subscriptions/issues/123751035/

cc @AWare @rtyley @tomverran @mario-galic 