### PR TITLE
Revert "Revert "Create guest identity account only after successful salesforce call""

### DIFF
--- a/app/model/PurchaserIdentifiers.scala
+++ b/app/model/PurchaserIdentifiers.scala
@@ -1,0 +1,8 @@
+package model
+
+import com.gu.identity.play.IdMinimalUser
+import com.gu.salesforce.ContactId
+
+case class PurchaserIdentifiers(memberId: ContactId, identityId: Option[IdMinimalUser]) {
+  val description = (Seq(s"SalesforceContactID - ${memberId.salesforceContactId}") ++ identityId.map(id => s"IdentityID - $id")).mkString("\n")
+}

--- a/app/model/error/CheckoutService.scala
+++ b/app/model/error/CheckoutService.scala
@@ -1,9 +1,11 @@
 package model.error
 
+import com.gu.identity.play.IdMinimalUser
 import com.gu.memsub.promo.PromoCode
 import com.gu.salesforce.ContactId
 import com.gu.zuora.soap.models.Results.SubscribeResult
 import com.gu.zuora.soap.models.errors.PaymentGatewayError
+import model.PurchaserIdentifiers
 import services.UserIdData
 
 object CheckoutService {
@@ -26,7 +28,7 @@ object CheckoutService {
   }
 
   case class CheckoutGenericFailure(
-      userId: String,
+      purchaserIds: PurchaserIdentifiers,
       msg: String,
       requestData: String,
       errorResponse: Option[String]) extends CheckoutResult with SubsError {
@@ -36,7 +38,7 @@ object CheckoutService {
   }
 
   case class CheckoutStripeError(
-      userId: String,
+      purchaserIds: PurchaserIdentifiers,
       paymentError: Throwable,
       msg: String,
       requestData: String,
@@ -47,7 +49,7 @@ object CheckoutService {
   }
 
   case class CheckoutZuoraPaymentGatewayError(
-      userId: String,
+      purchaserIds: PurchaserIdentifiers,
       paymentError: PaymentGatewayError,
       msg: String,
       requestData: String,
@@ -58,7 +60,7 @@ object CheckoutService {
   }
 
   case class CheckoutSalesforceFailure(
-      userId: String,
+      identityUser: Option[IdMinimalUser],
       msg: String,
       requestData: String,
       errorResponse: Option[String]) extends CheckoutResult with SubsError {
@@ -68,7 +70,7 @@ object CheckoutService {
   }
 
   case class CheckoutExactTargetFailure(
-      userId: String,
+      purchaserIds: PurchaserIdentifiers,
       msg: String,
       requestData: String,
       errorResponse: Option[String]) extends CheckoutResult with SubsError {
@@ -78,7 +80,7 @@ object CheckoutService {
   }
 
   case class CheckoutPaymentTypeFailure(
-      userId: String,
+      purchaserIds: PurchaserIdentifiers,
       msg: String,
       requestData: String,
       errorResponse: Option[String]) extends CheckoutResult with SubsError {
@@ -88,3 +90,5 @@ object CheckoutService {
   }
 
 }
+
+

--- a/app/services/PaymentService.scala
+++ b/app/services/PaymentService.scala
@@ -1,11 +1,11 @@
 package services
 
-import com.gu.i18n.{Currency, GBP, Country}
-import com.gu.memsub.{Current, PaidPlan, BillingPeriod}
+import com.gu.i18n.{Country, Currency, GBP}
+import com.gu.memsub.BillingPeriod
 import com.gu.salesforce.ContactId
 import com.gu.stripe.StripeService
 import com.gu.subscriptions.DigipackPlan
-import com.gu.zuora.soap.models.Commands.{PaymentMethod, CreditCardReferenceTransaction, BankTransfer, Account}
+import com.gu.zuora.soap.models.Commands.{Account, BankTransfer, CreditCardReferenceTransaction, PaymentMethod}
 import model._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
@@ -33,11 +33,12 @@ trait PaymentService {
       ))
   }
 
-  class CreditCardPayment(val paymentData: CreditCardData, val currency: Currency, userIdData: UserIdData, val memberId: ContactId) extends Payment {
-    override def makeAccount = Account.stripe(memberId, currency, autopay = true)
-    override def makePaymentMethod =
-      stripeService.Customer.create(userIdData.id.id, paymentData.stripeToken)
+  class CreditCardPayment(val paymentData: CreditCardData, val currency: Currency, val purchaserIds: PurchaserIdentifiers) extends Payment {
+    override def makeAccount = Account.stripe(purchaserIds.memberId, currency, autopay = true)
+    override def makePaymentMethod = {
+      stripeService.Customer.create(description = purchaserIds.description, card = paymentData.stripeToken)
         .map(a => CreditCardReferenceTransaction(a.card.id, a.id))
+    }
   }
 
   def makeDirectDebitPayment(paymentData: DirectDebitData, personalData: PersonalData, memberId: ContactId) = {
@@ -46,14 +47,13 @@ trait PaymentService {
   }
 
   def makeCreditCardPayment(
-      paymentData: CreditCardData,
-      personalData: PersonalData,
-      userIdData: UserIdData,
-      memberId: ContactId,
-      plan: DigipackPlan[BillingPeriod]) = {
+     paymentData: CreditCardData,
+     personalData: PersonalData,
+     purchaserIds: PurchaserIdentifiers,
+     plan: DigipackPlan[BillingPeriod]) = {
     val desiredCurrency = personalData.currency
     val currency = if (plan.currencies.contains(desiredCurrency)) desiredCurrency else GBP
 
-    new CreditCardPayment(paymentData, currency, userIdData, memberId = memberId)
+    new CreditCardPayment(paymentData, currency, purchaserIds)
   }
 }

--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -1,5 +1,6 @@
 package services
 
+import com.gu.identity.play.IdMinimalUser
 import com.gu.memsub.util.FutureSupplier
 import com.gu.salesforce.ContactDeserializer.Keys
 import com.gu.salesforce._
@@ -17,7 +18,7 @@ import scala.concurrent.duration._
 trait SalesforceService extends LazyLogging {
   def repo: SalesforceRepo
 
-  def createOrUpdateUser(personalData: PersonalData, userId: UserId): Future[ContactId]
+  def createOrUpdateUser(personalData: PersonalData, userId: Option[IdMinimalUser]): Future[ContactId]
 
   def createSalesforceUserData(personalData: PersonalData): JsObject = Json.obj(
       Keys.EMAIL -> personalData.email,
@@ -32,8 +33,8 @@ trait SalesforceService extends LazyLogging {
 }
 
 class SalesforceServiceImp(val repo: SalesforceRepo) extends SalesforceService {
-  override def createOrUpdateUser(personalData: PersonalData, userId: UserId): Future[ContactId] =
-    repo.upsert(userId.id, createSalesforceUserData(personalData))
+  override def createOrUpdateUser(personalData: PersonalData, userId: Option[IdMinimalUser]): Future[ContactId] =
+    repo.upsert(userId.map(_.id), createSalesforceUserData(personalData))
 }
 
 class SalesforceRepo(salesforceConfig: SalesforceConfig) extends ContactRepository {

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.187",
+    "com.gu" %% "membership-common" % "0.188",
     "com.gu" %% "memsub-common-play-auth" % "0.5",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.0.0",


### PR DESCRIPTION
Reverts #422, reinstating #420 , now that the Salesforce API tweak is present in the PROD Salesforce environment:

---------- Forwarded message ----------
From: Michael Ojo
Date: 20 April 2016 at 10:50
Subject: Register Customer Now in PROD

Hi All,

Register Customer updated service is now in PROD.

Cheers

cc @paulbrown1982 @joelochlann @tomverran 