### PR TITLE
Product specific thankyou page

### DIFF
--- a/app/configuration/Details.scala
+++ b/app/configuration/Details.scala
@@ -1,6 +1,0 @@
-package configuration
-
-object Details {
-  val digitalPackPhone = "+44 (0) 330 333 6767"
-  val digitalPackEmail = "digitalpack@theguardian.com"
-}

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -2,7 +2,7 @@ package controllers
 
 import actions.CommonActions._
 import com.gu.i18n.{Country, CountryGroup, Currency, GBP}
-import com.gu.identity.play.ProxiedIP
+import com.gu.identity.play.{IdUser, ProxiedIP}
 import com.gu.memsub.{BillingPeriod, Digipack, Paper, ProductFamily}
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.promo.Formatters.PromotionFormatters._
@@ -77,6 +77,15 @@ object Checkout extends Controller with LazyLogging with ActivityTracking with C
     renderCheckout(countryGroup, promoCode, product = Digipack).apply(req)
   }
 
+  def getProductData(tpBackend: TouchpointBackend, product: ProductFamily, user: Option[IdUser]): views.support.ProductPopulationData = product match {
+    case Paper =>
+      val catalog = tpBackend.catalogService.paperCatalog.get
+      PaperProductPopulationData(user.map(_.address), PlanList(catalog.everyday, catalog.sixday, catalog.weekend))
+    case _ =>
+      val catalog = tpBackend.catalogService.digipackCatalog
+      DigipackProductPopulationData(PlanList(catalog.digipackMonthly, catalog.digipackQuarterly, catalog.digipackYearly))
+  }
+
   def renderCheckout(countryGroup: CountryGroup, promoCode: Option[PromoCode], product: ProductFamily) = NoSubAction.async { implicit request =>
     implicit val resolution: TouchpointBackend.Resolution = TouchpointBackend.forRequest(PreSigninTestCookie, request.cookies)
     implicit val tpBackend = resolution.backend
@@ -90,31 +99,21 @@ object Checkout extends Controller with LazyLogging with ActivityTracking with C
     } yield idUser).run
 
     val plans = catalog.planMap.values.toSeq
-    val defaultPlan = catalog.digipackMonthly
 
     idUser map { user =>
 
-      val productData: views.support.ProductPopulationData = product match {
-        case Paper =>
-          val catalog = tpBackend.catalogService.paperCatalog.get
-          PaperProductPopulationData(user.map(_.address), PlanList(catalog.everyday, catalog.sixday, catalog.weekend))
-        case _ =>
-          val catalog = tpBackend.catalogService.digipackCatalog
-          DigipackProductPopulationData(PlanList(catalog.digipackMonthly, catalog.digipackQuarterly, catalog.digipackYearly))
-      }
-
+      val productData = getProductData(tpBackend, product, user)
       val personalData = user.map(PersonalData.fromIdUser)
       val countryOpt = personalData.flatMap(data => data.address.country)
       val countryGroupWithDefault = countryOpt.fold(countryGroup)(c => CountryGroup.byCountryCode(c.alpha2).getOrElse(countryGroup))
       val country = countryOpt orElse countryGroupWithDefault.defaultCountry
       val desiredCurrency = countryGroupWithDefault.currency
-      val supportedCurrencies = defaultPlan.currencies
+      val supportedCurrencies = productData.plans.default.currencies
       val defaultCurrency = if (supportedCurrencies.contains(desiredCurrency)) desiredCurrency else GBP
 
       Ok(views.html.checkout.payment(
         personalData = personalData,
         productData = productData,
-        defaultPlan = defaultPlan,
         country = country,
         countryGroup = countryGroupWithDefault,
         defaultCurrency = defaultCurrency,
@@ -224,8 +223,8 @@ object Checkout extends Controller with LazyLogging with ActivityTracking with C
       }
 
       val thankYouUrl = subscribeRequest.productData match {
-        case Left(x) => routes.Checkout.thankYou(Paper).url
-        case Right(y) => routes.Checkout.thankYou(Digipack).url
+        case Left(x) => routes.Checkout.thankYouPaper().url
+        case Right(y) => routes.Checkout.thankYouDigipack().url
       }
 
       Ok(Json.obj("redirect" -> thankYouUrl)).withSession(session)
@@ -241,6 +240,10 @@ object Checkout extends Controller with LazyLogging with ActivityTracking with C
       Ok(Json.obj("profileUrl" -> webAppProfileUrl.toString())).withCookies(cookies: _*)
     }
   }
+
+  def thankYouDigipack = NoCacheAction.async { request => thankYou(Digipack).apply(request) }
+
+  def thankYouPaper = AuthorisedTester.async { request => thankYou(Paper).apply(request) }
 
   def thankYou(product: ProductFamily) = NoCacheAction { implicit request =>
 
@@ -258,6 +261,8 @@ object Checkout extends Controller with LazyLogging with ActivityTracking with C
     sessionInfo.fold {
       Redirect(getCheckoutRouteForProductFamily(CountryGroup.UK, None, product)).withNewSession
     } { case (subsName, ratePlanId, currency) =>
+
+
       val passwordForm = authenticatedUserFor(request).fold {
         for {
           userId <- session.get(SessionKeys.UserId)
@@ -268,17 +273,19 @@ object Checkout extends Controller with LazyLogging with ActivityTracking with C
         const(None)
       } // Don't display the user registration form if the user is logged in
 
-
-      val prpId = ProductRatePlanId(ratePlanId)
-
-      val plan =
-        (tpBackend.catalogService.digipackCatalog.findPaid(prpId) orElse
-        tpBackend.catalogService.paperCatalog.flatMap(_.findCurrent(prpId))).get
+      def plan = {
+        val prpId = ProductRatePlanId(ratePlanId)
+        product match {
+          case Digipack => tpBackend.catalogService.digipackCatalog.findPaid(prpId).get
+          case Paper => tpBackend.catalogService.paperCatalog.flatMap(_.findCurrent(prpId)).get
+        }
+      }
 
       val promotion = session.get(AppliedPromoCode).flatMap(code => resolution.backend.promoService.findPromotion(PromoCode(code)))
 
-      Ok(view.thankyou(subsName, passwordForm, resolution, plan, promotion, currency))
+      Ok(view.thankyou(subsName, passwordForm, resolution, plan, promotion, currency, product))
     }
+
   }
 
   def validatePromoCode(promoCode: PromoCode, prpId: ProductRatePlanId, country: Country) = NoCacheAction { implicit request =>

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -8,10 +8,10 @@
 @import views.support.Pricing._
 @import com.gu.memsub.promo.PromoCode
 @import model.PersonalData
+@import views.support.ProductFamilyOps._
 
 @import views.support.ProductPopulationData
 @import views.support.ProductPopulationData._
-@import views.support.ProductFamilyOps._
 @import com.gu.memsub.Current
 @import com.gu.subscriptions.PaperPlan
 @import com.gu.subscriptions.Day
@@ -20,7 +20,6 @@
 @(
     personalData: Option[PersonalData],
     productData: ProductPopulationData,
-    defaultPlan : DigipackPlan[Month],
     country: Option[Country],
     countryGroup: CountryGroup,
     defaultCurrency: Currency,
@@ -54,7 +53,7 @@
 }
 
 @main(
-    title = "Details - name and address | Subscriptions | The Guardian",
+    title = s"Details - name and address | Subscribe to ${productData.family.title(productData.plans.default)} | The Guardian",
     jsVars = JsVars(userIsSignedIn = personalData.isDefined, ignorePageLoadTracking = true, countryGroup = countryGroup, currency = defaultCurrency, country = country),
     bodyClasses = List("is-wide"),
     touchpointBackendResolutionOpt = Some(touchpointBackendResolution)
@@ -68,11 +67,11 @@
         <form class="form js-checkout-form" action="" method="POST" novalidate>
             @helper.CSRF.formField
 
-            @fragments.checkout.checkoutHeader(productData.family.title)
+            @fragments.checkout.checkoutHeader(productData.family.title(productData.plans.default))
 
             @* ===== Plan selection ===== *@
             <div class="checkout-container__sidebar js-basket">
-                @fragments.checkout.basketPreview(productData.family)
+                @fragments.checkout.basketPreview(productData.family, productData.plans.default)
                 <div class="basket-options-toggle u-note prose">
                     <a class="js-toggle checkout-container__frequency" data-toggle="change-payment-frequency">
                         @productData.family.changeRatePlanText
@@ -97,7 +96,7 @@
                         }
                         </div>
                         <div class="js-payment-type-direct-debit u-note">
-                            @fragments.checkout.noticesDirectDebit()
+                            @fragments.checkout.noticesDirectDebit(productData.family)
                         </div>
                         <div class="js-payment-type-card" hidden="true">
                             @fragments.checkout.noticesCard()

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -120,10 +120,10 @@
                             </div>
                             <div class="field-note field-note--offset prose">
                                 @if(personalData.isDefined) {
-                                    <a href="@idWebAppSignOutUrl(routes.Checkout.renderCheckout(countryGroup, promoCode))">Sign out</a>
+                                    <a href="@idWebAppSignOutUrl(controllers.Checkout.getCheckoutRouteForProductFamily(countryGroup, promoCode, productData.family))">Sign out</a>
                                 } else {
                                     <span class="field-note__label">Already have a Guardian account?</span>
-                                    <a href="@idWebAppSigninUrl(routes.Checkout.renderCheckout(countryGroup, promoCode))">Sign in</a>
+                                    <a href="@idWebAppSigninUrl(controllers.Checkout.getCheckoutRouteForProductFamily(countryGroup, promoCode, productData.family))">Sign in</a>
                                 }
                             </div>
                         </div>

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -53,7 +53,7 @@
 }
 
 @main(
-    title = s"Details - name and address | Subscribe to ${productData.family.title(productData.plans.default)} | The Guardian",
+    title = s"Details - name and address | Subscribe to the ${productData.family.title(productData.plans.default)} | The Guardian",
     jsVars = JsVars(userIsSignedIn = personalData.isDefined, ignorePageLoadTracking = true, countryGroup = countryGroup, currency = defaultCurrency, country = country),
     bodyClasses = List("is-wide"),
     touchpointBackendResolutionOpt = Some(touchpointBackendResolution)

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -1,25 +1,27 @@
 @import com.gu.i18n.Currency
 @import com.gu.memsub.BillingPeriod
 @import com.gu.memsub.promo.Promotion.AnyPromotion
-@import com.gu.subscriptions.DigipackPlan
 @import views.support.BillingPeriod._
 @import views.support.Pricing._
 @import com.gu.memsub.Current
 @import com.gu.memsub.PaidPlan
+@import com.gu.memsub.ProductFamily
+@import views.support.ProductFamilyOps._
+
 @(subscriptionName: String,
     guestAccountForm: Option[Form[model.GuestAccountData]] = None,
     touchpointBackendResolution: services.TouchpointBackend.Resolution,
     plan: PaidPlan[Current, BillingPeriod],
     promotion: Option[AnyPromotion] = None,
-    currency: Currency
+    currency: Currency,
+    productFamily: ProductFamily
 )(implicit request: RequestHeader)
 
 @import configuration.Config.Identity.webAppProfileUrl
-@import configuration.Details
 @import services.IdentityToken.{paramName => identityTokenParam}
 @import services.UserId.{paramName => userIdParam}
 
-@main("Confirmation | Digital | Subscriptions | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
+@main(s"Confirmation | Subscribe to ${productFamily.title(plan)} | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
     @fragments.analytics.tagmanager()
 
@@ -44,9 +46,9 @@
                     We have received your request and are now processing your subscription,
                     you'll receive email confirmation of this shortly.
                 </p>
-                <p>Here are the details of your order, if any of these are incorrect please get in touch with us straight away via email at <a href="mailto:@Details.digitalPackEmail">@Details.digitalPackEmail</a> or on <strong>@Details.digitalPackPhone</strong>. Lines are open BST Monday&ndash;Friday 8.00am&ndash;8.00pm. Saturday &amp; Sunday 8.00am&ndash;6.00pm.</p>
+                <p>Here are the details of your order, if any of these are incorrect please get in touch with us straight away via email at <a href="mailto:@productFamily.email">@productFamily.email</a> or on <strong>@productFamily.phone</strong>. Lines are open BST Monday&ndash;Friday 8.00am&ndash;8.00pm. Saturday &amp; Sunday 8.00am&ndash;6.00pm.</p>
             </div>
-            @fragments.checkout.reviewPanel(subscriptionName, plan, promotion, currency)
+            @fragments.checkout.reviewPanel(subscriptionName, plan, promotion, currency, productFamily)
         </div>
     </section>
 

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -21,7 +21,7 @@
 @import services.IdentityToken.{paramName => identityTokenParam}
 @import services.UserId.{paramName => userIdParam}
 
-@main(s"Confirmation | Subscribe to ${productFamily.title(plan)} | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
+@main(s"Confirmation | Subscribe to the ${productFamily.title(plan)} | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
     @fragments.analytics.tagmanager()
 

--- a/app/views/digitalpack/info.scala.html
+++ b/app/views/digitalpack/info.scala.html
@@ -21,7 +21,7 @@
 }
 
 @main(
-    title = if(edition.id == "uk") "Digital | Subscriptions | The Guardian" else s"Digital - ${edition.name} | Subscriptions | The Guardian",
+    title = s"Subscribe to the Guardian Digital Pack | The Guardian (${edition.name})",
     bodyClasses = List("is-wide")
 ) {
 

--- a/app/views/fragments/checkout/basketPreview.scala.html
+++ b/app/views/fragments/checkout/basketPreview.scala.html
@@ -1,20 +1,23 @@
+@import com.gu.memsub.PaidPlan
+@import com.gu.memsub.Current
+@import com.gu.memsub.BillingPeriod
+@import com.gu.memsub.Paper
 @import com.gu.memsub.ProductFamily
 @import views.support.ProductFamilyOps._
-@(productFamily: ProductFamily)
+@(productFamily: ProductFamily, plan: PaidPlan[Current, BillingPeriod])
 
 <div class="basket-preview  basket-preview--products">
     <h3 class="basket-preview__title">You've chosen:</h3>
     <div class="basket-preview__image">
-        <img src="@controllers.CachedAssets.hashedPathFor(productFamily.packImage)" alt="">
+        <img src="@controllers.CachedAssets.hashedPathFor(productFamily.packImage)" alt="@productFamily.title(plan)">
     </div>
-
     <div class="basket-preview__product">
         <span class="basket-preview__product__title">
-            @productFamily.title
+            @productFamily.title(plan)
         </span>
-        <span class="basket-preview__product__caption">
-            @productFamily.subtitle
-        </span>
+            <span class="basket-preview__product__caption">
+                (@productFamily.subtitle(plan))
+            </span>
         <span class="basket-preview__product__payment js-option-mirror-value"></span>
     </div>
 </div>

--- a/app/views/fragments/checkout/noticesDirectDebit.scala.html
+++ b/app/views/fragments/checkout/noticesDirectDebit.scala.html
@@ -1,7 +1,8 @@
-@()
-
-@import configuration.Details
 @import controllers.CachedAssets.hashedPathFor
+@import com.gu.memsub.ProductFamily
+@import views.support.ProductFamilyOps._
+
+@(productFamily: ProductFamily)
 
 @fragments.checkout.notice("Advanced Notice") {
     <p>
@@ -19,8 +20,8 @@
     </address>
 
     <ul class="o-unstyled-list">
-        <li>Tel: @Details.digitalPackPhone</li>
-        <li><a href="mailto:@Details.digitalPackEmail">@Details.digitalPackEmail</a></li>
+        <li>Tel: @productFamily.phone</li>
+        <li><a href="mailto:@productFamily.email">@productFamily.email</a></li>
     </ul>
 
     <aside class="direct-debit">

--- a/app/views/fragments/checkout/reviewPanel.scala.html
+++ b/app/views/fragments/checkout/reviewPanel.scala.html
@@ -10,7 +10,10 @@
 @import scalaz.Id._
 @import com.gu.memsub.Current
 @import com.gu.memsub.PaidPlan
-@(subscriptionId: String, plan: PaidPlan[Current, BillingPeriod], promotion: Option[AnyPromotion] = None, currency: Currency)
+@import com.gu.memsub.ProductFamily
+@import views.support.ProductFamilyOps._
+
+@(subscriptionId: String, plan: PaidPlan[Current, BillingPeriod], promotion: Option[AnyPromotion] = None, currency: Currency, productFamily: ProductFamily)
 
 <div class="review-panel js-payment-frequency">
     <input type="checkbox" name="subscriptionDetails"
@@ -27,7 +30,8 @@
     <div class="review-panel__item">
         <h4 class="review-panel__label">Your subscription:</h4>
         <div class="review-panel__details">
-            The Guardian Digital Pack <em>(Daily Edition + Guardian App Premium Tier)</em>
+            <div>@productFamily.title(plan)</div>
+            <em>(@productFamily.subtitle(plan))</em>
         </div>
     </div>
     <div class="review-panel__item">
@@ -36,7 +40,7 @@
             @promotion.flatMap(_.asDiscount).fold {
                 @plan.prettyPricing(currency)
             } { discountPromo =>
-                @plan.prettyPricingForDiscountedPeriod(discountPromo, currency)
+                @Html(plan.prettyPricingForDiscountedPeriod(discountPromo, currency))
             }
         </div>
     </div>

--- a/app/views/fragments/global/footer.scala.html
+++ b/app/views/fragments/global/footer.scala.html
@@ -1,8 +1,9 @@
-@(showInternationalMessage: Boolean = false)
-
 @import configuration.Links
 @import org.joda.time.DateTime
-@import configuration.Details
+@import com.gu.memsub.ProductFamily
+@import views.support.ProductFamilyOps._
+
+@(showInternationalMessage: Boolean = false, productFamily: ProductFamily)
 
 <footer class="global-footer">
 
@@ -21,7 +22,7 @@
                 </p>
             } else {
                 <p>
-                  For help with Guardian and Observer subscription services please email <a href="mailto:@Details.digitalPackEmail">@Details.digitalPackEmail</a> or call @Details.digitalPackPhone. Open BST 8am to 8pm, Monday to Sunday.
+                  For help with Guardian and Observer subscription services please email <a href="mailto:@productFamily.email">@productFamily.email</a> or call @productFamily.phone. Open BST 8am to 8pm, Monday to Sunday.
                 </p>
                 <p>
                     You may also find help in our

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -2,7 +2,7 @@
 @import views.support.DigitalEdition._
 @()
 
-@main("Subscriptions | The Guardian") {
+@main("Subscriptions and Membership | The Guardian") {
 
     <main class="page-container gs-container">
         @fragments.page.header("Subscriptions and Membership")

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -1,8 +1,9 @@
 @import model.DigitalEdition
 @import views.support.DigitalEdition._
+
 @(edition: DigitalEdition)
 
-@main(s"Subscriptions | ${edition.name} | The Guardian", isInternational=true) {
+@main(s"${edition.name} | Subscriptions and Membership | The Guardian", isInternational=true) {
 
 <main class="page-container gs-container">
     <div class="page-header">

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,11 +1,15 @@
+@import com.gu.memsub.ProductFamily
+@import com.gu.memsub.Digipack
+@import utils.TestUsers.{PreSigninTestCookie, NameEnteredInForm, SignedInUsername}
+
 @(
     title: String,
     jsVars: model.JsVars = model.JsVars(),
     isInternational: Boolean = false,
     bodyClasses: Seq[String] = Nil,
-    touchpointBackendResolutionOpt: Option[services.TouchpointBackend.Resolution] = None
+    touchpointBackendResolutionOpt: Option[services.TouchpointBackend.Resolution] = None,
+    productFamily: ProductFamily = Digipack
 )(content: Html)
-@import utils.TestUsers.{PreSigninTestCookie, NameEnteredInForm, SignedInUsername}
 
 <!DOCTYPE html>
 <html lang="en-GB">
@@ -35,7 +39,7 @@
             @content
         </div>
 
-        @fragments.global.footer(isInternational)
+        @fragments.global.footer(isInternational, productFamily)
         @fragments.global.sessionCam()
         @fragments.footerJavaScript()
     </body>

--- a/app/views/promotion/landingPage.scala.html
+++ b/app/views/promotion/landingPage.scala.html
@@ -13,7 +13,7 @@
 @(edition: DigitalEdition, catalog: DigipackCatalog, promoCode: PromoCode, promotion: Promotion[PromotionType, Id, SubscriptionsLandingPage], defaultTrial: Days, md: MarkdownRenderer)
 @anyPromotion = @{asAnyPromotion(promotion)}
 @main(
-    title = "The Digital Pack offer | Subscriptions | The Guardian",
+    title = "Subscribe to the Guardian Digital Pack offer | The Guardian (${edition.name})",
     bodyClasses = Seq("is-wide")
 ) {
 

--- a/app/views/support/ProductFamilyOps.scala
+++ b/app/views/support/ProductFamilyOps.scala
@@ -1,29 +1,37 @@
 package views.support
 
-import com.gu.memsub.{Digipack, Paper, ProductFamily}
+import com.gu.memsub._
 
 object ProductFamilyOps {
 
   implicit class ProductFamilyName(in: ProductFamily) {
-    def title: String = in match {
-      case Digipack => "The Guardian Digital Pack"
-      case Paper => "Guardian & Observer papers"
+
+    def title(plan: PaidPlan[Current, BillingPeriod]): String = in match {
+      case Digipack => "Guardian Digital Pack"
+      case Paper => plan.description
     }
 
-    def subtitle: String = in match {
-      case Digipack => "(Daily Edition + Guardian App Premium Tier)"
-      case Paper => "Text here"
+    def subtitle(plan: PaidPlan[Current, BillingPeriod]): String = in match {
+      case Digipack => "Daily Edition + Guardian App Premium Tier"
+      case Paper => plan.name + " package"
     }
 
     def packImage: String = in match {
       case Digipack => "images/digital-pack.png"
-      case Paper => "images/digital-pack.png"
+      case Paper => "images/backgrounds/bg-paper-only.png"
     }
 
     def changeRatePlanText: String = in match {
       case Digipack => "Change payment frequency"
       case Paper => "Change package"
     }
+
+    def email: String = in match {
+      case Digipack => "digitalpack@theguardian.com"
+      case Paper => "todo@theguardian.com" // TODO
+    }
+
+    def phone: String = "+44 (0) 330 333 6767"
 
   }
 

--- a/app/views/testing/testUsers.scala.html
+++ b/app/views/testing/testUsers.scala.html
@@ -1,5 +1,6 @@
 @import com.gu.i18n.CountryGroup
 @import com.gu.memsub.Digipack
+@import com.gu.memsub.Paper
 @import com.gu.i18n.CountryGroup.UK
 @import controllers.Checkout.getCheckoutRouteForProductFamily
 @(userString: String)(implicit request: RequestHeader)
@@ -19,8 +20,13 @@
         </div>
 
         <div class="actions">
-            <a href="@idWebAppRegisterUrl(getCheckoutRouteForProductFamily(UK, None, Digipack))" class="button button--primary button--large">Register an Identity user</a>
-            <a href="@getCheckoutRouteForProductFamily(CountryGroup.UK, None, Digipack)" class="button button--primary button--large">Subscribe as a guest user</a>
+            <a href="@idWebAppRegisterUrl(getCheckoutRouteForProductFamily(UK, None, Digipack))" class="button button--primary button--large">Register for Digipack an Identity user</a>
+            <a href="@getCheckoutRouteForProductFamily(CountryGroup.UK, None, Digipack)" class="button button--primary button--large">Subscribe to Digipack as a guest user</a>
+        </div>
+        <hr/>
+        <div class="actions">
+            <a href="@idWebAppRegisterUrl(getCheckoutRouteForProductFamily(UK, None, Paper))" class="button button--primary button--large">Register for Paper an Identity user</a>
+            <a href="@getCheckoutRouteForProductFamily(CountryGroup.UK, None, Paper)" class="button button--primary button--large">Subscribe to Paper as a guest user</a>
         </div>
 
     </main>

--- a/app/views/testing/testUsers.scala.html
+++ b/app/views/testing/testUsers.scala.html
@@ -1,8 +1,10 @@
 @import com.gu.i18n.CountryGroup
+@import com.gu.memsub.Digipack
+@import com.gu.i18n.CountryGroup.UK
+@import controllers.Checkout.getCheckoutRouteForProductFamily
 @(userString: String)(implicit request: RequestHeader)
 
 @import configuration.Config.Identity.idWebAppRegisterUrl
-@import routes.Checkout.renderCheckout
 
 @main(title = "Test users") {
     <main class="page-container gs-container">
@@ -17,8 +19,8 @@
         </div>
 
         <div class="actions">
-            <a href="@idWebAppRegisterUrl(renderCheckout(CountryGroup.UK, None))" class="button button--primary button--large">Register an Identity user</a>
-            <a href="@renderCheckout(CountryGroup.UK, None)" class="button button--primary button--large">Subscribe as a guest user</a>
+            <a href="@idWebAppRegisterUrl(getCheckoutRouteForProductFamily(UK, None, Digipack))" class="button button--primary button--large">Register an Identity user</a>
+            <a href="@getCheckoutRouteForProductFamily(CountryGroup.UK, None, Digipack)" class="button button--primary button--large">Subscribe as a guest user</a>
         </div>
 
     </main>

--- a/assets/javascripts/modules/checkout/tracking.js
+++ b/assets/javascripts/modules/checkout/tracking.js
@@ -1,6 +1,8 @@
 define(['$', 'modules/analytics/omniture', 'modules/analytics/snowplow'], function ($, omniture, snowplow) {
     'use strict';
 
+    //TODO make this product aware
+
     function subscriptionProducts(eventName) {
         var selectedFrequency = $('.js-payment-frequency input:checked');
         if (selectedFrequency.length && eventName) {

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.223",
+    "com.gu" %% "membership-common" % "0.226",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.0.0",

--- a/conf/routes
+++ b/conf/routes
@@ -23,12 +23,12 @@ GET         /au/digital                      controllers.DigitalPack.au
 GET         /int/digital                     controllers.DigitalPack.int
 
 # Checkout
-GET         /checkout/:product               controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], product: com.gu.memsub.ProductFamily)
-GET         /checkout/:product/thank-you     controllers.Checkout.thankYou(product: com.gu.memsub.ProductFamily)
-GET         /checkout/paper                  controllers.Checkout.renderPaperCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode])
-POST        /checkout/paper                  controllers.Checkout.handlePaperCheckout
+
 GET         /checkout                        controllers.Checkout.renderDigipackCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode])
 POST        /checkout                        controllers.Checkout.handleCheckout(allowPaper: Boolean = false)
+GET         /checkout/paper                  controllers.Checkout.renderPaperCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode])
+POST        /checkout/paper                  controllers.Checkout.handlePaperCheckout
+GET         /checkout/:product/thank-you     controllers.Checkout.thankYou(product: com.gu.memsub.ProductFamily)
 
 GET         /checkout/check-identity         controllers.Checkout.checkIdentity(email: String)
 POST        /checkout/check-account          controllers.Checkout.checkAccount

--- a/conf/routes
+++ b/conf/routes
@@ -26,14 +26,14 @@ GET         /int/digital                     controllers.DigitalPack.int
 
 GET         /checkout                        controllers.Checkout.renderDigipackCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode])
 POST        /checkout                        controllers.Checkout.handleCheckout(allowPaper: Boolean = false)
-GET         /checkout/paper                  controllers.Checkout.renderPaperCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode])
 POST        /checkout/paper                  controllers.Checkout.handlePaperCheckout
-GET         /checkout/:product/thank-you     controllers.Checkout.thankYou(product: com.gu.memsub.ProductFamily)
+GET         /checkout/paper                  controllers.Checkout.renderPaperCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode])
+GET         /checkout/paper/thank-you        controllers.Checkout.thankYouPaper
 
 GET         /checkout/check-identity         controllers.Checkout.checkIdentity(email: String)
 POST        /checkout/check-account          controllers.Checkout.checkAccount
 POST        /checkout/register-guest-user    controllers.Checkout.convertGuestUser
-GET         /checkout/thank-you              controllers.Checkout.thankYou(product: com.gu.memsub.ProductFamily = com.gu.memsub.Digipack)
+GET         /checkout/thank-you              controllers.Checkout.thankYouDigipack
 
 GET         /checkout/lookupPromotion        controllers.Checkout.validatePromoCode(promoCode: PromoCode, productRatePlanId: ProductRatePlanId, country: Country)
 

--- a/conf/routes
+++ b/conf/routes
@@ -23,16 +23,20 @@ GET         /au/digital                      controllers.DigitalPack.au
 GET         /int/digital                     controllers.DigitalPack.int
 
 # Checkout
+GET         /checkout/:product               controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], product: com.gu.memsub.ProductFamily)
+GET         /checkout/:product/thank-you     controllers.Checkout.thankYou(product: com.gu.memsub.ProductFamily)
 GET         /checkout/paper                  controllers.Checkout.renderPaperCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode])
-GET         /checkout                        controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], product: com.gu.memsub.ProductFamily = com.gu.memsub.Digipack)
 POST        /checkout/paper                  controllers.Checkout.handlePaperCheckout
+GET         /checkout                        controllers.Checkout.renderDigipackCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode])
 POST        /checkout                        controllers.Checkout.handleCheckout(allowPaper: Boolean = false)
+
 GET         /checkout/check-identity         controllers.Checkout.checkIdentity(email: String)
 POST        /checkout/check-account          controllers.Checkout.checkAccount
 POST        /checkout/register-guest-user    controllers.Checkout.convertGuestUser
-GET         /checkout/thank-you              controllers.Checkout.thankYou
+GET         /checkout/thank-you              controllers.Checkout.thankYou(product: com.gu.memsub.ProductFamily = com.gu.memsub.Digipack)
 
 GET         /checkout/lookupPromotion        controllers.Checkout.validatePromoCode(promoCode: PromoCode, productRatePlanId: ProductRatePlanId, country: Country)
+
 # collection and delivery
 GET         /collection/paper-digital        controllers.Shipping.viewCollectionPaperDigital
 GET         /collection/paper                controllers.Shipping.viewCollectionPaper


### PR DESCRIPTION
- Carried forward the product rate plan description to the thank you page.
- Added new URL routes for the paper flow (these might change depending on how we want to do analytics)
- Added button on /test-users page to test paper flows.

Still to do:

- Deeplinking to a package
- Emails
- Redirects/confirmation of the digipack checkout URLs once analytics have been tweaked.
cc @tomverran 