### PR TITLE
The country field should be a required field.

### DIFF
--- a/app/views/fragments/checkout/fieldsPersonal.scala.html
+++ b/app/views/fragments/checkout/fieldsPersonal.scala.html
@@ -51,7 +51,7 @@
 <div class="js-checkout-full-address">
     <div class="form-field">
         <label class="label" for="country">Country</label>
-        <select name="personal.address.country" class=" select select--wide js-country">
+        <select name="personal.address.country" class=" select select--wide js-country" required>
             <option data-currency-choice="USD"></option>
             @for(c <- countriesWithCurrency) {
                 <option value="@c.alpha2" @c.country.validationRules.toAttributes @c.country.addressLabels data-currency-choice="@c.currency">@c.name</option>


### PR DESCRIPTION
The country field should be a required field. 

This stops https://app.getsentry.com/the-guardian/subscriptions/issues/124098463/ from happening.

https://trello.com/c/HrRRSyPI/494-bug-fix-front-end-validation-logic-for-when-no-country-is-selected

Also relates to: https://trello.com/c/lOdZUGdi/486-checkout-failure-for-existing-eu-identity-user-subscribing-to-the-digital-pack and https://trello.com/c/yt3TSe0Z/465-eu-and-international-members-cannot-subscribe

cc @tomverran 