### PR TITLE
Add X-Gu-Identity-Id & X-Gu-Membership-Test-User headers

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,4 +1,4 @@
-import filters.{AddEC2InstanceHeader, CheckCacheHeadersFilter}
+import filters.{AddGuIdentityHeaders, AddEC2InstanceHeader, CheckCacheHeadersFilter}
 import monitoring.SentryLogging
 import play.api.Application
 import play.api.mvc.WithFilters
@@ -13,6 +13,7 @@ object Global extends WithFilters(
     contentSecurityPolicy = None
   )),
   CSRFFilter(),
+  AddGuIdentityHeaders,
   AddEC2InstanceHeader) {
   override def onStart(app: Application) {
     SentryLogging.init()

--- a/app/filters/AddGuIdentityHeaders.scala
+++ b/app/filters/AddGuIdentityHeaders.scala
@@ -1,0 +1,23 @@
+package filters
+
+import play.api.http.HeaderNames
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.mvc._
+import services.AuthenticationService
+import utils.TestUsers._
+
+import scala.concurrent.Future
+
+object AddGuIdentityHeaders extends Filter with HeaderNames {
+
+  def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = for {
+    result <- nextFilter(requestHeader)
+  } yield (for {
+    cacheHeader <- result.header.headers.get(CACHE_CONTROL) if cacheHeader.contains("no-cache")
+    user <- AuthenticationService.authenticatedUserFor(requestHeader)
+  } yield result.withHeaders(
+    "X-Gu-Identity-Id" -> user.id,
+    "X-Gu-Membership-Test-User" -> SignedInUsername.passes(user).isDefined.toString
+  )).getOrElse(result)
+
+}


### PR DESCRIPTION
Verifying that https://github.com/guardian/subscriptions-frontend/pull/425 is succseful by looking at Fastly logs isn't possible, because although I can see users successfully hitting `/checkout/thank-you`, I can't easily see if they're logged in.

This code is borrowed from membership-frontend - but is slightly better, I think, because it uses a filter rather than an action builder.

cc @AWare 