### PR TITLE
Synchronise email validation across stack

### DIFF
--- a/assets/javascripts/modules/forms/regex.js
+++ b/assets/javascripts/modules/forms/regex.js
@@ -5,8 +5,8 @@ define([], function () {
         isNumber: function isNumber(s) {
             return !/[^\d]+/.test(s);
         },
-        isValidEmail: function isValidEmail(s) {
-            return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s);
+        isValidEmail: function isValidEmail(s) { // use regex from Scala Play
+            return /^[a-zA-Z0-9\.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(s);
         },
         isPostcode: function isPostcode(s) {
             return /^[\sA-Z\d]{5,}$/i.test(s);

--- a/test/js/spec/modules/forms/regex.spec.js
+++ b/test/js/spec/modules/forms/regex.spec.js
@@ -5,8 +5,9 @@ define(['modules/forms/regex'], function (regex) {
         it('email validation', function () {
             expect(regex.isValidEmail("rt@tg.com")).toBe(true);
             expect(regex.isValidEmail("rt1234@tg.com")).toBe(true);
-            expect(regex.isValidEmail("rt@tgcom")).toBe(false);
             expect(regex.isValidEmail("rttg.com")).toBe(false);
+            expect(regex.isValidEmail("rt@tg?.com")).toBe(false);
+            expect(regex.isValidEmail("§rt@tg.com")).toBe(false);
         });
 
         it('postcode validation', function () {


### PR DESCRIPTION
@markjamesbutler @nlindblad @paulbrown1982 

Corresponding PR in identity: https://github.com/guardian/identity/pull/577

**Do not merge this until above PR is merged first.**

[Trello card](https://trello.com/c/9l6TKO14/14-user-cannot-subscribe-to-digital-pack-due-to-email-validation-error)

Use email validation regex from Play throughout the stack.

Currently all three systems in the stack (sub-fe JavaScript, sub-fe Scala Play, identity-api) use different email validation regex:
```
JS          ^[^@\s]+@[^@\s]+\.[^@\s]+$
Scala Play  ^[a-zA-Z0-9\.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$
Identity    ^[a-zA-Z0-9_'\+-]+(\.[a-zA-Z0-9_'\+-]+)*@[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*\.([a-zA-Z]{2,63})$
```