### PR TITLE
Paper form

### DIFF
--- a/app/actions/ActionRefiners.scala
+++ b/app/actions/ActionRefiners.scala
@@ -18,7 +18,7 @@ object ActionRefiners {
         val tp = TouchpointBackend.forRequest(PreSigninTestCookie, request.cookies)(request).backend
         (for {
           sf <- OptionT(tp.salesforceService.repo.get(user.id))
-          sub <- OptionT(tp.subscriptionService.get(sf)(Digipack))
+          sub <- OptionT(tp.subscriptionService.get(sf))
         } yield onSubscription(sub)).run
       }
     }

--- a/app/controllers/Binders.scala
+++ b/app/controllers/Binders.scala
@@ -1,9 +1,12 @@
 package controllers
 
 import com.gu.i18n.{Country, CountryGroup}
+import com.gu.memsub.ProductFamily
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.promo.PromoCode
 import play.api.mvc.QueryStringBindable.{Parsing => QueryParsing}
+import play.api.mvc.PathBindable.{Parsing => PathParsing}
+
 import scala.reflect.runtime.universe._
 
 object Binders {
@@ -23,6 +26,14 @@ object Binders {
 
   implicit object bindablePromoCode extends QueryParsing[PromoCode](
     applyNonEmpty(PromoCode), _.get, (key: String, _: Exception) => s"Cannot parse parameter $key as a PromoCode"
+  )
+
+  implicit object bindableProductFamilyPath extends PathParsing[ProductFamily](
+    applyNonEmpty(id => ProductFamily.fromId(id).get), _.id, (key: String, _: Exception) => s"Cannot parse parameter $key as a Product"
+  )
+
+  implicit object bindableProductFamilyQuery extends QueryParsing[ProductFamily](
+    applyNonEmpty(id => ProductFamily.fromId(id).get), _.id, (key: String, _: Exception) => s"Cannot parse parameter $key as a Product"
   )
 
   implicit object bindableCountry extends QueryParsing[Country](

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -233,7 +233,12 @@ object Checkout extends Controller with LazyLogging with ActivityTracking with C
         const(None)
       } // Don't display the user registration form if the user is logged in
 
-      val plan = catalog.unsafeFindPaid(ProductRatePlanId(ratePlanId))
+
+      val prpId = ProductRatePlanId(ratePlanId)
+
+      val plan =
+        (tpBackend.catalogService.digipackCatalog.findPaid(prpId) orElse
+        tpBackend.catalogService.paperCatalog.flatMap(_.findCurrent(prpId))).get
 
       val promotion = session.get(AppliedPromoCode).flatMap(code => resolution.backend.promoService.findPromotion(PromoCode(code)))
 

--- a/app/model/SubscriptionData.scala
+++ b/app/model/SubscriptionData.scala
@@ -4,10 +4,10 @@ import com.gu.i18n.Country.UK
 import com.gu.i18n.{Country, CountryGroup, Title}
 import com.gu.identity.play.IdUser
 import com.gu.memsub.Subscription.ProductRatePlanId
-import com.gu.memsub.{Address, BillingPeriod, FullName}
+import com.gu.memsub.{Address, BillingPeriod, Current, FullName}
 import com.gu.memsub.promo.PromoCode
 import IdUserOps._
-import com.gu.subscriptions.DigipackPlan
+import com.gu.subscriptions.{Day, DigipackPlan, PaperPlan}
 import org.joda.time.LocalDate
 
 sealed trait PaymentType {
@@ -68,21 +68,10 @@ case class PaperData(
   startDate: LocalDate,
   deliveryAddress: Address,
   deliveryInstructions: Option[String],
-  plan: ProductRatePlanId,
+  plan: PaperPlan[Current, Day],
   includesDigipack: Boolean,
   isHomeDelivery: Boolean
 )
-
-object PaperData {
-  def fromIdUser(u: IdUser) = PaperData(
-    LocalDate.now().plusDays(5),
-    u.address,
-    deliveryInstructions = None,
-    plan = ProductRatePlanId(""),
-    includesDigipack = false,
-    isHomeDelivery = false
-  )
-}
 
 object PersonalData {
   def fromIdUser(u: IdUser) = {
@@ -101,5 +90,5 @@ object PersonalData {
 
 
 case class SubscribeRequest(genericData: SubscriptionData, productData: Either[PaperData, DigipackData]) {
-  def productRatePlanId = productData.right.map(_.plan.productRatePlanId).right.getOrElse(throw new Exception("Paper subscription detected"))
+  def productRatePlanId = productData.fold(_.plan.productRatePlanId, _.plan.productRatePlanId)
 }

--- a/app/services/PaymentService.scala
+++ b/app/services/PaymentService.scala
@@ -2,7 +2,7 @@ package services
 
 import com.gu.i18n.Country.UK
 import com.gu.i18n.{Currency, GBP}
-import com.gu.memsub.BillingPeriod
+import com.gu.memsub.{BillingPeriod, Current, PaidPlan}
 import com.gu.salesforce.ContactId
 import com.gu.stripe.StripeService
 import com.gu.subscriptions.DigipackPlan
@@ -51,7 +51,7 @@ trait PaymentService {
      paymentData: CreditCardData,
      personalData: PersonalData,
      purchaserIds: PurchaserIdentifiers,
-     plan: DigipackPlan[BillingPeriod]) = {
+     plan: PaidPlan[Current, BillingPeriod]) = {
     val desiredCurrency = personalData.currency
     val currency = if (plan.currencies.contains(desiredCurrency)) desiredCurrency else GBP
 

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -9,9 +9,16 @@
 @import com.gu.memsub.promo.PromoCode
 @import model.PersonalData
 
+@import views.support.SubscriptionsForm
+@import views.support.SubscriptionsForm._
+@import com.gu.memsub.Current
+@import com.gu.subscriptions.PaperPlan
+@import com.gu.subscriptions.Day
+@import com.gu.i18n.Currency
+@import com.gu.i18n.Country
 @(
     personalData: Option[PersonalData],
-    plans: Seq[DigipackPlan[BillingPeriod]],
+    productData: SubscriptionsForm,
     defaultPlan : DigipackPlan[Month],
     country: Option[Country],
     countryGroup: CountryGroup,
@@ -20,21 +27,21 @@
     touchpointBackendResolution: services.TouchpointBackend.Resolution,
     promoCode: Option[PromoCode])(implicit request: RequestHeader)
 
-@priceOption(plan: DigipackPlan[BillingPeriod], currency: Currency) = {
+@priceOption(plan: Either[DigipackPlan[BillingPeriod], PaperPlan[Current, Day]], currency: Currency) = {
     <label class="option" data-currency="@currency">
         <span class="option__input">
             <input
             type="radio" name="ratePlanId"
-            data-option-mirror-label-default="@plan.prettyPricing(currency)"
-            data-option-mirror-label="@plan.prettyPricing(currency)"
-            data-amount="@plan.gbpPrice.amount"
-            data-number-of-months="@plan.billingPeriod.numberOfMonths"
+            data-option-mirror-label-default="@plan.asPaidPlan.prettyPricing(currency)"
+            data-option-mirror-label="@plan.asPaidPlan.prettyPricing(currency)"
+            data-amount="@plan.asPaidPlan.gbpPrice.amount"
+            data-number-of-months="@plan.asPaidPlan.billingPeriod.numberOfMonths"
             data-currency="@currency"
             value="@plan.productRatePlanId.get"
-            @if(plan == defaultPlan && currency == defaultCurrency){checked}
+            @if(plan == productData.plans.default && currency == defaultCurrency){checked}
             >
         </span>
-        <span class="option__label" id="label-for-@plan.productRatePlanId.get-@currency">@plan.prettyPricing(currency)</span>
+        <span class="option__label" id="label-for-@plan.productRatePlanId.get-@currency">@plan.asPaidPlan.name @plan.asPaidPlan.prettyPricing(currency)</span>
     </label>
 }
 
@@ -64,8 +71,8 @@
                     </a>
                 </div>
                 <fieldset class="basket-billing-options is-hidden js-payment-frequency js-option-mirror-group" id="change-payment-frequency">
-                    @plans.map { p =>
-                        @p.currencies.map { c =>
+                    @productData.toPlanEither.list.map { p =>
+                        @p.asPaidPlan.currencies.map { c =>
                             @priceOption(p, c)
                         }
                     }
@@ -117,6 +124,9 @@
                         </div>
                         <div class="field-panel__fields">
                             @fragments.checkout.fieldsPersonal(personalData, countriesWithCurrency)
+                            @for(p <- productData.paper) {
+                                @fragments.checkout.fieldsPaper(p, countriesWithCurrency)
+                            }
 
                             <div class="actions">
                                 <a href="#paymentDetails" class="button button--primary button--large js-checkout-your-details-submit">Continue</a>

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -38,7 +38,7 @@
             data-number-of-months="@plan.asPaidPlan.billingPeriod.numberOfMonths"
             data-currency="@currency"
             value="@plan.productRatePlanId.get"
-            @if(plan == productData.plans.default && currency == defaultCurrency){checked}
+            @if(plan.fold(identity, identity) == productData.plans.default && currency == defaultCurrency){checked}
             >
         </span>
         <span class="option__label" id="label-for-@plan.productRatePlanId.get-@currency">@plan.asPaidPlan.name @plan.asPaidPlan.prettyPricing(currency)</span>
@@ -60,7 +60,7 @@
         <form class="form js-checkout-form" action="@routes.Checkout.renderCheckout(CountryGroup.UK, None).toString" method="POST" novalidate>
             @helper.CSRF.formField
 
-            @fragments.checkout.checkoutHeader("Digital Pack")
+            @fragments.checkout.checkoutHeader(productData.family.id)
 
             @* ===== Plan selection ===== *@
             <div class="checkout-container__sidebar js-basket">

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -57,10 +57,10 @@
 <main class="page-container gs-container">
 
     <section class="checkout-container">
-        <form class="form js-checkout-form" action="@routes.Checkout.renderCheckout(CountryGroup.UK, None).toString" method="POST" novalidate>
+        <form class="form js-checkout-form" action="" method="POST" novalidate>
             @helper.CSRF.formField
 
-            @fragments.checkout.checkoutHeader(productData.family.id)
+            @fragments.checkout.checkoutHeader("Digital Pack")
 
             @* ===== Plan selection ===== *@
             <div class="checkout-container__sidebar js-basket">

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -41,7 +41,7 @@
             @if(plan.fold(identity, identity) == productData.plans.default && currency == defaultCurrency){checked}
             >
         </span>
-        <span class="option__label" id="label-for-@plan.productRatePlanId.get-@currency">@plan.asPaidPlan.name @plan.asPaidPlan.prettyPricing(currency)</span>
+        <span class="option__label" id="label-for-@plan.productRatePlanId.get-@currency">@plan.asPaidPlan.prettyPricing(currency)</span>
     </label>
 }
 

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -4,10 +4,12 @@
 @import com.gu.subscriptions.DigipackPlan
 @import views.support.BillingPeriod._
 @import views.support.Pricing._
+@import com.gu.memsub.Current
+@import com.gu.memsub.PaidPlan
 @(subscriptionName: String,
     guestAccountForm: Option[Form[model.GuestAccountData]] = None,
     touchpointBackendResolution: services.TouchpointBackend.Resolution,
-    plan: DigipackPlan[BillingPeriod],
+    plan: PaidPlan[Current, BillingPeriod],
     promotion: Option[AnyPromotion] = None,
     currency: Currency
 )(implicit request: RequestHeader)

--- a/app/views/fragments/checkout/address.scala.html
+++ b/app/views/fragments/checkout/address.scala.html
@@ -12,10 +12,14 @@
     Html(s"id='${(namePrefix + "-" + field).replace('.', '-')}' name='${namePrefix}.${field}'")
 }
 
+@labelFor(field: String) = @{
+    Html(s"for='${(namePrefix + "-" + field).replace('.', '-')}'")
+}
+
 @* ===== Address ===== *@
 <div class="js-checkout-@{namePrefix.replace('.', '-')}">
     <div class="form-field">
-        <label class="label" for="country">Country</label>
+        <label class="label" @labelFor("country")>Country</label>
         <select @attrs("country") class=" select select--wide js-country" required>
             <option data-currency-choice="USD"></option>
             @for(c <- countriesWithCurrency) {
@@ -25,32 +29,32 @@
         @fragments.forms.errorMessage("This field is required")
     </div>
     <div class="form-field js-checkout-house">
-        <label class="label" for="address-line-1">Address line 1</label>
+        <label class="label" @labelFor("address1")>Address line 1</label>
         @* Salesforce accepts up to 255 chars but this field gets concatenated with address line 2 *@
         <input type="text" class="input-text js-input" @attrs("address1")
             value="@address.map(_.lineOne)" maxlength="126" required>
         @fragments.forms.errorMessage("This field is required")
     </div>
     <div class="form-field js-checkout-street">
-        <label class="label optional-marker" for="address-line-2">Address line 2</label>
+        <label class="label optional-marker" @labelFor("address2")>Address line 2</label>
         @* Salesforce accepts up to 255 chars but this field gets concatenated with address line 1 *@
         <input type="text" class="input-text js-input" @attrs("address2")
             value="@address.map(_.lineTwo)" maxlength="126">
         @fragments.forms.errorMessage("This field is required")
     </div>
     <div class="form-field js-checkout-town">
-        <label class="label" for="address-town">Town/City</label>
+        <label class="label" @labelFor("town")>Town/City</label>
         <input type="text" class="input-text js-input" @attrs("town")
             value="@address.map(_.town)" maxlength="40" required>
         @fragments.forms.errorMessage("This field is required")
     </div>
     <div class="form-field js-checkout-subdivision">
-        <label class="label" for="address-subdivision">County</label>
+        <label class="label" @labelFor("subdivision")>County</label>
         <select @attrs("subdivision")></select>
         @fragments.forms.errorMessage("Please enter a valid state/county")
     </div>
     <div class="form-field js-checkout-postcode">
-        <label class="label" for="address-postcode">Postcode</label>
+        <label class="label" @labelFor("postcode")>Postcode</label>
         <input type="text" class="input-text js-input input-text input-text--small" @attrs("postcode")
         value="@address.map(_.postCode)" maxlength="10" required>
         @fragments.forms.errorMessage("Please enter a valid postal code")

--- a/app/views/fragments/checkout/address.scala.html
+++ b/app/views/fragments/checkout/address.scala.html
@@ -1,0 +1,61 @@
+@import views.support.CountryOps._
+@import views.support.AddressValidationRulesOps._
+@import views.support.CountryWithCurrency
+@import com.gu.i18n.Title
+@import model.PersonalData
+@import com.gu.memsub.Address
+
+@(address: Option[Address], namePrefix: String, countriesWithCurrency: List[CountryWithCurrency])
+
+
+@attrs(field: String) = @{
+    Html(s"id='${namePrefix.replace('.', '-')}-${field}' name='${namePrefix}.${field}'")
+}
+
+@* ===== Address ===== *@
+<div class="js-checkout-@{namePrefix.replace('.', '-')}">
+    <div class="form-field">
+        <label class="label" for="country">Country</label>
+        <select @attrs("country") class=" select select--wide js-country" required>
+            <option data-currency-choice="USD"></option>
+            @for(c <- countriesWithCurrency) {
+                <option value="@c.alpha2" @c.country.validationRules.toAttributes @c.country.addressLabels data-currency-choice="@c.currency">@c.name</option>
+            }
+        </select>
+        @fragments.forms.errorMessage("This field is required")
+    </div>
+    <div class="form-field js-checkout-house">
+        <label class="label" for="address-line-1">Address line 1</label>
+        @* Salesforce accepts up to 255 chars but this field gets concatenated with address line 2 *@
+        <input type="text" class="input-text js-input" @attrs("address1")
+            value="@address.map(_.lineOne)" maxlength="126" required>
+        @fragments.forms.errorMessage("This field is required")
+    </div>
+    <div class="form-field js-checkout-street">
+        <label class="label optional-marker" for="address-line-2">Address line 2</label>
+        @* Salesforce accepts up to 255 chars but this field gets concatenated with address line 1 *@
+        <input type="text" class="input-text js-input" @attrs("address2")
+            value="@address.map(_.lineTwo)" maxlength="126">
+        @fragments.forms.errorMessage("This field is required")
+    </div>
+    <div class="form-field js-checkout-town">
+        <label class="label" for="address-town">Town/City</label>
+        <input type="text" class="input-text js-input" @attrs("town")
+            value="@address.map(_.town)" maxlength="40" required>
+        @fragments.forms.errorMessage("This field is required")
+    </div>
+    <div class="form-field js-checkout-subdivision">
+        <label class="label" for="address-subdivision">County</label>
+        <select @attrs("subdivision")></select>
+        @fragments.forms.errorMessage("Please enter a valid state/county")
+    </div>
+    <div class="form-field js-checkout-postcode">
+        <label class="label" for="address-postcode">Postcode</label>
+        <input type="text" class="input-text js-input input-text input-text--small" @attrs("postcode")
+        value="@address.map(_.postCode)" maxlength="10" required>
+        @fragments.forms.errorMessage("Please enter a valid postal code")
+    </div>
+</div>
+
+
+

--- a/app/views/fragments/checkout/address.scala.html
+++ b/app/views/fragments/checkout/address.scala.html
@@ -9,7 +9,7 @@
 
 
 @attrs(field: String) = @{
-    Html(s"id='${namePrefix.replace('.', '-')}-${field}' name='${namePrefix}.${field}'")
+    Html(s"id='${(namePrefix + "-" + field).replace('.', '-')}' name='${namePrefix}.${field}'")
 }
 
 @* ===== Address ===== *@

--- a/app/views/fragments/checkout/fieldsPaper.scala.html
+++ b/app/views/fragments/checkout/fieldsPaper.scala.html
@@ -1,0 +1,26 @@
+@import views.support.CountryOps._
+@import views.support.AddressValidationRulesOps._
+@import views.support.CountryWithCurrency
+@import com.gu.i18n.Title
+@import model.PersonalData
+@import views.support.PaperSubscriptionsForm
+
+@(data: PaperSubscriptionsForm, countriesWithCurrency: List[CountryWithCurrency])
+
+@address(data.deliveryAddress, "delivery", countriesWithCurrency)
+
+<div class="js-checkout-delivery-data">
+    <div class="form-field js-checkout-delivery">
+        <label class="label" for="address-town">Delivery instructions</label>
+        <textarea class="input-text js-input" id="delivery-instructions" name="deliveryInstructions"></textarea>
+    </div>
+    <div class="form-field js-checkout-delivery">
+        <label class="label" for="address-town">Date of first paper</label>
+        <input class="input-text js-input" id="delivery-instructions" name="startDate"/>
+    </div>
+    <input type="hidden" name="voucher" value="false">
+    <input type="hidden" name="digipack" value="false">
+</div>
+
+
+

--- a/app/views/fragments/checkout/fieldsPersonal.scala.html
+++ b/app/views/fragments/checkout/fieldsPersonal.scala.html
@@ -61,46 +61,4 @@
 
 
 @* ===== Address ===== *@
-<div class="js-checkout-full-address">
-    <div class="form-field">
-        <label class="label" for="country">Country</label>
-        <select name="personal.address.country" class=" select select--wide js-country" required>
-            <option data-currency-choice="USD"></option>
-            @for(c <- countriesWithCurrency) {
-                <option value="@c.alpha2" @c.country.validationRules.toAttributes @c.country.addressLabels data-currency-choice="@c.currency">@c.name</option>
-            }
-        </select>
-        @fragments.forms.errorMessage("This field is required")
-    </div>
-    <div class="form-field js-checkout-house">
-        <label class="label" for="address-line-1">Address line 1</label>
-        @* Salesforce accepts up to 255 chars but this field gets concatenated with address line 2 *@
-        <input type="text" class="input-text js-input" id="address-line-1" name="personal.address.address1"
-            value="@form.map(_.address.lineOne)" maxlength="126" required>
-        @fragments.forms.errorMessage("This field is required")
-    </div>
-    <div class="form-field js-checkout-street">
-        <label class="label optional-marker" for="address-line-2">Address line 2</label>
-        @* Salesforce accepts up to 255 chars but this field gets concatenated with address line 1 *@
-        <input type="text" class="input-text js-input" id="address-line-2" name="personal.address.address2"
-            value="@form.map(_.address.lineTwo)" maxlength="126">
-        @fragments.forms.errorMessage("This field is required")
-    </div>
-    <div class="form-field js-checkout-town">
-        <label class="label" for="address-town">Town/City</label>
-        <input type="text" class="input-text js-input" id="address-town" name="personal.address.town"
-            value="@form.map(_.address.town)" maxlength="40" required>
-        @fragments.forms.errorMessage("This field is required")
-    </div>
-    <div class="form-field js-checkout-subdivision">
-        <label class="label" for="address-subdivision">County</label>
-        <select name="address.subdivision" id="address-subdivision"></select>
-        @fragments.forms.errorMessage("Please enter a valid state/county")
-    </div>
-    <div class="form-field js-checkout-postcode">
-        <label class="label" for="address-postcode">Postcode</label>
-        <input type="text" class="input-text js-input input-text input-text--small"
-        id="address-postcode" name="personal.address.postcode"
-        value="@form.map(_.address.postCode)" maxlength="10" required>
-    @fragments.forms.errorMessage("Please enter a valid postal code")
-</div>
+@address(form.map(_.address), "personal.address", countriesWithCurrency)

--- a/app/views/fragments/checkout/reviewPanel.scala.html
+++ b/app/views/fragments/checkout/reviewPanel.scala.html
@@ -8,7 +8,9 @@
 @import views.support.Pricing._
 @import com.gu.memsub.promo.SubscriptionsLandingPage
 @import scalaz.Id._
-@(subscriptionId: String, plan: DigipackPlan[BillingPeriod], promotion: Option[AnyPromotion] = None, currency: Currency)
+@import com.gu.memsub.Current
+@import com.gu.memsub.PaidPlan
+@(subscriptionId: String, plan: PaidPlan[Current, BillingPeriod], promotion: Option[AnyPromotion] = None, currency: Currency)
 
 <div class="review-panel js-payment-frequency">
     <input type="checkbox" name="subscriptionDetails"

--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -14,7 +14,7 @@ object Pricing {
     def asPaidPlan: PaidPlan[Current, BP] = in.fold(identity, identity)
   }
 
-  implicit class PlanWithPricing(digipackPlan: PaidPlan[Current, BP]) {
+  implicit class PlanWithPricing(digipackPlan: PaidPlan[Status, BP]) {
     lazy val gbpPrice = digipackPlan.pricing.getPrice(GBP).get
 
     def unsafePrice(currency: Currency) = digipackPlan.pricing.getPrice(currency).getOrElse(

--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -3,12 +3,18 @@ package views.support
 import com.gu.i18n.{Currency, GBP}
 import com.gu.memsub.promo.PercentDiscount.getDiscountScaledToPeriod
 import com.gu.memsub.promo.{LandingPage, PercentDiscount, Promotion}
-import com.gu.memsub.{Month, Quarter, Year, BillingPeriod => BP}
-import com.gu.subscriptions.DigipackPlan
+import com.gu.memsub.{BillingPeriod => BP, _}
+import com.gu.subscriptions.{Day, DigipackPlan, PaperPlan}
 import views.support.BillingPeriod._
 
 object Pricing {
-  implicit class PlanWithPricing(digipackPlan: DigipackPlan[BP]) {
+
+  implicit class EitherPlanPlan(in: Either[DigipackPlan[BP], PaperPlan[Current, Day]]) {
+    def productRatePlanId = in.fold(_.productRatePlanId, _.productRatePlanId)
+    def asPaidPlan: PaidPlan[Current, BP] = in.fold(identity, identity)
+  }
+
+  implicit class PlanWithPricing(digipackPlan: PaidPlan[Current, BP]) {
     lazy val gbpPrice = digipackPlan.pricing.getPrice(GBP).get
 
     def unsafePrice(currency: Currency) = digipackPlan.pricing.getPrice(currency).getOrElse(

--- a/app/views/support/SubscriptionsForm.scala
+++ b/app/views/support/SubscriptionsForm.scala
@@ -1,5 +1,5 @@
 package views.support
-import com.gu.memsub.{Address, BillingPeriod, Current, PaidPlan}
+import com.gu.memsub._
 import com.gu.subscriptions.{Day, DigipackPlan, PaperPlan}
 
 case class PlanList[+A](default: A, others: A*) {
@@ -9,16 +9,21 @@ case class PlanList[+A](default: A, others: A*) {
 
 sealed trait SubscriptionsForm {
   def plans: PlanList[PaidPlan[Current, BillingPeriod]]
+  def family: ProductFamily
 }
 
 case class DigipackSubscriptionsForm(
   plans: PlanList[DigipackPlan[BillingPeriod]]
-) extends SubscriptionsForm
+) extends SubscriptionsForm {
+  val family = Digipack
+}
 
 case class PaperSubscriptionsForm(
   deliveryAddress: Option[Address],
   plans: PlanList[PaperPlan[Current, Day]]
-) extends SubscriptionsForm
+) extends SubscriptionsForm {
+  val family = Paper
+}
 
 object SubscriptionsForm {
   implicit class EitherySubscriptionsForm(in: SubscriptionsForm) {

--- a/app/views/support/SubscriptionsForm.scala
+++ b/app/views/support/SubscriptionsForm.scala
@@ -1,0 +1,32 @@
+package views.support
+import com.gu.memsub.{Address, BillingPeriod, Current, PaidPlan}
+import com.gu.subscriptions.{Day, DigipackPlan, PaperPlan}
+
+case class PlanList[+A](default: A, others: A*) {
+  def map[B](f: A => B): PlanList[B] = PlanList(f(default), others.map(f):_*)
+  def list = Seq(default) ++ others
+}
+
+sealed trait SubscriptionsForm {
+  def plans: PlanList[PaidPlan[Current, BillingPeriod]]
+}
+
+case class DigipackSubscriptionsForm(
+  plans: PlanList[DigipackPlan[BillingPeriod]]
+) extends SubscriptionsForm
+
+case class PaperSubscriptionsForm(
+  deliveryAddress: Option[Address],
+  plans: PlanList[PaperPlan[Current, Day]]
+) extends SubscriptionsForm
+
+object SubscriptionsForm {
+  implicit class EitherySubscriptionsForm(in: SubscriptionsForm) {
+    def toPlanEither: PlanList[Either[DigipackPlan[BillingPeriod], PaperPlan[Current, Day]]] = in match {
+      case DigipackSubscriptionsForm(plans) => plans.map(Left(_))
+      case PaperSubscriptionsForm(_, plans) => plans.map(Right(_))
+    }
+    def paper: Option[PaperSubscriptionsForm] = Some(in).collect { case e: PaperSubscriptionsForm => e }
+    def digipack: Option[PaperSubscriptionsForm] = Some(in).collect { case e: PaperSubscriptionsForm => e }
+  }
+}

--- a/assets/javascripts/modules/checkout/addressFields.js
+++ b/assets/javascripts/modules/checkout/addressFields.js
@@ -16,7 +16,7 @@ define([], function () {
 
     var formField = function(required, name, element) {
         var e = document.createElement(element);
-        e.id = 'address-' + name;
+        e.id = name.split('.').join('-');
         e.name = name;
 
         if (required) {

--- a/assets/javascripts/modules/checkout/addressFields.js
+++ b/assets/javascripts/modules/checkout/addressFields.js
@@ -17,7 +17,7 @@ define([], function () {
     var formField = function(required, name, element) {
         var e = document.createElement(element);
         e.id = 'address-' + name;
-        e.name = 'personal.address.' + name;
+        e.name = name;
 
         if (required) {
             e.setAttribute('required', 'required');
@@ -47,15 +47,14 @@ define([], function () {
     };
 
 
-    var postcode = function (required, text) {
+    var postcode = function (name, required, text) {
         return {
-            label: label(required, text, 'postcode'),
-            input: textInput(required, 'postcode')
+            label: label(required, text, name),
+            input: textInput(required, name)
         };
     };
 
-    var subdivision = function (required, text, values) {
-        var name = 'subdivision';
+    var subdivision = function (name, required, text, values) {
         return {
             label: label(required, text, name),
             input: values.length ? selectInput(required, name, values) : textInput(required, name)

--- a/assets/javascripts/modules/checkout/addressFields.js
+++ b/assets/javascripts/modules/checkout/addressFields.js
@@ -3,7 +3,7 @@ define([], function () {
 
     var label = function (required, text, forAttr) {
         var labelElement = document.createElement('label');
-        labelElement.setAttribute('for', 'address-' + forAttr);
+        labelElement.setAttribute('for', forAttr.split('.').join('-'));
 
         if(!required) {
             labelElement.classList.add('optional-marker');

--- a/assets/javascripts/modules/checkout/countryChoice.js
+++ b/assets/javascripts/modules/checkout/countryChoice.js
@@ -1,41 +1,41 @@
-define([
-    '$',
-    'modules/checkout/formElements'
-], function ($, formElements) {
+define(['$'], function ($) {
     'use strict';
 
-    var countrySelect = formElements.$COUNTRY_SELECT[0];
+    return function(addressObject) {
 
-    var getCurrentCountryOption = function () {
-        return countrySelect.options[countrySelect.selectedIndex];
-    };
+        var countrySelect = addressObject.$COUNTRY_SELECT[0];
 
-    var addressRules = function (option) {
-        option = option || getCurrentCountryOption();
-        var postcodeRequired = option.getAttribute('data-postcode-required');
-        var postcodeLabel = option.getAttribute('data-postcode-label');
-        var subdivisionLabel = option.getAttribute('data-subdivision-label');
-        var subdivisionRequired = option.getAttribute('data-subdivision-required');
-        var list = option.getAttribute('data-subdivision-list');
-        var subdivisionValues = list ? list.split(',') : [];
+        var getCurrentCountryOption = function () {
+            return countrySelect.options[countrySelect.selectedIndex];
+        };
+
+        var addressRules = function (option) {
+            option = option || getCurrentCountryOption();
+            var postcodeRequired = option.getAttribute('data-postcode-required');
+            var postcodeLabel = option.getAttribute('data-postcode-label');
+            var subdivisionLabel = option.getAttribute('data-subdivision-label');
+            var subdivisionRequired = option.getAttribute('data-subdivision-required');
+            var list = option.getAttribute('data-subdivision-list');
+            var subdivisionValues = list ? list.split(',') : [];
+
+            return {
+                postcode: {required: postcodeRequired === 'true', label: postcodeLabel},
+                subdivision: {required: subdivisionRequired === 'true', values: subdivisionValues, label: subdivisionLabel}
+            };
+        };
+
+        var preselectCountry = function(country) {
+            $('option', countrySelect).each(function (el) {
+                if (el.value === country) {
+                    el.selected = true;
+                }
+            });
+        };
 
         return {
-            postcode: {required: postcodeRequired === 'true', label: postcodeLabel},
-            subdivision: {required: subdivisionRequired === 'true', values: subdivisionValues, label: subdivisionLabel}
+            addressRules: addressRules,
+            getCurrentCountryOption: getCurrentCountryOption,
+            preselectCountry: preselectCountry
         };
-    };
-
-    var preselectCountry = function(country) {
-        $('option', countrySelect).each(function (el) {
-            if (el.value === country) {
-                el.selected = true;
-            }
-        });
-    };
-
-    return {
-        addressRules: addressRules,
-        getCurrentCountryOption: getCurrentCountryOption,
-        preselectCountry: preselectCountry
     };
 });

--- a/assets/javascripts/modules/checkout/fieldSwitcher.js
+++ b/assets/javascripts/modules/checkout/fieldSwitcher.js
@@ -6,109 +6,123 @@ define([
     'modules/checkout/addressFields',
     'modules/checkout/localizationSwitcher',
     'modules/checkout/formElements'
-], function ($, bean, countryChoice, addressFields, localizationSwitcher, formElements) {
+], function ($, bean, countryChoiceFunction, addressFields, localizationSwitcher, formElements) {
     'use strict';
 
-    var $postcode = formElements.$POSTCODE_CONTAINER,
-        $subdivision = formElements.$SUBDIVISION_CONTAINER;
+    var everything = function(addressObject) {
 
-    var check = function(domEl) {
-        $(domEl).attr('checked', 'checked');
-        bean.fire(domEl, 'change');
-    };
+        var $postcode = addressObject.$POSTCODE_CONTAINER,
+            $subdivision = addressObject.$SUBDIVISION_CONTAINER,
+            countryChoice = countryChoiceFunction(addressObject);
 
-    var checkPlanInput = function (ratePlanId, currency) {
-        formElements.$PLAN_INPUTS.each(function(input) {
-            if ($(input).val() === ratePlanId && $(input).attr('data-currency') === currency) {
-                check(input);
+        var check = function(domEl) {
+            $(domEl).attr('checked', 'checked');
+            bean.fire(domEl, 'change');
+        };
+
+        var checkPlanInput = function (ratePlanId, currency) {
+            formElements.$PLAN_INPUTS.each(function(input) {
+                if ($(input).val() === ratePlanId && $(input).attr('data-currency') === currency) {
+                    check(input);
+                }
+            });
+        };
+
+        var redrawAddressFields = function(model) {
+
+            var newPostcode = addressFields.postcode(
+                addressObject.$POSTCODE.attr('name'),
+                model.postcodeRules.required,
+                model.postcodeRules.label);
+
+            var newSubdivision = addressFields.subdivision(
+                $('input, select', $subdivision).attr('name'),
+                model.subdivisionRules.required,
+                model.subdivisionRules.label,
+                model.subdivisionRules.values);
+
+            newPostcode.input.value = model.postcode;
+
+            $('input', $postcode).replaceWith(newPostcode.input);
+            $('label', $postcode).replaceWith(newPostcode.label);
+
+            $('input, select', $subdivision).replaceWith(newSubdivision.input);
+            $('label', $subdivision).replaceWith(newSubdivision.label);
+        };
+
+        // Change the payment method to Direct Debit for UK users,
+        // Credit Card for international users
+        var selectPaymentMethod = function (country) {
+            if (country === 'GB') {
+                check(formElements.$DIRECT_DEBIT_TYPE[0]);
+            } else {
+                check(formElements.$CARD_TYPE[0]);
             }
-        });
-    };
+        };
 
-    var redrawAddressFields = function(model) {
-        var newPostcode = addressFields.postcode(
-            model.postcodeRules.required,
-            model.postcodeRules.label);
+        var switchLocalization = function (model) {
+            var currency = model.currency || guardian.currency;
+            localizationSwitcher.set(currency, model.country);
+        };
 
-        var newSubdivision = addressFields.subdivision(
-            model.subdivisionRules.required,
-            model.subdivisionRules.label,
-            model.subdivisionRules.values);
+        var redraw = function(model) {
+            redrawAddressFields(model);
+            switchLocalization(model);
+            checkPlanInput(model.ratePlanId, model.currency);
+            selectPaymentMethod(model.country);
+        };
 
-        newPostcode.input.value = model.postcode;
+        var getCurrentState = function() {
+            var currentCountryOption = $(countryChoice.getCurrentCountryOption()),
+                rules = countryChoice.addressRules();
 
-        $('input', $postcode).replaceWith(newPostcode.input);
-        $('label', $postcode).replaceWith(newPostcode.label);
+            return {
+                postcode: $('input', $postcode).val(),
+                postcodeRules: rules.postcode,
+                subdivisionRules: rules.subdivision,
+                currency: currentCountryOption.attr('data-currency-choice'),
+                country: currentCountryOption.val(),
+                ratePlanId: formElements.getRatePlanId()
+            };
+        };
 
-        $('#address-subdivision', $subdivision).replaceWith(newSubdivision.input);
-        $('label', $subdivision).replaceWith(newSubdivision.label);
-    };
+        var updateGuardianPageInfo = function(model) {
+            var pageInfo = guardian.pageInfo;
+            if (pageInfo) {
+                pageInfo.billingCountry = model.country;
+                pageInfo.billingCurrency = model.currency;
+            }
+        };
 
-    // Change the payment method to Direct Debit for UK users,
-    // Credit Card for international users
-    var selectPaymentMethod = function (country) {
-        if (country === 'GB') {
-            check(formElements.$DIRECT_DEBIT_TYPE[0]);
-        } else {
-            check(formElements.$CARD_TYPE[0]);
-        }
-    };
+        var refresh = function () {
+            var model = getCurrentState();
+            redraw(model);
+            updateGuardianPageInfo(model);
+        };
 
-    var switchLocalization = function (model) {
-        var currency = model.currency || guardian.currency;
-        localizationSwitcher.set(currency, model.country);
-    };
+        var refreshOnChange = function(el) {
+            bean.on(el[0], 'change', function() {
+                refresh();
+            });
+        };
 
-    var redraw = function(model) {
-        redrawAddressFields(model);
-        switchLocalization(model);
-        checkPlanInput(model.ratePlanId, model.currency);
-        selectPaymentMethod(model.country);
-    };
-
-    var getCurrentState = function() {
-        var currentCountryOption = $(countryChoice.getCurrentCountryOption()),
-            rules = countryChoice.addressRules();
+        var init = function() {
+            if (addressObject.$COUNTRY_SELECT.length) {
+                countryChoice.preselectCountry(guardian.country);
+                refreshOnChange(addressObject.$COUNTRY_SELECT);
+                refresh();
+            }
+        };
 
         return {
-            postcode: $('input', $postcode).val(),
-            postcodeRules: rules.postcode,
-            subdivisionRules: rules.subdivision,
-            currency: currentCountryOption.attr('data-currency-choice'),
-            country: currentCountryOption.val(),
-            ratePlanId: formElements.getRatePlanId()
+            init: init
         };
     };
 
-    var updateGuardianPageInfo = function(model) {
-        var pageInfo = guardian.pageInfo;
-        if (pageInfo) {
-            pageInfo.billingCountry = model.country;
-            pageInfo.billingCurrency = model.currency;
-        }
-    };
-
-    var refresh = function () {
-        var model = getCurrentState();
-        redraw(model);
-        updateGuardianPageInfo(model);
-    };
-
-    var refreshOnChange = function(el) {
-        bean.on(el[0], 'change', function() {
-            refresh();
-        });
-    };
-
-    var init = function() {
-        if (formElements.$CHECKOUT_FORM.length) {
-            countryChoice.preselectCountry(guardian.country);
-            refreshOnChange(formElements.$COUNTRY_SELECT);
-            refresh();
-        }
-    };
-
     return {
-        init: init
+        init: function() {
+            everything(formElements.BILLING).init();
+            everything(formElements.DELIVERY).init();
+        }
     };
 });

--- a/assets/javascripts/modules/checkout/formElements.js
+++ b/assets/javascripts/modules/checkout/formElements.js
@@ -14,20 +14,45 @@ define(['$'], function ($) {
         return ratePlanId;
     };
 
+    var addressFields = function(relativeTo) {
+
+        var container = $(relativeTo)[0];
+        var $ADDRESS1_CONTAINER = $('.js-checkout-house', container);
+        var $ADDRESS2_CONTAINER = $('.js-checkout-street', container);
+        var $ADDRESS3_CONTAINER = $('.js-checkout-town', container);
+        var $SUBDIVISION_CONTAINER = $('.js-checkout-subdivision', container);
+        var $POSTCODE_CONTAINER = $('.js-checkout-postcode', container);
+        var $MANUAL_ADDRESS_CONTAINER = $('.js-checkout-manual-address', container); //wat
+
+        return {
+            $ADDRESS1_CONTAINER: $ADDRESS1_CONTAINER,
+            $ADDRESS2_CONTAINER: $ADDRESS2_CONTAINER,
+            $ADDRESS3_CONTAINER: $ADDRESS3_CONTAINER,
+            $SUBDIVISION_CONTAINER: $SUBDIVISION_CONTAINER,
+            $POSTCODE_CONTAINER: $POSTCODE_CONTAINER,
+            $MANUAL_ADDRESS_CONTAINER: $MANUAL_ADDRESS_CONTAINER, //wat
+
+            $ADDRESS1: $('.js-input', $ADDRESS1_CONTAINER[0]),
+            $ADDRESS2: $('.js-input', $ADDRESS2_CONTAINER[0]),
+            $ADDRESS3: $('.js-input', $ADDRESS3_CONTAINER[0]),
+            $POSTCODE: $('.js-input', $POSTCODE_CONTAINER[0]),
+            $SUBDIVISION: $('select', $SUBDIVISION_CONTAINER[0]),
+            $COUNTRY_SELECT: $('.js-country', container)
+        };
+    };
+
     return {
         $CHECKOUT_FORM: $('.js-checkout-form'),
-
         $NOTICES: $('.js-checkout-notices'),
+
+        BILLING: addressFields('.js-checkout-personal-address'),
+        DELIVERY: addressFields('.js-checkout-delivery'),
 
         $FIRST_NAME: $('.js-checkout-first .js-input'),
         $LAST_NAME: $('.js-checkout-last .js-input'),
         $EMAIL: $('.js-checkout-email .js-input'),
         $CONFIRM_EMAIL: $('.js-checkout-confirm-email .js-input'),
         $EMAIL_ERROR: $('.js-checkout-email .js-error-message'),
-        $ADDRESS1: $('.js-checkout-house .js-input'),
-        $ADDRESS2: $('.js-checkout-street .js-input'),
-        $ADDRESS3: $('.js-checkout-town .js-input'),
-        $POSTCODE: $('.js-checkout-postcode .js-input'),
 
         // Promo Code:
         $PROMO_CODE : $('.js-promo-code .js-input'),
@@ -61,13 +86,6 @@ define(['$'], function ($) {
         $LAST_NAME_CONTAINER: $('.js-checkout-last'),
         $EMAIL_CONTAINER: $('.js-checkout-email'),
         $CONFIRM_EMAIL_CONTAINER: $('.js-checkout-confirm-email'),
-        $ADDRESS1_CONTAINER: $('.js-checkout-house'),
-        $ADDRESS2_CONTAINER: $('.js-checkout-street'),
-        $ADDRESS3_CONTAINER: $('.js-checkout-town'),
-        $SUBDIVISION_CONTAINER: $('.js-checkout-subdivision'),
-        $POSTCODE_CONTAINER: $('.js-checkout-postcode'),
-        $MANUAL_ADDRESS_CONTAINER: $('.js-checkout-manual-address'),
-        $FULL_ADDRESS_CONTAINER: $('.js-checkout-full-address'),
 
         $YOUR_DETAILS_SUBMIT: $('.js-checkout-your-details-submit'),
         $PAYMENT_DETAILS_SUBMIT: $('.js-checkout-payment-details-submit'),
@@ -89,8 +107,6 @@ define(['$'], function ($) {
         $EDIT_PAYMENT_DETAILS: $('.js-edit-payment-details'),
 
         $BASKET: $('.js-basket'),
-
-        $COUNTRY_SELECT: $('.js-country'),
         $PLAN_INPUTS :_PLAN_INPUTS,
 
         getRatePlanId: getRatePlanId

--- a/assets/javascripts/modules/checkout/promoCode.js
+++ b/assets/javascripts/modules/checkout/promoCode.js
@@ -81,7 +81,7 @@ define([
     }
 
     function validate() {
-        var country = guardian.country.value.trim(),
+        var country = formElements.BILLING.$COUNTRY_SELECT.val().trim(),
             promoCode = $inputBox.val().trim();
 
         if (country === '' || promoCode === '') {

--- a/assets/javascripts/modules/checkout/promoCode.js
+++ b/assets/javascripts/modules/checkout/promoCode.js
@@ -3,9 +3,8 @@ define([
     'bean',
     'modules/forms/toggleError',
     'utils/ajax',
-    'modules/checkout/formElements',
-    'modules/checkout/countryChoice'
-], function ($, bean, toggleError, ajax, formElements, countryChoice) {
+    'modules/checkout/formElements'
+], function ($, bean, toggleError, ajax, formElements) {
     'use strict';
 
     var $inputBox           = formElements.$PROMO_CODE,
@@ -82,8 +81,8 @@ define([
     }
 
     function validate() {
-        var country = countryChoice.getCurrentCountryOption().value.trim(),
-            promoCode  = $inputBox.val().trim();
+        var country = guardian.country.value.trim(),
+            promoCode = $inputBox.val().trim();
 
         if (country === '' || promoCode === '') {
             clearDown();
@@ -121,7 +120,7 @@ define([
 
     return {
         init: function () {
-            var $countrySelectBox = formElements.$COUNTRY_SELECT,
+            var $countrySelectBox = formElements.BILLING.$COUNTRY_SELECT,
                 $promoCodeButton = formElements.$PROMO_CODE_BTN;
 
             if ($countrySelectBox.length && $promoCodeButton.length) {

--- a/assets/javascripts/modules/checkout/reviewDetails.js
+++ b/assets/javascripts/modules/checkout/reviewDetails.js
@@ -38,10 +38,10 @@ define([
             ], ' '));
 
             formEls.$REVIEW_ADDRESS.text(textUtils.mergeValues([
-                formEls.$ADDRESS1.val(),
-                formEls.$ADDRESS2.val(),
-                formEls.$ADDRESS3.val(),
-                formEls.$POSTCODE.val()
+                formEls.BILLING.$ADDRESS1.val(),
+                formEls.BILLING.$ADDRESS2.val(),
+                formEls.BILLING.$ADDRESS3.val(),
+                formEls.BILLING.$POSTCODE.val()
             ], ', '));
 
             formEls.$REVIEW_EMAIL.text(formEls.$EMAIL.val());

--- a/assets/javascripts/modules/checkout/reviewDetails.js
+++ b/assets/javascripts/modules/checkout/reviewDetails.js
@@ -78,7 +78,7 @@ define([
                 }
 
                 ajax({
-                    url: form.action,
+                    url: window.location.href,
                     method: 'post',
                     data: data,
                     success: function(successData) {

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.223-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.223",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.0.0",

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.222",
+    "com.gu" %% "membership-common" % "0.223-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.0.0",

--- a/conf/routes
+++ b/conf/routes
@@ -23,8 +23,10 @@ GET         /au/digital                      controllers.DigitalPack.au
 GET         /int/digital                     controllers.DigitalPack.int
 
 # Checkout
-GET         /checkout                        controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], product: com.gu.memsub.ProductFamily ?= com.gu.memsub.Digipack)
-POST        /checkout                        controllers.Checkout.handleCheckout
+GET         /checkout/paper                  controllers.Checkout.renderPaperCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode])
+GET         /checkout                        controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], product: com.gu.memsub.ProductFamily = com.gu.memsub.Digipack)
+POST        /checkout/paper                  controllers.Checkout.handlePaperCheckout
+POST        /checkout                        controllers.Checkout.handleCheckout(allowPaper: Boolean = false)
 GET         /checkout/check-identity         controllers.Checkout.checkIdentity(email: String)
 POST        /checkout/check-account          controllers.Checkout.checkAccount
 POST        /checkout/register-guest-user    controllers.Checkout.convertGuestUser

--- a/conf/routes
+++ b/conf/routes
@@ -23,7 +23,7 @@ GET         /au/digital                      controllers.DigitalPack.au
 GET         /int/digital                     controllers.DigitalPack.int
 
 # Checkout
-GET         /checkout                        controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode])
+GET         /checkout                        controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], product: com.gu.memsub.ProductFamily ?= com.gu.memsub.Digipack)
 POST        /checkout                        controllers.Checkout.handleCheckout
 GET         /checkout/check-identity         controllers.Checkout.checkIdentity(email: String)
 POST        /checkout/check-account          controllers.Checkout.checkAccount

--- a/test/acceptance/pages/Checkout.scala
+++ b/test/acceptance/pages/Checkout.scala
@@ -54,10 +54,10 @@ case class Checkout(val testUser: TestUser) extends Page with Browser {
     val lastName = id("last")
     val email = id("email")
     val emailConfirm = id("confirm")
-    val address1 = id("address-line-1")
-    val address2 = id("address-line-2")
-    val town = id("address-town")
-    val postcode = id("address-postcode")
+    val address1 = id("personal-address-address1")
+    val address2 = id("personal-address-address2")
+    val town = id("personal-address-town")
+    val postcode = id("personal-address-postcode")
     val continueButton = cssSelector(".js-checkout-your-details-submit")
 
     def fillIn(): Unit = {

--- a/test/js/spec/modules/checkout/AddressFields.spec.js
+++ b/test/js/spec/modules/checkout/AddressFields.spec.js
@@ -11,45 +11,45 @@ define(['modules/checkout/addressFields'], function (addressFields) {
     describe('Address fields generator', function() {
 
         it('should generate a compulsory postcode field with the right label', function () {
-            var output = addressFields.postcode(true, 'Postcode');
+            var output = addressFields.postcode('personal.address.postcode', true, 'Postcode');
 
             expect(output.input.isEqualNode(dom(
-                '<input type="text" id="address-postcode" name="personal.address.postcode" class="input-text" required="required">'
+                '<input type="text" id="personal-address-postcode" name="personal.address.postcode" class="input-text" required="required">'
             ))).toBeTruthy();
 
             expect(output.label.isEqualNode(dom(
-                '<label for="address-postcode" class="label">Postcode</label>'
+                '<label for="personal-address-postcode" class="label">Postcode</label>'
             ))).toBeTruthy();
         });
 
         it('should generate an optional postcode field with the right label', function () {
-            var output = addressFields.postcode(false, 'Zipcode');
+            var output = addressFields.postcode('personal.address.postcode', false, 'Zipcode');
             expect(output.input.isEqualNode(dom(
-                '<input type="text" id="address-postcode" class="input-text" name="personal.address.postcode">'
+                '<input type="text" id="personal-address-postcode" class="input-text" name="personal.address.postcode">'
             ))).toBeTruthy();
 
             expect(output.label.isEqualNode(dom(
-                '<label for="address-postcode" class="optional-marker label">Zipcode</label>'
+                '<label for="personal-address-postcode" class="optional-marker label">Zipcode</label>'
             ))).toBeTruthy();
         });
 
         it('should generate a freeform region box when no list is supplied', function () {
-            var output = addressFields.subdivision(true, 'Province', []);
+            var output = addressFields.subdivision('personal.address.subdivision', true, 'Province', []);
 
             expect(output.input.isEqualNode(dom(
-                '<input type="text" id="address-subdivision" name="personal.address.subdivision" class="input-text" required="required">'
+                '<input type="text" id="personal-address-subdivision" name="personal.address.subdivision" class="input-text" required="required">'
             ))).toBeTruthy();
 
             expect(output.label.isEqualNode(dom(
-                '<label for="address-subdivision" class="label">Province</label>'
+                '<label for="personal-address-subdivision" class="label">Province</label>'
             ))).toBeTruthy();
         });
 
         it('should generate a select box when a list is supplied', function () {
-            var output = addressFields.subdivision(true, 'Province', ['Bromley']);
+            var output = addressFields.subdivision('personal.address.subdivision', true, 'Province', ['Bromley']);
 
             expect(output.input.isEqualNode(dom(
-                '<select id="address-subdivision" name="personal.address.subdivision" class="select--wide" required="required">' +
+                '<select id="personal-address-subdivision" name="personal.address.subdivision" class="select--wide" required="required">' +
                     '<option></option>' +
                     '<option value="Bromley">Bromley</option>' +
                 '</select>'

--- a/test/js/spec/modules/checkout/CountryChoice.spec.js
+++ b/test/js/spec/modules/checkout/CountryChoice.spec.js
@@ -1,6 +1,9 @@
-define(['modules/checkout/countryChoice'], function (addressRules) {
+define(['modules/checkout/countryChoice', '$'], function (countryChoice, $) {
 
     'use strict';
+    var addressRules = countryChoice({
+        $COUNTRY_SELECT: $(document.createElement('div'))
+    });
 
     describe('CountryChoice option-parser', function() {
 


### PR DESCRIPTION
- Introduce new SubscriptionsForm model to populate the form with
- Support for both delivery and billing address (which is not used at the moment)
- Paper form locked behind Google Auth for now
- Extra form fields for start date and delivery instructions
- Split out address into reusable view fragment
- Tested end-to-end from form to Zuora

Sorry this PR is quite massive but @paulbrown1982 would you mind taking a look