### PR TITLE
More copy tweaks to help with conversion

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -51,7 +51,7 @@
         <form class="form js-checkout-form" action="@routes.Checkout.renderCheckout(CountryGroup.UK, None).toString" method="POST" novalidate>
             @helper.CSRF.formField
 
-            @fragments.checkout.checkoutHeader("Digital Pack", promoCode.exists(_.get == "DGA85"))
+            @fragments.checkout.checkoutHeader("Digital Pack")
 
             @* ===== Plan selection ===== *@
             <div class="checkout-container__sidebar js-basket">
@@ -68,8 +68,17 @@
                         }
                     }
                 </fieldset>
+                @fragments.checkout.promoCode(form)
                 <div class="js-checkout-notices notices-container" data-set="checkout-notices" hidden="true">
                     <div class="js-append">
+                        <div class=u-note">
+                        @fragments.checkout.notice("Money Back Guarantee") {
+                            <p>
+                                If you wish to cancel your subscription, we will send
+                                you a refund of the unexpired part of your subscription.
+                            </p>
+                        }
+                        </div>
                         <div class="js-payment-type-direct-debit u-note">
                             @fragments.checkout.noticesDirectDebit()
                         </div>
@@ -78,7 +87,6 @@
                         </div>
                     </div>
                 </div>
-                @fragments.checkout.promoCode(form)
             </div>
 
             <div class="checkout-container__form">
@@ -90,12 +98,15 @@
                             <span class="field-panel__legend__num">1</span> Your details
                         </legend>
                         <div class="field-panel__intro">
+                            <div class="field-note field-note--offset">
+                                @fragments.forms.securityNote()
+                            </div>
                             <div class="field-note field-note--offset prose">
                                 @if(userIsSignedIn) {
-                                    <a href="@idWebAppSignOutUrl(routes.Checkout.renderCheckout(CountryGroup.UK, None))">Sign out</a>
+                                    <a class="u-nowrap" href="@idWebAppSignOutUrl(routes.Checkout.renderCheckout(CountryGroup.UK, None))">Sign out</a>
                                 } else {
                                     <span class="field-note__label">Already have a Guardian account?</span>
-                                    <a href="@idWebAppSigninUrl(routes.Checkout.renderCheckout(CountryGroup.UK, None))">Sign in</a>
+                                    <a class="u-nowrap" href="@idWebAppSigninUrl(routes.Checkout.renderCheckout(CountryGroup.UK, None))">Sign in</a>
                                 }
                             </div>
                         </div>

--- a/app/views/fragments/checkout/checkoutHeader.scala.html
+++ b/app/views/fragments/checkout/checkoutHeader.scala.html
@@ -1,13 +1,4 @@
-@(extra: String, showDetails: Boolean = false)
-
+@(product: String)
 <div class="checkout-header">
-    <h1 class="checkout-header__title">Subscribe to the @extra</h1>
-    @if(showDetails) {
-        <ul>
-            <li>14-day free trial</li>
-            <li>Access to the Daily Edition and Guardian App Premium Tier</li>
-            <li>Available on Apple, Android and Kindle Fire</li>
-            <li>Use on up to 10 devices</li>
-        </ul>
-    }
+    <h1 class="checkout-header__title">Subscribe to the @product</h1>
 </div>

--- a/app/views/fragments/checkout/fieldsDirectDebit.scala.html
+++ b/app/views/fragments/checkout/fieldsDirectDebit.scala.html
@@ -1,12 +1,7 @@
+@import controllers.CachedAssets.hashedPathFor
+
 @()
 
-@* ===== Account number ===== *@
-<div class="form-field js-checkout-account">
-    <label class="label" for="payment-account">Bank account number</label>
-    <input type="text" class="input-text js-input" id="payment-account"
-    name="payment.account" pattern="[0-9]*" minlength="6" maxlength="10" required>
-        @fragments.forms.errorMessage("Please enter between 6 and 10 digits for the account number, and make sure the account is valid")
-</div>
 
 @* ===== Sortcode ===== *@
 <div class="form-field js-checkout-sortcode">
@@ -16,7 +11,19 @@
     placeholder="00-00-00"  maxlength="8" required
     data-masker-delim="-" data-masker-length="2">
     @fragments.forms.errorMessage("")
+    <div class="u-align-right">
+        <img src="@hashedPathFor("images/direct-debit.png")" alt="Direct Debit">
+    </div>
 </div>
+
+@* ===== Account number ===== *@
+<div class="form-field js-checkout-account">
+    <label class="label" for="payment-account">Bank account number</label>
+    <input type="text" class="input-text js-input" id="payment-account"
+    name="payment.account" pattern="[0-9]*" minlength="6" maxlength="10" required>
+    @fragments.forms.errorMessage("Please enter between 6 and 10 digits for the account number, and make sure the account is valid")
+</div>
+
 
 @* ===== Account Holder Name ===== *@
 <div class="form-field js-checkout-holder">

--- a/app/views/fragments/checkout/fieldsPersonal.scala.html
+++ b/app/views/fragments/checkout/fieldsPersonal.scala.html
@@ -71,9 +71,6 @@
         </select>
         @fragments.forms.errorMessage("This field is required")
     </div>
-
-    <div class="js-postcode"><!--populated in js--></div>
-
     <div class="form-field js-checkout-house">
         <label class="label" for="address-line-1">Address line 1</label>
         @* Salesforce accepts up to 255 chars but this field gets concatenated with address line 2 *@
@@ -94,16 +91,16 @@
             value="@form.data.get("personal.address.town")" maxlength="40" required>
         @fragments.forms.errorMessage("This field is required")
     </div>
-</div>
-<div class="form-field js-checkout-subdivision">
-    <label class="label" for="address-subdivision">County</label>
-    <select name="address.subdivision" id="address-subdivision"></select>
-    @fragments.forms.errorMessage("Please enter a valid state/county")
-</div>
-<div class="form-field js-checkout-postcode">
-    <label class="label" for="address-postcode">Postcode</label>
-    <input type="text" class="input-text js-input input-text input-text--small"
+    <div class="form-field js-checkout-subdivision">
+        <label class="label" for="address-subdivision">County</label>
+        <select name="address.subdivision" id="address-subdivision"></select>
+        @fragments.forms.errorMessage("Please enter a valid state/county")
+    </div>
+    <div class="form-field js-checkout-postcode">
+        <label class="label" for="address-postcode">Postcode</label>
+        <input type="text" class="input-text js-input input-text input-text--small"
         id="address-postcode" name="personal.address.postcode"
         value="@form.data.get("personal.address.postcode")" maxlength="10" required>
-    @fragments.forms.errorMessage("Please enter a valid postal code")
+        @fragments.forms.errorMessage("Please enter a valid postal code")
+    </div>
 </div>

--- a/app/views/fragments/checkout/noticesCard.scala.html
+++ b/app/views/fragments/checkout/noticesCard.scala.html
@@ -6,9 +6,3 @@
         due date, frequency and amount will be sent to you within three working days.
     </p>
 }
-@fragments.checkout.notice("Money Back Guarantee") {
-    <p>
-        If you wish to cancel your subscription, we will send
-        you a refund of the unexpired part of your subscription.
-    </p>
-}

--- a/app/views/fragments/checkout/noticesDirectDebit.scala.html
+++ b/app/views/fragments/checkout/noticesDirectDebit.scala.html
@@ -10,12 +10,6 @@
         All the normal Direct Debit safeguards and guarantees apply.
     </p>
 }
-@fragments.checkout.notice("Money Back Guarantee") {
-    <p>
-        If you wish to cancel your subscription, we will send
-        you a refund of the unexpired part of your subscription.
-    </p>
-}
 @fragments.checkout.notice("Direct Debit") {
 
     <address>

--- a/app/views/fragments/checkout/promoCode.scala.html
+++ b/app/views/fragments/checkout/promoCode.scala.html
@@ -13,7 +13,7 @@
             <li>Free premium upgrade to the Guardian app</li>
         </ul>
     </div>
-    <input name="promoCode" type="hidden" value="@form.data.get("promoCode")">
+    <input name="promoCode" type="hidden" value="@form.data.get("promoCode")"/>
 } else {
     @defining(
         // use Play reverse routing to get the action request path

--- a/app/views/fragments/checkout/promoCode.scala.html
+++ b/app/views/fragments/checkout/promoCode.scala.html
@@ -2,25 +2,36 @@
 @import com.gu.memsub.Subscription.ProductRatePlanId
 @import com.gu.memsub.promo.PromoCode
 @import controllers.routes.Checkout.validatePromoCode
-@import services.TouchpointBackend
 @(form: Form[model.SubscriptionData])
-@defining(
-  // use Play reverse routing to get the action request path
-  validatePromoCode(
-      PromoCode("_"),
-      ProductRatePlanId("_"),
-      Country.UK).path.replaceFirst("\\?.*", "")) { lookupUrl =>
+@if(form.data.get("promoCode").contains("DGA85")) {
+    <div class="promo-code-applied">✓&nbsp; Promotion applied</div>
+    <div class="promo-code-snippet">
+        <ul>
+            <li><strong>£30 digital gift card</strong></li>
+            <li><strong>14 day free trial before first payment</strong></li>
+            <li>Access to the daily edition</li>
+            <li>Free premium upgrade to the Guardian app</li>
+        </ul>
+    </div>
+} else {
+    @defining(
+        // use Play reverse routing to get the action request path
+        validatePromoCode(
+            PromoCode("_"),
+            ProductRatePlanId("_"),
+            Country.UK).path.replaceFirst("\\?.*", "")) { lookupUrl =>
         <div class="checkout-promo-code js-promo-code">
             <label class="label" for="promo-code">Promo code</label>
             <div class="form-field field-group__item">
                 <div class="col-2">
                     <input id="promo-code" name="promoCode" value="@form.data.get("promoCode")" class="input-text js-input" data-lookup-url="@lookupUrl"/>
-                    <a class="button button--primary button--large button--arrow-right js-promo-code-validate">
-                        Apply</a>
+                    <a class="button button--primary button--large button--arrow-right js-promo-code-validate">Apply</a>
                 </div>
                 @fragments.forms.errorMessage("Please enter a valid promo code.")
             </div>
-            <div class="js-promo-code-applied promo-code-applied" style="display:none"><strong>✓&nbsp;</strong>Promotion applied</div>
+            <div class="js-promo-code-applied promo-code-applied" style="display: none"><strong>✓&nbsp;</strong>
+                Promotion applied</div>
             <div class="promo-code-snippet js-promo-code-snippet"></div>
         </div>
+    }
 }

--- a/app/views/fragments/checkout/promoCode.scala.html
+++ b/app/views/fragments/checkout/promoCode.scala.html
@@ -13,6 +13,7 @@
             <li>Free premium upgrade to the Guardian app</li>
         </ul>
     </div>
+    <input name="promoCode" type="hidden" value="@form.data.get("promoCode")">
 } else {
     @defining(
         // use Play reverse routing to get the action request path

--- a/app/views/fragments/checkout/promoCode.scala.html
+++ b/app/views/fragments/checkout/promoCode.scala.html
@@ -10,7 +10,7 @@
             <li><strong>£30 digital gift card</strong></li>
             <li><strong>14 day free trial before first payment</strong></li>
             <li>Access to the daily edition</li>
-            <li>Free premium upgrade to the Guardian app</li>
+            <li>Ad free experience on the live news app</li>
         </ul>
     </div>
     <input name="promoCode" type="hidden" value="@form.data.get("promoCode")"/>

--- a/app/views/promotion/landingPage.scala.html
+++ b/app/views/promotion/landingPage.scala.html
@@ -38,7 +38,7 @@
                 </div>
             </div>
         </section>
-        @promotion.asFreeTrial.fold {
+        @if(promotion.asFreeTrial.isEmpty && promotion.asTracking.isEmpty){
             <section class="@promotion.landingPageSectionColour section--dark-sides">
                 <div class="gs-container gs-container--slim page-slice page-slice">
                     <div class="page-slice__content @promotion.getSectionSeparator">
@@ -53,7 +53,7 @@
                     </div>
                 </div>
             </section>
-        } { _ => }
+        }
         <section class="section-white section--dark-sides">
             <div class="gs-container gs-container--slim page-slice">
                 <div class="page-slice__content @promotion.getSectionSeparator">

--- a/assets/javascripts/modules/checkout/fieldSwitcher.js
+++ b/assets/javascripts/modules/checkout/fieldSwitcher.js
@@ -9,8 +9,8 @@ define([
 ], function ($, bean, countryChoice, addressFields, localizationSwitcher, formElements) {
     'use strict';
 
-    var $postcode = $('.js-checkout-postcode'),
-        $subdivision = $('.js-checkout-subdivision');
+    var $postcode = formElements.$POSTCODE_CONTAINER,
+        $subdivision = formElements.$SUBDIVISION_CONTAINER;
 
     var check = function(domEl) {
         $(domEl).attr('checked', 'checked');

--- a/assets/javascripts/modules/checkout/formElements.js
+++ b/assets/javascripts/modules/checkout/formElements.js
@@ -64,6 +64,7 @@ define(['$'], function ($) {
         $ADDRESS1_CONTAINER: $('.js-checkout-house'),
         $ADDRESS2_CONTAINER: $('.js-checkout-street'),
         $ADDRESS3_CONTAINER: $('.js-checkout-town'),
+        $SUBDIVISION_CONTAINER: $('.js-checkout-subdivision'),
         $POSTCODE_CONTAINER: $('.js-checkout-postcode'),
         $MANUAL_ADDRESS_CONTAINER: $('.js-checkout-manual-address'),
         $FULL_ADDRESS_CONTAINER: $('.js-checkout-full-address'),

--- a/assets/stylesheets/modules/_checkout-basket.scss
+++ b/assets/stylesheets/modules/_checkout-basket.scss
@@ -16,16 +16,8 @@
 }
 
 .basket-preview__image {
-    display: none;
-    @include mq(tablet) {
-        display: block;
-    }
-
-    @include mq($from: tablet, $until: desktop) {
-        bottom: -$gs-baseline;
-        position: absolute;
+    @include mq($until: desktop) {
         width: 150px;
-        right: 0;
     }
 
 }

--- a/assets/stylesheets/modules/_checkout-promocode.scss
+++ b/assets/stylesheets/modules/_checkout-promocode.scss
@@ -25,7 +25,18 @@
     .form-field__error-message {
         clear: both;
     }
-    .promo-code-applied {
-        margin-bottom: ($gs-baseline);
+}
+.promo-code-applied {
+    font-weight: guss-font-weight(bold);
+
+    @include mq($until: desktop) {
+        @include fs-textSans(3);
+    }
+}
+.promo-code-snippet {
+    margin-bottom: ($gs-baseline);
+
+    @include mq($until: desktop) {
+        @include fs-textSans(3);
     }
 }

--- a/assets/stylesheets/utilities/_text.scss
+++ b/assets/stylesheets/utilities/_text.scss
@@ -54,3 +54,7 @@
         border-bottom: none;
     }
 }
+
+.u-nowrap {
+    white-space: nowrap;
+}


### PR DESCRIPTION
- Moved the DGA85 bit into the promoCode section to keep things tidier, and because it just wasn't right being in the header.
- Put the sort code before the account number.
- Added the direct debit logo.
- Put the lock symbol on the first section too.
- Tidied up HTML a bit for address fields.

https://trello.com/c/lMC63OmG/32-update-digipack-checkout-page-to-improve-conversion

cc @AWare  