### PR TITLE
Fix React loading

### DIFF
--- a/assets/javascripts/modules/checkout.js
+++ b/assets/javascripts/modules/checkout.js
@@ -29,7 +29,7 @@ define([
             reviewDetails.init();
             promoCode.init();
             paperDeliveryAddress.init();
-            if (formElements.$PAPER_CHECKOUT_DATE_PICKER != null) {
+            if (formElements.$PAPER_CHECKOUT_DATE_PICKER.length) {
                 require(['modules/checkout/datePicker'], function(datePicker) {
                     datePicker.default.init();
                 });

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -1,5 +1,7 @@
 var Uglify = require("webpack/lib/optimize/UglifyJsPlugin");
 
+var webpack = require("webpack");
+
 var path = require('path');
 
 module.exports = function(debug) { return {
@@ -53,6 +55,11 @@ module.exports = function(debug) { return {
     },
 
     plugins: !debug ? [
+        new webpack.DefinePlugin({
+            'process.env':{
+                'NODE_ENV': JSON.stringify('production')
+            }
+        }),
         new Uglify({compress: {warnings: false}})
     ] : [],
 


### PR DESCRIPTION
Gets rid of console error and makes sure React is only loaded for paper checkout.

**The error in question**:

![image](https://cloud.githubusercontent.com/assets/164991/16592399/6c7003ae-42d8-11e6-851b-60379664dae8.png)

Fixed by following [this](http://dev.topheman.com/make-your-react-production-minified-version-with-webpack/).

React is now loaded async on the paper checkout page only:

**Digipack checkout**:
![screen shot 2016-07-05 at 17 41 59](https://cloud.githubusercontent.com/assets/164991/16592435/96031d14-42d8-11e6-941a-b0921b293799.png)

**Paper checkout**:
![screen shot 2016-07-05 at 17 42 36](https://cloud.githubusercontent.com/assets/164991/16592436/9604e09a-42d8-11e6-993f-e982b689c418.png)

