### PR TITLE
Add jasmine-core to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "grunt-sass": "^1.0.0",
     "grunt-svgmin": "^2.0.1",
     "grunt-svgstore": "^0.5.0",
+    "jasmine-core": "^2.4.1",
     "karma": "~0.12.31",
     "karma-chrome-launcher": "^0.1.7",
     "karma-coverage": "^0.2.7",


### PR DESCRIPTION
@paulbrown1982 

Resolves the following error when running `grunt test` locally:

```
UNMET PEER DEPENDENCY jasmine-core@*

npm WARN karma-jasmine@0.3.8 requires a peer of jasmine-core@* but none was installed.
```

Since karma-jasmine 0.3.0 the jasmine library is no longer bundled with karma-jasmine and you have to install it on your own (see official [readme](https://github.com/karma-runner/karma-jasmine/blob/aaee433141f76ad6cf13495f4f19e9eeb2e49d06/README.md#jasmine-20-docs)).