### PR TITLE
Make the global-nav not lowercase.

### DIFF
--- a/assets/stylesheets/modules/_global-navigation.scss
+++ b/assets/stylesheets/modules/_global-navigation.scss
@@ -18,7 +18,6 @@
     border: none; // [1]
     padding: 8px 0 6px; // [2]
     margin-right: $gs-gutter;
-    text-transform: lowercase;
 
     &:hover,
     &:focus,


### PR DESCRIPTION
old: 
![image](https://cloud.githubusercontent.com/assets/2670496/16542071/fbda8860-4090-11e6-87b9-a2e36583b1b2.png)

NEW:
![image](https://cloud.githubusercontent.com/assets/2670496/16542069/f4427112-4090-11e6-91f7-5e036fe4f8dd.png)

I'm not sure why this was lowercase. What do you all think?