### PR TITLE
Add redemption instructions to Welcome 1

### DIFF
--- a/app/model/exactTarget/SubscriptionDataExtensionRow.scala
+++ b/app/model/exactTarget/SubscriptionDataExtensionRow.scala
@@ -17,7 +17,8 @@ object SubscriptionDataExtensionRow extends LazyLogging {
              paymentMethod: PaymentMethod,
              gracePeriod: Days,
              subscriptionDetails: String,
-             promotionDescription: Option[String] = None
+             promotionDescription: Option[String] = None,
+             redemptionInstructions: Option[String] = None
   ): SubscriptionDataExtensionRow = {
 
 
@@ -37,7 +38,9 @@ object SubscriptionDataExtensionRow extends LazyLogging {
       )
     }
 
-    val promotionFields = promotionDescription.map(d => "Promotion description" -> d.substring(0, Math.min(d.length, 255)))
+    val promotionFields =
+      promotionDescription.map(d => "Promotion description" -> d.substring(0, Math.min(d.length, 255))) ++
+        redemptionInstructions.map(i => "Redemption instructions" -> i.substring(0, Math.min(i.length, 255)))
 
     SubscriptionDataExtensionRow(
       personalData.email,

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -52,6 +52,12 @@ trait ExactTargetService extends LazyLogging {
     )
     val subscriptionDetails = getPlanDescription(validPromotion, subscriptionData.personalData.currency, subscriptionData.productRatePlanId)
     val promotionDescription = validPromotion.filterNot(_.promotion.promotionType == Tracking).map(_.promotion.description)
+    val redemptionInstructions = for {
+      vp <- validPromotion
+      p <- vp.promotion.asIncentive
+    } yield {
+      p.promotionType.redemptionInstructions
+    }
 
     for {
       sub <- subscription
@@ -62,7 +68,8 @@ trait ExactTargetService extends LazyLogging {
         paymentMethod = pm,
         gracePeriod = gracePeriod,
         subscriptionDetails = subscriptionDetails,
-        promotionDescription = promotionDescription
+        promotionDescription = promotionDescription,
+        redemptionInstructions = redemptionInstructions
       )
       response <- etClient.sendSubscriptionRow(row)
     } yield {


### PR DESCRIPTION
Added the promotion redemption instructions to the Exact Target data extension.

cc @tomverran 