### PR TITLE
Fix the promise polyfill

### DIFF
--- a/assets/javascripts/main.js
+++ b/assets/javascripts/main.js
@@ -29,9 +29,11 @@ require([
     checkout,
     confirmation,
     cas,
-    patterns
+    patterns,
+    promise
 ) {
     'use strict';
+    window.Promise = window.Promise || promise;
 
     ajax.init({page: {ajaxUrl: ''}});
     raven.init('https://6dd79da86ec54339b403277d8baac7c8@app.getsentry.com/47380');


### PR DESCRIPTION
When we switched from bower to NPM we copied across the libraries we use but unfortunately promise-polyfill places its Promise object onto the object loading it, rather than specifically the window

As such it used to work when we used it via bower but quietly does nothing now we use NPM