### PR TITLE
Checkout flows and thankyou

### DIFF
--- a/app/configuration/Details.scala
+++ b/app/configuration/Details.scala
@@ -1,6 +1,0 @@
-package configuration
-
-object Details {
-  val digitalPackPhone = "+44 (0) 330 333 6767"
-  val digitalPackEmail = "digitalpack@theguardian.com"
-}

--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -1,11 +1,11 @@
 package forms
 
-import com.gu.i18n.{Country, CountryGroup, Title}
+import com.gu.i18n.{CountryGroup, Title}
 import com.gu.memsub.promo.PromoCode
-import com.gu.memsub.{Address, BillingPeriod, Current, Status}
+import com.gu.memsub.{Address, BillingPeriod, Current}
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.services.CatalogService
-import com.gu.subscriptions.{Day, DigipackPlan, PaperPlan}
+import com.gu.subscriptions.{ChargeName, DigipackPlan, PaperPlan}
 import model._
 import play.api.data.format.Formats._
 import play.api.data.format.Formatter
@@ -25,10 +25,10 @@ class SubscriptionsForm(catalogService: CatalogService) {
       Map(key -> value.productRatePlanId.get)
   }
 
-  implicit val pf2 = new Formatter[PaperPlan[Current, Day]] {
-    override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], PaperPlan[Current, Day]] =
+  implicit val pf2 = new Formatter[PaperPlan[Current, ChargeName]] {
+    override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], PaperPlan[Current, ChargeName]] =
       data.get(key).map(ProductRatePlanId).flatMap(id => catalogService.paperCatalog.flatMap(_.findCurrent(id))).toRight(Seq(FormError(key, "Bad plan")))
-    override def unbind(key: String, value: PaperPlan[Current, Day]): Map[String, String] =
+    override def unbind(key: String, value: PaperPlan[Current, ChargeName]): Map[String, String] =
       Map(key -> value.productRatePlanId.get)
   }
 
@@ -40,7 +40,7 @@ class SubscriptionsForm(catalogService: CatalogService) {
     "startDate" -> jodaLocalDate,
     "delivery" -> addressDataMapping,
     "deliveryInstructions" -> optional(text),
-    "ratePlanId" -> of[PaperPlan[Current, Day]]
+    "ratePlanId" -> of[PaperPlan[Current, ChargeName]]
   )(PaperData.apply)(PaperData.unapply))
 
   implicit class FormOps[A](in: Form[A]) {

--- a/app/model/SubscriptionData.scala
+++ b/app/model/SubscriptionData.scala
@@ -7,7 +7,7 @@ import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.{Address, BillingPeriod, Current, FullName}
 import com.gu.memsub.promo.PromoCode
 import IdUserOps._
-import com.gu.subscriptions.{Day, DigipackPlan, PaperPlan}
+import com.gu.subscriptions.{ChargeName, DigipackPlan, PaperPlan}
 import org.joda.time.LocalDate
 
 sealed trait PaymentType {
@@ -68,7 +68,7 @@ case class PaperData(
   startDate: LocalDate,
   deliveryAddress: Address,
   deliveryInstructions: Option[String],
-  plan: PaperPlan[Current, Day]
+  plan: PaperPlan[Current, ChargeName]
 )
 
 object PersonalData {

--- a/app/tracking/activities/SubscriptionRegistrationActivity.scala
+++ b/app/tracking/activities/SubscriptionRegistrationActivity.scala
@@ -18,7 +18,6 @@ case class MemberData(checkoutResult: CheckoutSuccess, subscriptionData: Subscri
     def bcrypt(string: String) = (string + Config.bcryptPepper).bcrypt(Config.bcryptSalt)
 
     val billingAddress = subscriptionData.genericData.personalData.address
-    val deliveryAddress = subscriptionData.genericData.personalData.address // TODO change to deliveryAddress once merged
 
     // TODO test that the billing period is correctly carried through, now that we are not getting plan from the catalog
     val subscriptionPlan = Map("subscriptionPlan" -> subscriptionData.productData.fold(_.plan.name, _.plan.billingPeriod.adjective))
@@ -36,7 +35,7 @@ case class MemberData(checkoutResult: CheckoutSuccess, subscriptionData: Subscri
 
     val addressData = Map(
       "billingPostcode" -> truncatePostcode(billingAddress.postCode),
-      "deliveryPostcode" -> truncatePostcode(deliveryAddress.postCode),
+      "deliveryPostcode" -> truncatePostcode(subscriptionData.productData.fold(_.deliveryAddress.postCode, _ => billingAddress.postCode)),
       "city" -> billingAddress.town,
       "country" -> billingAddress.country
     )

--- a/app/tracking/activities/SubscriptionRegistrationActivity.scala
+++ b/app/tracking/activities/SubscriptionRegistrationActivity.scala
@@ -11,53 +11,45 @@ import model.error.CheckoutService._
 
 import scala.collection.JavaConversions._
 
-object MemberData {
-  def apply(checkoutResult: CheckoutSuccess, subscriptionData: SubscribeRequest, billingPeriod: BillingPeriod): MemberData = {
-    val address: Address = subscriptionData.genericData.personalData.address
-    MemberData(address.town,
-      address.country.fold(address.countryName)(_.name),
-      address.postCode,
-      billingPeriod,
-      subscriptionData.genericData.personalData.receiveGnmMarketing,
-      checkoutResult.salesforceMember.salesforceContactId,
-      checkoutResult.userIdData.map(_.id).mkString,
-      subscriptionData.genericData.paymentData
-    )
-  }
-}
-
-case class MemberData(town: String, country: String, postCode: String, billingPeriod: BillingPeriod, receiveGnmMarketing: Boolean, salesForceContactId: String, userId: String, paymentData: PaymentData) {
+case class MemberData(checkoutResult: CheckoutSuccess, subscriptionData: SubscribeRequest) {
 
   def toMap: JMap[String, Any] = {
 
     def bcrypt(string: String) = (string + Config.bcryptPepper).bcrypt(Config.bcryptSalt)
 
-    val subscriptionPlan = Map("subscriptionPlan" -> billingPeriod.adjective)
+    val billingAddress = subscriptionData.genericData.personalData.address
+    val deliveryAddress = subscriptionData.genericData.personalData.address // TODO change to deliveryAddress once merged
+
+    // TODO test that the billing period is correctly carried through, now that we are not getting plan from the catalog
+    val subscriptionPlan = Map("subscriptionPlan" -> subscriptionData.productData.fold(_.plan.name, _.plan.billingPeriod.adjective))
 
     val marketingChoices = Map("marketingChoicesForm" -> ActivityTracking.setSubMap(Map(
-      "gnm" -> receiveGnmMarketing,
+      "gnm" -> subscriptionData.genericData.personalData.receiveGnmMarketing,
       "membership" -> false,
       "thirdParty" -> false
     )))
 
     val identityData = Map(
-      "salesforceContactId" -> bcrypt(salesForceContactId),
-      "identityId" -> bcrypt(userId)
+      "salesforceContactId" -> bcrypt(checkoutResult.salesforceMember.salesforceContactId),
+      "identityId" -> bcrypt(checkoutResult.userIdData.map(_.id).mkString)
     )
 
     val addressData = Map(
-      "billingPostcode" -> truncatePostcode(postCode),
-      "deliveryPostcode" -> truncatePostcode(postCode),
-      "city" -> town,
-      "country" -> country
+      "billingPostcode" -> truncatePostcode(billingAddress.postCode),
+      "deliveryPostcode" -> truncatePostcode(deliveryAddress.postCode),
+      "city" -> billingAddress.town,
+      "country" -> billingAddress.country
     )
 
     val tierData = Map(
-      "tier" -> "digital"
+      "tier" -> subscriptionData.productData.fold(
+        x => "paper", // TODO change to s"${if (is a bundle) "bundle" else "paper"}-${if (home delivery) "delivery" else "voucher"}"
+        _ => "digital"
+      )
     )
 
     val paymentMethodData = Map(
-      "paymentMethod" -> (paymentData match {
+      "paymentMethod" -> (subscriptionData.genericData.paymentData match {
         case d: DirectDebitData => "direct-debit"
         case c: CreditCardData => "credit-card"
       })

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -13,7 +13,6 @@
 @import views.support.ProductPopulationData._
 @import com.gu.memsub.Current
 @import com.gu.subscriptions.PaperPlan
-@import com.gu.subscriptions.Day
 @import com.gu.i18n.Currency
 @import com.gu.i18n.Country
 @import com.gu.memsub.Paper

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -1,5 +1,5 @@
 @import com.gu.i18n.{Country, CountryGroup, Currency}
-@import com.gu.memsub.{BillingPeriod, Month}
+@import com.gu.memsub.BillingPeriod
 @import com.gu.subscriptions.DigipackPlan
 @import configuration.Config.Identity._
 @import model.JsVars
@@ -8,20 +8,20 @@
 @import views.support.Pricing._
 @import com.gu.memsub.promo.PromoCode
 @import model.PersonalData
-
+@import views.support.ProductFamilyOps._
 @import views.support.ProductPopulationData
 @import views.support.ProductPopulationData._
-@import views.support.ProductFamilyOps._
 @import com.gu.memsub.Current
 @import com.gu.subscriptions.PaperPlan
 @import com.gu.subscriptions.Day
 @import com.gu.i18n.Currency
 @import com.gu.i18n.Country
 @import com.gu.memsub.Paper
+@import com.gu.subscriptions.ChargeName
+@import views.support.ProductFamilyOps._
 @(
     personalData: Option[PersonalData],
     productData: ProductPopulationData,
-    defaultPlan : DigipackPlan[Month],
     country: Option[Country],
     countryGroup: CountryGroup,
     defaultCurrency: Currency,
@@ -29,21 +29,22 @@
     touchpointBackendResolution: services.TouchpointBackend.Resolution,
     promoCode: Option[PromoCode])(implicit request: RequestHeader)
 
-@priceOption(plan: Either[DigipackPlan[BillingPeriod], PaperPlan[Current, Day]], currency: Currency) = {
+@priceOption(plan: Either[DigipackPlan[BillingPeriod], PaperPlan[Current, ChargeName]], currency: Currency) = {
     <label class="option" data-currency="@currency">
         <span class="option__input">
             <input
             type="radio" name="ratePlanId"
-            data-option-mirror-label-default="@plan.asPaidPlan.prettyPricing(currency)"
-            data-option-mirror-label="@plan.asPaidPlan.prettyPricing(currency)"
+            data-option-mirror-payment-default="@plan.asPaidPlan.prettyPricing(currency)"
+            data-option-mirror-payment="@plan.asPaidPlan.prettyPricing(currency)"
+            data-option-mirror-package="@productData.family.title(plan.asPaidPlan)"
             data-amount="@plan.asPaidPlan.gbpPrice.amount"
             data-number-of-months="@plan.asPaidPlan.billingPeriod.numberOfMonths"
             data-currency="@currency"
             value="@plan.productRatePlanId.get"
-            @if(plan.fold(identity, identity) == productData.plans.default && currency == defaultCurrency){checked}
+            @if(plan.fold(identity, identity) == productData.plans.default && currency == defaultCurrency){ checked="checked" }
             >
         </span>
-        <span class="option__label" id="label-for-@plan.productRatePlanId.get-@currency">@plan.prettyName(currency)</span>
+        <span class="option__label" id="label-for-@plan.productRatePlanId.get-@currency" title="@plan.title">@plan.prettyName(currency)</span>
     </label>
 }
 
@@ -55,7 +56,7 @@
 }
 
 @main(
-    title = "Details - name and address | Subscriptions | The Guardian",
+    title = s"Details - name and address | Subscribe to the ${productData.family.title(productData.plans.default)} | The Guardian",
     jsVars = JsVars(userIsSignedIn = personalData.isDefined, ignorePageLoadTracking = true, countryGroup = countryGroup, currency = defaultCurrency, country = country),
     bodyClasses = List("is-wide"),
     touchpointBackendResolutionOpt = Some(touchpointBackendResolution)
@@ -69,16 +70,18 @@
         <form class="form js-checkout-form" action="" method="POST" novalidate>
             @helper.CSRF.formField
 
-            @fragments.checkout.checkoutHeader(productData.family.title)
+            @fragments.checkout.checkoutHeader(productData.family.title(productData.plans.default))
 
             @* ===== Plan selection ===== *@
             <div class="checkout-container__sidebar js-basket">
-                @fragments.checkout.basketPreview(productData.family)
-                <div class="basket-options-toggle u-note prose">
-                    <a class="js-toggle checkout-container__frequency" data-toggle="change-payment-frequency">
+                @fragments.checkout.basketPreview(productData.family, productData.plans.default)
+                @if(productData.plans.list.length > 1) {
+                    <div class="basket-options-toggle u-note prose">
+                        <a class="js-toggle checkout-container__frequency" data-toggle="change-payment-frequency">
                         @productData.family.changeRatePlanText
-                    </a>
-                </div>
+                        </a>
+                    </div>
+                }
                 <fieldset class="basket-billing-options is-hidden js-payment-frequency js-option-mirror-group" id="change-payment-frequency">
                     @productData.toPlanEither.list.map { p =>
                         @p.asPaidPlan.currencies.map { c =>
@@ -98,7 +101,7 @@
                         }
                         </div>
                         <div class="js-payment-type-direct-debit u-note">
-                            @fragments.checkout.noticesDirectDebit()
+                            @fragments.checkout.noticesDirectDebit(productData.family)
                         </div>
                         <div class="js-payment-type-card" hidden="true">
                             @fragments.checkout.noticesCard()
@@ -121,10 +124,10 @@
                             </div>
                             <div class="field-note field-note--offset prose">
                                 @if(personalData.isDefined) {
-                                    <a href="@idWebAppSignOutUrl(routes.Checkout.renderCheckout(countryGroup, promoCode))">Sign out</a>
+                                    <a href="@idWebAppSignOutUrl(controllers.Checkout.getCheckoutRouteForProductFamily(productData.family, countryGroup, promoCode, productData.plans.default.name))">Sign out</a>
                                 } else {
                                     <span class="field-note__label">Already have a Guardian account?</span>
-                                    <a href="@idWebAppSigninUrl(routes.Checkout.renderCheckout(countryGroup, promoCode))">Sign in</a>
+                                    <a href="@idWebAppSigninUrl(controllers.Checkout.getCheckoutRouteForProductFamily(productData.family, countryGroup, promoCode, productData.plans.default.name))">Sign in</a>
                                 }
                             </div>
                         </div>

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -206,7 +206,7 @@
                                 Review and confirm
                         </legend>
                         <div class="field-panel__fields">
-                            @fragments.checkout.reviewDetails(personalData)
+                            @fragments.checkout.reviewDetails(personalData, productData)
                         </div>
                     </fieldset>
                 </div>

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -1,25 +1,26 @@
 @import com.gu.i18n.Currency
 @import com.gu.memsub.BillingPeriod
 @import com.gu.memsub.promo.Promotion.AnyPromotion
-@import com.gu.subscriptions.DigipackPlan
 @import views.support.BillingPeriod._
 @import views.support.Pricing._
 @import com.gu.memsub.Current
+@import com.gu.memsub.Digipack
 @import com.gu.memsub.PaidPlan
+@import com.gu.memsub.ProductFamily
+@import views.support.ProductFamilyOps._
+@import com.gu.memsub.Paper
+
 @(subscriptionName: String,
     guestAccountForm: Option[Form[model.GuestAccountData]] = None,
     touchpointBackendResolution: services.TouchpointBackend.Resolution,
     plan: PaidPlan[Current, BillingPeriod],
     promotion: Option[AnyPromotion] = None,
-    currency: Currency
+    currency: Currency,
+    productFamily: ProductFamily,
+    isBundle: Boolean
 )(implicit request: RequestHeader)
 
-@import configuration.Config.Identity.webAppProfileUrl
-@import configuration.Details
-@import services.IdentityToken.{paramName => identityTokenParam}
-@import services.UserId.{paramName => userIdParam}
-
-@main("Confirmation | Digital | Subscriptions | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
+@main(s"Confirmation | Subscribe to the ${productFamily.title(plan)} | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
     @fragments.analytics.tagmanager()
 
@@ -35,7 +36,7 @@
 </script>
 
 <main class="page-container gs-container gs-container--slim">
-    @fragments.page.header("Thank you for your order", None, List("l-padded"))
+    @fragments.page.header("Thank you for subscribing", None, List("l-padded"))
 
     <section class="section-slice section-slice--bleed section-slice--limited">
         <div class="section-slice__content">
@@ -44,9 +45,9 @@
                     We have received your request and are now processing your subscription,
                     you'll receive email confirmation of this shortly.
                 </p>
-                <p>Here are the details of your order, if any of these are incorrect please get in touch with us straight away via email at <a href="mailto:@Details.digitalPackEmail">@Details.digitalPackEmail</a> or on <strong>@Details.digitalPackPhone</strong>. Lines are open BST Monday&ndash;Friday 8.00am&ndash;8.00pm. Saturday &amp; Sunday 8.00am&ndash;6.00pm.</p>
+                <p>Here are the details of your subscription, if any of these are incorrect please get in touch with us straight away via email at <a href="mailto:@productFamily.email">@productFamily.email</a> or on <strong>@productFamily.phone</strong>. Lines are open BST Monday&ndash;Friday 8.00am&ndash;8.00pm. Saturday &amp; Sunday 8.00am&ndash;6.00pm.</p>
             </div>
-            @fragments.checkout.reviewPanel(subscriptionName, plan, promotion, currency)
+            @fragments.checkout.reviewPanel(subscriptionName, plan, promotion, currency, productFamily)
         </div>
     </section>
 
@@ -54,57 +55,16 @@
         <div class="section-slice__content">
 
             <h2 class="section-title">What happens now?</h2>
-            @fragments.confirmation.appSteps()
 
-            @guestAccountForm.map { form =>
+            @{
+                productFamily match {
+                    case Digipack => fragments.confirmation.appSteps()
+                    case Paper => fragments.confirmation.deliverySteps(isBundle)
+                }
+            }
 
-                <h3 class="section-divider">Register for an account</h3>
-                <div class="prose prose--full">
-                    <p>Some features of your subscription require you to be signed in to theguardian.com before you can make use of them.</p>
-                </div>
+            @fragments.confirmation.registerGuestAccount(guestAccountForm)
 
-                <form action="@routes.Checkout.convertGuestUser" method="POST" class="form js-finish-account" autocomplete="off">
-                    @helper.CSRF.formField
-
-                    <div class="form-field js-checkout-finish-account-password">
-
-                        <input name="@userIdParam" type="hidden" value="@form.data.get(userIdParam)">
-                        <input name="@identityTokenParam" type="hidden" value="@form.data.get(identityTokenParam)">
-
-                        <label class="label" for="password">
-                            Enter a password to finish creating your account:
-                        </label>
-                        <input
-                            class="input-text js-input js-password-strength"
-                            id="password"
-                            name="password"
-                            type="password"
-                            minlength="6"
-                            maxlength="20"
-                            value=""
-                           required
-                        />
-                        @fragments.forms.errorMessage("Password too short")
-
-                    </div>
-                    @fragments.forms.passwordStrengthIndicator()
-
-                    <div class="actions">
-                        <button class="button button--primary button--large js-checkout-finish-account-submit">Confirm</button>
-                    </div>
-                </form>
-
-                <div class="js-finish-account-success is-hidden">
-                    <p>All done!</p>
-                    <p>You can edit your details as well as manage your subscription in your Profile area</p>
-                    <div class="actions">
-                        <a href="@webAppProfileUrl" class="button button--primary button--large">My profile</a>
-                    </div>
-                </div>
-                <div class="js-finish-account-error is-hidden finish-account-error">
-                    <p>An internal server error occurred while trying to set a password for your account. Please try again later.</p>
-                </div>
-        }
         </div>
     </section>
 </main>

--- a/app/views/digitalpack/info.scala.html
+++ b/app/views/digitalpack/info.scala.html
@@ -21,7 +21,7 @@
 }
 
 @main(
-    title = if(edition.id == "uk") "Digital | Subscriptions | The Guardian" else s"Digital - ${edition.name} | Subscriptions | The Guardian",
+    title = s"Subscribe to the Guardian Digital Pack | The Guardian (${edition.name})",
     bodyClasses = List("is-wide")
 ) {
 

--- a/app/views/fragments/checkout/basketPreview.scala.html
+++ b/app/views/fragments/checkout/basketPreview.scala.html
@@ -1,20 +1,22 @@
+@import com.gu.memsub.PaidPlan
+@import com.gu.memsub.Current
+@import com.gu.memsub.BillingPeriod
 @import com.gu.memsub.ProductFamily
 @import views.support.ProductFamilyOps._
-@(productFamily: ProductFamily)
+@(productFamily: ProductFamily, plan: PaidPlan[Current, BillingPeriod])
 
 <div class="basket-preview  basket-preview--products">
     <h3 class="basket-preview__title">You've chosen:</h3>
     <div class="basket-preview__image">
-        <img src="@controllers.CachedAssets.hashedPathFor(productFamily.packImage)" alt="">
+        <img src="@controllers.CachedAssets.hashedPathFor(productFamily.packImage)" alt="@productFamily.title(plan)">
     </div>
-
     <div class="basket-preview__product">
-        <span class="basket-preview__product__title">
-            @productFamily.title
+        <span class="basket-preview__product__title js-option-mirror-package-display">
+            @productFamily.title(plan)
         </span>
-        <span class="basket-preview__product__caption">
-            @productFamily.subtitle
-        </span>
-        <span class="basket-preview__product__payment js-option-mirror-value"></span>
+            <span class="basket-preview__product__caption">
+                (@productFamily.subtitle(plan))
+            </span>
+        <span class="basket-preview__product__payment js-option-mirror-payment-display"></span>
     </div>
 </div>

--- a/app/views/fragments/checkout/checkoutHeader.scala.html
+++ b/app/views/fragments/checkout/checkoutHeader.scala.html
@@ -1,4 +1,4 @@
 @(product: String)
 <div class="checkout-header">
-    <h1 class="checkout-header__title">Subscribe to the @product</h1>
+    <h1 class="checkout-header__title">Subscribe to the <span class="js-option-mirror-package-display">@product</span></h1>
 </div>

--- a/app/views/fragments/checkout/noticesDirectDebit.scala.html
+++ b/app/views/fragments/checkout/noticesDirectDebit.scala.html
@@ -1,7 +1,8 @@
-@()
-
-@import configuration.Details
 @import controllers.CachedAssets.hashedPathFor
+@import com.gu.memsub.ProductFamily
+@import views.support.ProductFamilyOps._
+
+@(productFamily: ProductFamily)
 
 @fragments.checkout.notice("Advanced Notice") {
     <p>
@@ -19,8 +20,8 @@
     </address>
 
     <ul class="o-unstyled-list">
-        <li>Tel: @Details.digitalPackPhone</li>
-        <li><a href="mailto:@Details.digitalPackEmail">@Details.digitalPackEmail</a></li>
+        <li>Tel: @productFamily.phone</li>
+        <li><a href="mailto:@productFamily.email">@productFamily.email</a></li>
     </ul>
 
     <aside class="direct-debit">

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -1,7 +1,9 @@
 @import model.PersonalData
 @import configuration.Links
+@import views.support.ProductPopulationData
+@import views.support.ProductPopulationData._
 
-@(personalData: Option[PersonalData])
+@(personalData: Option[PersonalData], productData: ProductPopulationData)
 <div class="review-details">
     <div class="review-details__item">
         <span class="review-details__heading">Your details</span>
@@ -9,17 +11,17 @@
             <ul class="o-unstyled-list">
                 <li class="js-checkout-review-name sessioncamhidetext"></li>
                 <li class="js-checkout-review-address sessioncamhidetext"></li>
-                <li>Email: <span class="js-checkout-review-email sessioncamhidetext"></span></li>
-                <li>Phone: <span class="js-checkout-review-phone sessioncamhidetext"></span></li>
+                <li><span class="review-details__detail">Email:</span> <span class="js-checkout-review-email sessioncamhidetext"></span></li>
+                <li><span class="review-details__detail">Phone:</span> <span class="js-checkout-review-phone sessioncamhidetext"></span></li>
             </ul>
         </div>
     </div>
-    // TODO carry through the product so we know to remove this.
-    @if(true) {
+    @productData.paper.map { p =>
         <div class="review-details__item">
             <span class="review-details__heading">Delivery details</span>
             <div class="js-checkout-review-delivery-address sessioncamhidetext"></div>
-            <div>Delivery instructions: <span class="js-checkout-review-delivery-instructions sessioncamhidetext"></span></div>
+            <div><span class="review-details__detail">Delivery instructions:</span> <span class="js-checkout-review-delivery-instructions sessioncamhidetext"></span></div>
+            <div><span class="review-details__detail">Date of first paper delivery:</span> <span class="js-checkout-review-delivery-start-date"></span></div>
         </div>
     }
     <div class="review-details__item">
@@ -42,9 +44,8 @@
     </div>
     <div class="review-details__item">
         <span class="review-details__heading">Subscription details</span>
-        <h4 class="js-option-mirror-package-display"></h4>
+        <div class="js-option-mirror-package-display"></div>
         <div class="js-option-mirror-payment-display"></div>
-        <div>Date of first paper: <span class="js-checkout-review-delivery-start-date sessioncamhidetext"></span></div>
     </div>
     <div class="review-details__actions">
         <p class="u-note">
@@ -79,6 +80,7 @@
             <a href="@Links.whyYourDataMattersToUs.href" target="_blank">here</a>.
         </p>
 
+        <!-- TODO confirm whether these T&Cs apply to paper-only packages too -->
         <p class="u-note prose">
             By proceeding you agree to the
             <a href="@Links.terms.href" target="_blank">@Links.terms.title</a>

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -1,8 +1,7 @@
 @import model.PersonalData
-@(personalData: Option[PersonalData])
-
 @import configuration.Links
 
+@(personalData: Option[PersonalData])
 <div class="review-details">
     <div class="review-details__item">
         <span class="review-details__heading">Your details</span>
@@ -10,18 +9,27 @@
             <ul class="o-unstyled-list">
                 <li class="js-checkout-review-name sessioncamhidetext"></li>
                 <li class="js-checkout-review-address sessioncamhidetext"></li>
-                <li class="js-checkout-review-email sessioncamhidetext"></li>
+                <li>Email: <span class="js-checkout-review-email sessioncamhidetext"></span></li>
+                <li>Phone: <span class="js-checkout-review-phone sessioncamhidetext"></span></li>
             </ul>
         </div>
     </div>
+    // TODO carry through the product so we know to remove this.
+    @if(true) {
+        <div class="review-details__item">
+            <span class="review-details__heading">Delivery details</span>
+            <div class="js-checkout-review-delivery-address sessioncamhidetext"></div>
+            <div>Delivery instructions: <span class="js-checkout-review-delivery-instructions sessioncamhidetext"></span></div>
+        </div>
+    }
     <div class="review-details__item">
         <span class="review-details__heading">Payment details</span>
         <div class="review-details__list js-payment-type-direct-debit">
             <ul class="o-unstyled-list">
                 <li><span class="review-details__detail">Payment method:</span> Direct Debit</li>
                 <li><span class="review-details__detail">Bank account:</span> <span class="js-checkout-review-account sessioncamhidetext"></span></li>
-                <li><span class="review-details__detail">Sort code:</span> <span class=" js-checkout-review-sortcode sessioncamhidetext"></span></li>
-                <li><span class="review-details__detail">Account holder:</span> <span class=" js-checkout-review-holder sessioncamhidetext"></span></li>
+                <li><span class="review-details__detail">Sort code:</span> <span class="js-checkout-review-sortcode sessioncamhidetext"></span></li>
+                <li><span class="review-details__detail">Account holder:</span> <span class="js-checkout-review-holder sessioncamhidetext"></span></li>
             </ul>
         </div>
         <div class="review-details__list js-payment-type-card" hidden="true">
@@ -32,9 +40,16 @@
             </ul>
         </div>
     </div>
+    <div class="review-details__item">
+        <span class="review-details__heading">Subscription details</span>
+        <h4 class="js-option-mirror-package-display"></h4>
+        <div class="js-option-mirror-payment-display"></div>
+        <div>Date of first paper: <span class="js-checkout-review-delivery-start-date sessioncamhidetext"></span></div>
+    </div>
     <div class="review-details__actions">
         <p class="u-note">
-            Your subscription includes a range of exclusive benefits which will be sent to you from Guardian Subscriptions. These may include special offers from other companies, but your data will not be shared with these companies.
+            Your subscription includes a range of exclusive benefits which will be sent to you from Guardian Subscriptions.
+            These may include special offers from other companies, but your data will not be shared with these companies.
         </p>
 
         <label class="option u-pad-bottom" for="receive-gnm-marketing">
@@ -62,7 +77,6 @@
             Our <a href="@Links.privacyPolicy.href" target="_blank">@Links.privacyPolicy.title</a>
             explains in further detail how we use your information and you can find out why your data matters to us
             <a href="@Links.whyYourDataMattersToUs.href" target="_blank">here</a>.
-
         </p>
 
         <p class="u-note prose">

--- a/app/views/fragments/checkout/reviewPanel.scala.html
+++ b/app/views/fragments/checkout/reviewPanel.scala.html
@@ -10,7 +10,10 @@
 @import scalaz.Id._
 @import com.gu.memsub.Current
 @import com.gu.memsub.PaidPlan
-@(subscriptionId: String, plan: PaidPlan[Current, BillingPeriod], promotion: Option[AnyPromotion] = None, currency: Currency)
+@import com.gu.memsub.ProductFamily
+@import views.support.ProductFamilyOps._
+
+@(subscriptionId: String, plan: PaidPlan[Current, BillingPeriod], promotion: Option[AnyPromotion] = None, currency: Currency, productFamily: ProductFamily)
 
 <div class="review-panel js-payment-frequency">
     <input type="checkbox" name="subscriptionDetails"
@@ -27,7 +30,8 @@
     <div class="review-panel__item">
         <h4 class="review-panel__label">Your subscription:</h4>
         <div class="review-panel__details">
-            The Guardian Digital Pack <em>(Daily Edition + Guardian App Premium Tier)</em>
+            <div>@productFamily.title(plan)</div>
+            <em>(@productFamily.subtitle(plan))</em>
         </div>
     </div>
     <div class="review-panel__item">
@@ -36,7 +40,7 @@
             @promotion.flatMap(_.asDiscount).fold {
                 @plan.prettyPricing(currency)
             } { discountPromo =>
-                @plan.prettyPricingForDiscountedPeriod(discountPromo, currency)
+                @Html(plan.prettyPricingForDiscountedPeriod(discountPromo, currency))
             }
         </div>
     </div>

--- a/app/views/fragments/confirmation/collectionSteps.scala.html
+++ b/app/views/fragments/confirmation/collectionSteps.scala.html
@@ -1,0 +1,11 @@
+@(isBundle: Boolean)
+
+<h3 class="section-divider">Wait for your vouchers to arrive then pop down the newsagent!</h3>
+
+<div class="steps">
+</div>
+
+
+@if(isBundle) {
+    @fragments.confirmation.appSteps()
+}

--- a/app/views/fragments/confirmation/deliverySteps.scala.html
+++ b/app/views/fragments/confirmation/deliverySteps.scala.html
@@ -1,0 +1,11 @@
+@(isBundle: Boolean)
+
+<h3 class="section-divider">Sit back and wait for your first paper to be delivered</h3>
+
+<div class="steps">
+</div>
+
+
+@if(isBundle) {
+    @fragments.confirmation.appSteps()
+}

--- a/app/views/fragments/confirmation/registerGuestAccount.scala.html
+++ b/app/views/fragments/confirmation/registerGuestAccount.scala.html
@@ -1,0 +1,55 @@
+@(guestAccountForm: Option[Form[model.GuestAccountData]])(implicit request: RequestHeader)
+
+@import configuration.Config.Identity.webAppProfileUrl
+@import services.IdentityToken.{paramName => identityTokenParam}
+@import services.UserId.{paramName => userIdParam}
+
+@guestAccountForm.map { form =>
+
+    <h3 class="section-divider">Register for an account</h3>
+    <div class="prose prose--full">
+        <p>Some features of your subscription require you to be signed in to theguardian.com before you can make use of them.</p>
+    </div>
+
+    <form action="@routes.Checkout.convertGuestUser" method="POST" class="form js-finish-account" autocomplete="off">
+        @helper.CSRF.formField
+
+        <div class="form-field js-checkout-finish-account-password">
+
+            <input name="@userIdParam" type="hidden" value="@form.data.get(userIdParam)">
+            <input name="@identityTokenParam" type="hidden" value="@form.data.get(identityTokenParam)">
+
+            <label class="label" for="password">
+                Enter a password to finish creating your account:
+            </label>
+            <input
+            class="input-text js-input js-password-strength"
+            id="password"
+            name="password"
+            type="password"
+            minlength="6"
+            maxlength="20"
+            value=""
+            required
+            />
+            @fragments.forms.errorMessage("Password too short")
+
+        </div>
+        @fragments.forms.passwordStrengthIndicator()
+
+        <div class="actions">
+            <button class="button button--primary button--large js-checkout-finish-account-submit">Confirm</button>
+        </div>
+    </form>
+
+    <div class="js-finish-account-success is-hidden">
+        <p>All done!</p>
+        <p>You can edit your details as well as manage your subscription in your Profile area</p>
+        <div class="actions">
+            <a href="@webAppProfileUrl" class="button button--primary button--large">My profile</a>
+        </div>
+    </div>
+    <div class="js-finish-account-error is-hidden finish-account-error">
+        <p>An internal server error occurred while trying to set a password for your account. Please try again later.</p>
+    </div>
+}

--- a/app/views/fragments/global/footer.scala.html
+++ b/app/views/fragments/global/footer.scala.html
@@ -1,8 +1,9 @@
-@(showInternationalMessage: Boolean = false)
-
 @import configuration.Links
 @import org.joda.time.DateTime
-@import configuration.Details
+@import com.gu.memsub.ProductFamily
+@import views.support.ProductFamilyOps._
+
+@(showInternationalMessage: Boolean = false, productFamily: ProductFamily)
 
 <footer class="global-footer">
 
@@ -21,7 +22,7 @@
                 </p>
             } else {
                 <p>
-                  For help with Guardian and Observer subscription services please email <a href="mailto:@Details.digitalPackEmail">@Details.digitalPackEmail</a> or call @Details.digitalPackPhone. Open BST 8am to 8pm, Monday to Sunday.
+                  For help with Guardian and Observer subscription services please email <a href="mailto:@productFamily.email">@productFamily.email</a> or call @productFamily.phone. Open BST 8am to 8pm, Monday to Sunday.
                 </p>
                 <p>
                     You may also find help in our

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -2,7 +2,7 @@
 @import views.support.DigitalEdition._
 @()
 
-@main("Subscriptions | The Guardian") {
+@main("Subscriptions and Membership | The Guardian") {
 
     <main class="page-container gs-container">
         @fragments.page.header("Subscriptions and Membership")

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -1,8 +1,9 @@
 @import model.DigitalEdition
 @import views.support.DigitalEdition._
+
 @(edition: DigitalEdition)
 
-@main(s"Subscriptions | ${edition.name} | The Guardian", isInternational=true) {
+@main(s"${edition.name} | Subscriptions and Membership | The Guardian", isInternational=true) {
 
 <main class="page-container gs-container">
     <div class="page-header">

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,11 +1,15 @@
+@import com.gu.memsub.ProductFamily
+@import com.gu.memsub.Digipack
+@import utils.TestUsers.{PreSigninTestCookie, NameEnteredInForm, SignedInUsername}
+
 @(
     title: String,
     jsVars: model.JsVars = model.JsVars(),
     isInternational: Boolean = false,
     bodyClasses: Seq[String] = Nil,
-    touchpointBackendResolutionOpt: Option[services.TouchpointBackend.Resolution] = None
+    touchpointBackendResolutionOpt: Option[services.TouchpointBackend.Resolution] = None,
+    productFamily: ProductFamily = Digipack
 )(content: Html)
-@import utils.TestUsers.{PreSigninTestCookie, NameEnteredInForm, SignedInUsername}
 
 <!DOCTYPE html>
 <html lang="en-GB">
@@ -35,7 +39,7 @@
             @content
         </div>
 
-        @fragments.global.footer(isInternational)
+        @fragments.global.footer(isInternational, productFamily)
         @fragments.global.sessionCam()
         @fragments.footerJavaScript()
     </body>

--- a/app/views/promotion/landingPage.scala.html
+++ b/app/views/promotion/landingPage.scala.html
@@ -13,7 +13,7 @@
 @(edition: DigitalEdition, catalog: DigipackCatalog, promoCode: PromoCode, promotion: Promotion[PromotionType, Id, SubscriptionsLandingPage], defaultTrial: Days, md: MarkdownRenderer)
 @anyPromotion = @{asAnyPromotion(promotion)}
 @main(
-    title = "The Digital Pack offer | Subscriptions | The Guardian",
+    title = "Subscribe to the Guardian Digital Pack offer | The Guardian (${edition.name})",
     bodyClasses = Seq("is-wide")
 ) {
 

--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -4,7 +4,7 @@ import com.gu.i18n.{Currency, GBP}
 import com.gu.memsub.promo.PercentDiscount.getDiscountScaledToPeriod
 import com.gu.memsub.promo.{LandingPage, PercentDiscount, Promotion}
 import com.gu.memsub.{BillingPeriod => BP, _}
-import com.gu.subscriptions.{Day, DigipackPlan, PaperPlan}
+import com.gu.subscriptions.{ChargeName, DigipackPlan, PaperPlan}
 import views.support.BillingPeriod._
 
 object Pricing {
@@ -56,14 +56,14 @@ object Pricing {
     }
   }
 
-  implicit class EitherPlanPlan(in: Either[DigipackPlan[BP], PaperPlan[Current, Day]]) {
+  implicit class EitherPlanPlan(in: Either[DigipackPlan[BP], PaperPlan[Current, ChargeName]]) {
 
     implicit val planWithPricing = new PlanWithPricing(asPaidPlan)
 
-    import Pricing._
-
     def productRatePlanId = in.fold(_.productRatePlanId, _.productRatePlanId)
     def asPaidPlan: PaidPlan[Current, BP] = in.fold(identity, identity)
-    def prettyName(currency: Currency): String = in.fold(_ => planWithPricing.prettyPricing(currency), p => s"${p.name} ${planWithPricing.prettyPricing(currency)}")
+    def prettyName(currency: Currency): String = in.fold(_ => planWithPricing.prettyPricing(currency), p => s"${p.name} package - ${planWithPricing.prettyPricing(currency)}")
+    def title: String = in.fold(_.description, _.description)
+
   }
 }

--- a/app/views/support/ProductFamilyOps.scala
+++ b/app/views/support/ProductFamilyOps.scala
@@ -1,29 +1,42 @@
 package views.support
 
-import com.gu.memsub.{Digipack, Paper, ProductFamily}
+import com.gu.memsub._
 
 object ProductFamilyOps {
 
   implicit class ProductFamilyName(in: ProductFamily) {
-    def title: String = in match {
-      case Digipack => "The Guardian Digital Pack"
-      case Paper => "Guardian & Observer papers"
+
+    def title(plan: PaidPlan[Current, BillingPeriod]): String = in match {
+      case Digipack => "Guardian Digital Pack"
+      case Paper => plan.name + " package"
+      case _ => ""
     }
 
-    def subtitle: String = in match {
-      case Digipack => "(Daily Edition + Guardian App Premium Tier)"
-      case Paper => "Text here"
+    def subtitle(plan: PaidPlan[Current, BillingPeriod]): String = in match {
+      case Digipack => "Daily Edition + Guardian App Premium Tier"
+      case Paper => plan.description
+      case _ => ""
     }
 
     def packImage: String = in match {
       case Digipack => "images/digital-pack.png"
-      case Paper => "images/digital-pack.png"
+      case Paper => "images/backgrounds/bg-paper-only.png"
+      case _ => ""
     }
 
     def changeRatePlanText: String = in match {
       case Digipack => "Change payment frequency"
-      case Paper => "Change package"
+      case Paper => "Add more"
+      case _ => ""
     }
+
+    def email: String = in match {
+      case Digipack => "digitalpack@theguardian.com"
+      case Paper => "todo@theguardian.com" // TODO
+      case _ => ""
+    }
+
+    def phone: String = "+44 (0) 330 333 6767"
 
   }
 

--- a/app/views/support/ProductPopulationData.scala
+++ b/app/views/support/ProductPopulationData.scala
@@ -1,6 +1,6 @@
 package views.support
 import com.gu.memsub._
-import com.gu.subscriptions.{Day, DigipackPlan, PaperPlan}
+import com.gu.subscriptions.{ChargeName, DigipackPlan, PaperPlan}
 
 case class PlanList[+A](default: A, others: A*) {
   def map[B](f: A => B): PlanList[B] = PlanList(f(default), others.map(f):_*)
@@ -20,14 +20,14 @@ case class DigipackProductPopulationData(
 
 case class PaperProductPopulationData(
   deliveryAddress: Option[Address],
-  plans: PlanList[PaperPlan[Current, Day]]
+  plans: PlanList[PaperPlan[Current, ChargeName]]
 ) extends ProductPopulationData {
   val family = Paper
 }
 
 object ProductPopulationData {
   implicit class EitherySubscriptionsForm(in: ProductPopulationData) {
-    def toPlanEither: PlanList[Either[DigipackPlan[BillingPeriod], PaperPlan[Current, Day]]] = in match {
+    def toPlanEither: PlanList[Either[DigipackPlan[BillingPeriod], PaperPlan[Current, ChargeName]]] = in match {
       case DigipackProductPopulationData(plans) => plans.map(Left(_))
       case PaperProductPopulationData(_, plans) => plans.map(Right(_))
     }

--- a/app/views/testing/testUsers.scala.html
+++ b/app/views/testing/testUsers.scala.html
@@ -1,8 +1,11 @@
 @import com.gu.i18n.CountryGroup
+@import com.gu.memsub.Digipack
+@import com.gu.memsub.Paper
+@import com.gu.i18n.CountryGroup.UK
+@import controllers.Checkout.getCheckoutRouteForProductFamily
 @(userString: String)(implicit request: RequestHeader)
 
 @import configuration.Config.Identity.idWebAppRegisterUrl
-@import routes.Checkout.renderCheckout
 
 @main(title = "Test users") {
     <main class="page-container gs-container">
@@ -17,9 +20,33 @@
         </div>
 
         <div class="actions">
-            <a href="@idWebAppRegisterUrl(renderCheckout(CountryGroup.UK, None))" class="button button--primary button--large">Register an Identity user</a>
-            <a href="@renderCheckout(CountryGroup.UK, None)" class="button button--primary button--large">Subscribe as a guest user</a>
+            <h3>Register as an Identity user, redirecting to checkout for:</h3>
+            <a href="@idWebAppRegisterUrl(getCheckoutRouteForProductFamily(Digipack))" class="button button--primary button--large">Digital Pack</a>
+            <a href="@idWebAppRegisterUrl(getCheckoutRouteForProductFamily(Paper))" class="button button--primary button--large">Everyday package</a>
+            <a href="@idWebAppRegisterUrl(getCheckoutRouteForProductFamily(Paper, forThisPlan = "everyday+"))" class="button button--primary button--large">Everyday+ package</a>
         </div>
+
+        <hr/>
+
+        <div class="actions">
+            <h3>Subscribe as a <em>guest</em> user to:</h3>
+            <dl>
+                <a href="@getCheckoutRouteForProductFamily(Digipack)" class="button button--primary button--large">Digital Pack</a>
+            </dl>
+            <dl>
+                <a href="@getCheckoutRouteForProductFamily(Paper)" class="button button--primary button--large">Everyday package</a>
+                <a href="@getCheckoutRouteForProductFamily(Paper, forThisPlan = "sixday")" class="button button--primary button--large">Sixday package</a>
+                <a href="@getCheckoutRouteForProductFamily(Paper, forThisPlan = "weekend")" class="button button--primary button--large">Weekend package</a>
+            </dl>
+            <dl>
+                <a href="@getCheckoutRouteForProductFamily(Paper, forThisPlan = "everyday+")" class="button button--primary button--large">Everyday+ package</a>
+                <a href="@getCheckoutRouteForProductFamily(Paper, forThisPlan = "sixday+")" class="button button--primary button--large">Sixday+ package</a>
+                <a href="@getCheckoutRouteForProductFamily(Paper, forThisPlan = "weekend+")" class="button button--primary button--large">Weekend+ package</a>
+                <a href="@getCheckoutRouteForProductFamily(Paper, forThisPlan = "sunday+")" class="button button--primary button--large">Sunday+ package</a>
+            </dl>
+        </div>
+
+        <hr/>
 
     </main>
 }

--- a/assets/javascripts/modules/checkout/formElements.js
+++ b/assets/javascripts/modules/checkout/formElements.js
@@ -2,6 +2,7 @@ define(['$'], function ($) {
     'use strict';
     var _PLAN_SELECT = $('.js-payment-frequency');
     var _PLAN_INPUTS = $('input[type="radio"]', _PLAN_SELECT);
+    var _PAPER_CHECKOUT_DATE_PICKER_FORM_FIELD_NAME = 'startDate';
 
     var getRatePlanId = function () {
         // Bonzo has no filter function :(
@@ -22,7 +23,6 @@ define(['$'], function ($) {
         var $ADDRESS3_CONTAINER = $('.js-checkout-town', container);
         var $SUBDIVISION_CONTAINER = $('.js-checkout-subdivision', container);
         var $POSTCODE_CONTAINER = $('.js-checkout-postcode', container);
-        var $MANUAL_ADDRESS_CONTAINER = $('.js-checkout-manual-address', container); //wat
 
         return {
             $CONTAINER: $CONTAINER,
@@ -31,7 +31,6 @@ define(['$'], function ($) {
             $ADDRESS3_CONTAINER: $ADDRESS3_CONTAINER,
             $SUBDIVISION_CONTAINER: $SUBDIVISION_CONTAINER,
             $POSTCODE_CONTAINER: $POSTCODE_CONTAINER,
-            $MANUAL_ADDRESS_CONTAINER: $MANUAL_ADDRESS_CONTAINER, //wat
 
             $ADDRESS1: $('.js-input', $ADDRESS1_CONTAINER[0]),
             $ADDRESS2: $('.js-input', $ADDRESS2_CONTAINER[0]),
@@ -42,6 +41,10 @@ define(['$'], function ($) {
         };
     };
 
+    var getPaperCheckoutField = function() {
+        return $('[name="' + _PAPER_CHECKOUT_DATE_PICKER_FORM_FIELD_NAME + '"]');
+    };
+
     return {
         $CHECKOUT_FORM: $('.js-checkout-form'),
         $NOTICES: $('.js-checkout-notices'),
@@ -49,11 +52,15 @@ define(['$'], function ($) {
         BILLING: addressFields('.js-billing-address'),
         DELIVERY: addressFields('.js-checkout-delivery'),
 
+        $DELIVERY_INSTRUCTIONS: $('textarea[name="deliveryInstructions"]'),
+
+        $TITLE: $('.js-checkout-title .js-input'),
         $FIRST_NAME: $('.js-checkout-first .js-input'),
         $LAST_NAME: $('.js-checkout-last .js-input'),
         $EMAIL: $('.js-checkout-email .js-input'),
         $CONFIRM_EMAIL: $('.js-checkout-confirm-email .js-input'),
         $EMAIL_ERROR: $('.js-checkout-email .js-error-message'),
+        $PHONE: $('.js-checkout-phone-number .js-input'),
 
         // Promo Code:
         $PROMO_CODE : $('.js-promo-code .js-input'),
@@ -100,6 +107,7 @@ define(['$'], function ($) {
         $REVIEW_NAME: $('.js-checkout-review-name'),
         $REVIEW_ADDRESS: $('.js-checkout-review-address'),
         $REVIEW_EMAIL: $('.js-checkout-review-email'),
+        $REVIEW_PHONE: $('.js-checkout-review-phone'),
 
         $FIELDSET_BILLING_ADDRESS: $('.js-fieldset-billing-address'),
         $FIELDSET_PAYMENT_DETAILS: $('.js-fieldset-payment-details'),
@@ -110,6 +118,9 @@ define(['$'], function ($) {
         $REVIEW_CARD_NUMBER: $('.js-checkout-review-card-number'),
         $REVIEW_CARD_EXPIRY: $('.js-checkout-review-card-expiry'),
 
+        $REVIEW_DELIVERY_ADDRESS: $('.js-checkout-review-delivery-address'),
+        $REVIEW_DELIVERY_INSTRUCTIONS: $('.js-checkout-review-delivery-instructions'),
+        $REVIEW_DELIVERY_START_DATE: $('.js-checkout-review-delivery-start-date'),
         $EDIT_YOUR_DETAILS: $('.js-edit-your-details'),
         $EDIT_DELIVERY_DETAILS: $('.js-edit-your-delivery-details'),
         $EDIT_PAYMENT_DETAILS: $('.js-edit-payment-details'),
@@ -118,11 +129,12 @@ define(['$'], function ($) {
         // Paper checkout date picker
         $PAPER_CHECKOUT_DATE_PICKER: $('#deliveryDatePicker'),
         PAPER_CHECKOUT_DATE_PICKER_ID: 'deliveryDatePicker',
-        PAPER_CHECKOUT_DATE_PICKER_FORM_FIELD_NAME: 'startDate',
+        PAPER_CHECKOUT_DATE_PICKER_FORM_FIELD_NAME: _PAPER_CHECKOUT_DATE_PICKER_FORM_FIELD_NAME,
 
         $BASKET: $('.js-basket'),
         $PLAN_INPUTS :_PLAN_INPUTS,
 
-        getRatePlanId: getRatePlanId
+        getRatePlanId: getRatePlanId,
+        getPaperCheckoutField: getPaperCheckoutField
     };
 });

--- a/assets/javascripts/modules/checkout/promoCode.js
+++ b/assets/javascripts/modules/checkout/promoCode.js
@@ -27,9 +27,9 @@ define([
             var $el = $(el),
                 currency = $el.data('currency'),
                 $label = $('#label-for-' + $el.val() + '-' + currency),
-                newDisplayPrice = $el.data('option-mirror-label-default');
+                newDisplayPrice = $el.data('option-mirror-payment-default');
             $label.html(newDisplayPrice);
-            $el.attr('data-option-mirror-label', newDisplayPrice);
+            $el.attr('data-option-mirror-payment', newDisplayPrice);
             if ($el.attr('checked')) {
                 bean.fire(el, 'change');
             }
@@ -46,7 +46,7 @@ define([
 
                 if (adjustedRatePlans[ratePlanId]) {
                     $label.html(adjustedRatePlans[ratePlanId]);
-                    $el.attr('data-option-mirror-label', adjustedRatePlans[ratePlanId]);
+                    $el.attr('data-option-mirror-payment', adjustedRatePlans[ratePlanId]);
                     if ($el.attr('checked')) {
                         bean.fire(el, 'change');
                     }

--- a/assets/javascripts/modules/checkout/reviewDetails.js
+++ b/assets/javascripts/modules/checkout/reviewDetails.js
@@ -33,18 +33,33 @@ define([
     function populateDetails() {
         clickHelper(formEls.$PAYMENT_DETAILS_SUBMIT, function() {
             formEls.$REVIEW_NAME.text(textUtils.mergeValues([
+                formEls.$TITLE.val(),
                 formEls.$FIRST_NAME.val(),
                 formEls.$LAST_NAME.val()
             ], ' '));
+
+            var BILLING_COUNTRY_SELECT = formEls.BILLING.$COUNTRY_SELECT[0];
 
             formEls.$REVIEW_ADDRESS.text(textUtils.mergeValues([
                 formEls.BILLING.$ADDRESS1.val(),
                 formEls.BILLING.$ADDRESS2.val(),
                 formEls.BILLING.$ADDRESS3.val(),
-                formEls.BILLING.$POSTCODE.val()
+                formEls.BILLING.$POSTCODE.val(),
+                BILLING_COUNTRY_SELECT.options[BILLING_COUNTRY_SELECT.selectedIndex].text
+            ], ', '));
+
+            var DELIVERY_COUNTRY_SELECT = formEls.DELIVERY.$COUNTRY_SELECT[0];
+
+            formEls.$REVIEW_DELIVERY_ADDRESS.text(textUtils.mergeValues([
+                formEls.DELIVERY.$ADDRESS1.val(),
+                formEls.DELIVERY.$ADDRESS2.val(),
+                formEls.DELIVERY.$ADDRESS3.val(),
+                formEls.DELIVERY.$POSTCODE.val(),
+                DELIVERY_COUNTRY_SELECT.options[DELIVERY_COUNTRY_SELECT.selectedIndex].text
             ], ', '));
 
             formEls.$REVIEW_EMAIL.text(formEls.$EMAIL.val());
+            formEls.$REVIEW_PHONE.text(formEls.$PHONE.val());
             formEls.$REVIEW_ACCOUNT.text(formEls.$ACCOUNT.val());
             formEls.$REVIEW_SORTCODE.text(formEls.$SORTCODE.val());
             formEls.$REVIEW_HOLDER.text(formEls.$HOLDER.val());
@@ -55,6 +70,9 @@ define([
                 formEls.$CARD_EXPIRY_MONTH.val(),
                 formEls.$CARD_EXPIRY_YEAR.val()
             ], '/'));
+
+            formEls.$REVIEW_DELIVERY_INSTRUCTIONS.text(formEls.$DELIVERY_INSTRUCTIONS.val());
+            formEls.$REVIEW_DELIVERY_START_DATE.text(formEls.getPaperCheckoutField().val());
         });
     }
 
@@ -78,7 +96,7 @@ define([
                 }
 
                 ajax({
-                    url: window.location.href,
+                    url: '/checkout',
                     method: 'post',
                     data: data,
                     success: function(successData) {
@@ -99,7 +117,7 @@ define([
 
                         toggleError(formEls.$CARD_CONTAINER, true);
                     }
-                })
+                });
             }, false);
         }
 

--- a/assets/javascripts/modules/checkout/tracking.js
+++ b/assets/javascripts/modules/checkout/tracking.js
@@ -1,6 +1,8 @@
 define(['$', 'modules/analytics/omniture', 'modules/analytics/snowplow'], function ($, omniture, snowplow) {
     'use strict';
 
+    //TODO make this product aware
+
     function subscriptionProducts(eventName) {
         var selectedFrequency = $('.js-payment-frequency input:checked');
         if (selectedFrequency.length && eventName) {

--- a/assets/javascripts/modules/optionMirror.js
+++ b/assets/javascripts/modules/optionMirror.js
@@ -3,28 +3,32 @@ define(['$'], function ($) {
 
     var selectors = {
         OPTION_GROUP: '.js-option-mirror-group',
-        MIRROR_VALUE: '.js-option-mirror-value'
+        $MIRROR_VALUES: $('.js-option-mirror-payment-display'),
+        $MIRROR_TITLES: $('.js-option-mirror-package-display')
     };
 
-    function mirror(valueElems, input) {
-        var selectedValue = input.getAttribute('data-option-mirror-label');
-        if (selectedValue) {
-            valueElems.each(function (el) {
+    function mirror(input) {
+        var selectedValue = input.getAttribute('data-option-mirror-payment'),
+            selectedTitle = input.getAttribute('data-option-mirror-package');
+        if (selectedValue && selectedTitle) {
+            selectors.$MIRROR_VALUES.each(function (el) {
                 el.textContent = selectedValue;
+            });
+            selectors.$MIRROR_TITLES.each(function (el) {
+                el.textContent = selectedTitle;
             });
         }
     }
 
     var init = function() {
-        var valueElems = $(selectors.MIRROR_VALUE);
         var options = $(selectors.OPTION_GROUP + ' input');
-        if (valueElems && options.length) {
+        if (options.length) {
             options.each(function(option) {
                 option.addEventListener('change', function(e) {
-                    mirror(valueElems, e.target);
+                    mirror(e.target);
                 });
                 if (option.checked) {
-                    mirror(valueElems, option);
+                    mirror(option);
                 }
             });
         }

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.223",
+    "com.gu" %% "membership-common" % "0.227-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.0.0",

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.227-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.229",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.0.0",

--- a/conf/routes
+++ b/conf/routes
@@ -22,17 +22,19 @@ GET         /us/digital                      controllers.DigitalPack.us
 GET         /au/digital                      controllers.DigitalPack.au
 GET         /int/digital                     controllers.DigitalPack.int
 
-# Checkout
-GET         /checkout/paper                  controllers.Checkout.renderPaperCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode])
-GET         /checkout                        controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], product: com.gu.memsub.ProductFamily = com.gu.memsub.Digipack)
-POST        /checkout/paper                  controllers.Checkout.handlePaperCheckout
-POST        /checkout                        controllers.Checkout.handleCheckout(allowPaper: Boolean = false)
+# Checkout AJAX endpoints
+POST        /checkout                        controllers.Checkout.handleCheckout
 GET         /checkout/check-identity         controllers.Checkout.checkIdentity(email: String)
 POST        /checkout/check-account          controllers.Checkout.checkAccount
 POST        /checkout/register-guest-user    controllers.Checkout.convertGuestUser
-GET         /checkout/thank-you              controllers.Checkout.thankYou
-
 GET         /checkout/lookupPromotion        controllers.Checkout.validatePromoCode(promoCode: PromoCode, productRatePlanId: ProductRatePlanId, country: Country)
+
+# Checkout pages
+GET         /checkout                        controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode])
+GET         /checkout/thank-you              controllers.Checkout.thankYouDigipack
+GET         /checkout/paper/thank-you        controllers.Checkout.thankYouPaper
+GET         /checkout/paper/:forThisPlan     controllers.Checkout.renderPaperCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], forThisPlan: String)
+
 # collection and delivery
 GET         /collection/paper-digital        controllers.Shipping.viewCollectionPaperDigital
 GET         /collection/paper                controllers.Shipping.viewCollectionPaper


### PR DESCRIPTION
Sorry for the humungous PR, lots of text and copy related changes included here too.

New stuff for paper:
- New route URLs to allow us to deeplink into checkout flows for a particular package.
- Added ability for user to select the corresponding "plus" package, and change the UI to reflect.
- Updating the Review and confirm section, adding the new delivery address fields and others which we've forgotten like title and phone number.
- Tweaked layout of thank you page to be contextual to subscription, displaying the product rate plan description, etc.

Changes affecting digipack:
- Updated the subscription details and page when selecting rate plans.
- Updated the POST JavaScript to use /checkout AJAX endpoint for all products.
- Added buttons on /test-users page.
- Rationalised the routes file, adding some new routes, and updated redirect logic.
- Fixed the double 'the' on the checkout page heading.
- Updated the HTML &lt;title&gt; text to be product-aware and be more SEO friendly.

Still to do (will raise tickets in Trello):

- Have 6 TODOs below to work on, but I'm submitting PR to allow for early review about approach.
- Emails
- Redirects/confirmation of the digipack checkout URLs once analytics have been tweaked.

cc @nlindblad @tomverran 
