### PR TITLE
Handle bad requests with a template and some logging

### DIFF
--- a/app/monitoring/ErrorHandler.scala
+++ b/app/monitoring/ErrorHandler.scala
@@ -32,4 +32,8 @@ class ErrorHandler @Inject() (env: Environment,
   override protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] = {
     Future.successful(NoCache(InternalServerError(views.html.error500(exception))))
   }
+  override protected def onBadRequest(request: RequestHeader, message: String): Future[Result] = {
+    logServerError(request, new PlayException("Bad request", "A bad request was received."))
+    Future.successful(NoCache(BadRequest(views.html.error400(request, message))))
+  }
 }

--- a/app/views/error400.scala.html
+++ b/app/views/error400.scala.html
@@ -1,0 +1,18 @@
+@(req: RequestHeader, err: String)
+    @main("Bad Request") {
+        <main class="page-container gs-container">
+          @fragments.page.header("Error 400", Some("Bad Request"))
+            <div class="prose">
+                    <p>
+                        Sorry, there was an error with this page. Please contact support at:<a href="mailto:subscriptions.dev@@theguardian.com">
+                        subscriptions.dev@@theguardian.com</a>.
+                    </p>
+
+                    <p>Please provide the following error code to help identify the issue.</p>
+                    <pre>Error: @err</pre>
+                    <pre>Path: @req.path</pre>
+
+                </div>
+         </main>
+    }
+


### PR DESCRIPTION
https://github.com/guardian/membership-frontend/pull/1149 -> Subs. 
OLD:
![image](https://cloud.githubusercontent.com/assets/2670496/14643880/028b8a16-0648-11e6-8e67-003d0a8793fa.png)
NEW:
![image](https://cloud.githubusercontent.com/assets/2670496/14643871/f9172436-0647-11e6-92fc-f6a67a22baf8.png)
trello:https://trello.com/c/58tIPCvq/470-play-error-messages-in-prod

@adamnfish @tomverran 
