### PR TITLE
Fixing country select and county review

### DIFF
--- a/app/views/fragments/checkout/address.scala.html
+++ b/app/views/fragments/checkout/address.scala.html
@@ -38,18 +38,7 @@
             value="@address.map(_.town)" maxlength="40" required>
         @fragments.forms.errorMessage("This field is required")
     </div>
-    <div class="form-field js-checkout-subdivision">
-        <label class="label" @labelFor("subdivision")>County</label>
-        <select @attrs("subdivision")></select>
-        @fragments.forms.errorMessage("Please enter a valid state/county")
-    </div>
-    <div class="form-field js-checkout-postcode">
-        <label class="label" @labelFor("postcode")>Postcode</label>
-        <input type="text" class="input-text js-input input-text input-text--small" @attrs("postcode")
-        value="@address.map(_.postCode)" maxlength="10" required>
-        @fragments.forms.errorMessage("Please enter a valid postal code")
-    </div>
-    <div class="form-field">
+    <div class="form-field js-checkout-country">
         <label class="label" @labelFor("country")>Country</label>
         <select @attrs("country") class=" select select--wide js-country" required>
             <option data-currency-choice="USD"></option>
@@ -58,6 +47,17 @@
             }
         </select>
         @fragments.forms.errorMessage("This field is required")
+    </div>
+    <div class="form-field js-checkout-subdivision">
+        <label class="label" @labelFor("subdivision")>County</label>
+        <select @attrs("subdivision") class="js-input"></select>
+        @fragments.forms.errorMessage("Please enter a valid state/county")
+    </div>
+    <div class="form-field js-checkout-postcode">
+        <label class="label" @labelFor("postcode")>Postcode</label>
+        <input type="text" class="input-text js-input input-text input-text--small" @attrs("postcode")
+        value="@address.map(_.postCode)" maxlength="10" required>
+        @fragments.forms.errorMessage("Please enter a valid postal code")
     </div>
 </div>
 

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -17,10 +17,10 @@
     </div>
     @productData.paper.map { p =>
         <div class="review-details__item">
-            <span class="review-details__heading">Delivery address</span>
+            <span class="review-details__heading">Deliver to</span>
             <div class="js-checkout-review-delivery-address sessioncamhidetext"></div>
             <div><span class="review-details__detail">Delivery instructions:</span> <span class="js-checkout-review-delivery-instructions sessioncamhidetext"></span></div>
-            <div><span class="review-details__detail">Date of first paper delivery:</span> <span class="js-checkout-review-delivery-start-date"></span></div>
+            <div><span class="review-details__detail">Date of first paper:</span> <span class="js-checkout-review-delivery-start-date"></span></div>
         </div>
     }
     <div class="review-details__item">

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -10,7 +10,6 @@
         <div class="review-details__list">
             <ul class="o-unstyled-list">
                 <li class="js-checkout-review-name sessioncamhidetext"></li>
-                <li class="js-checkout-review-address sessioncamhidetext"></li>
                 <li><span class="review-details__detail">Email:</span> <span class="js-checkout-review-email sessioncamhidetext"></span></li>
                 <li><span class="review-details__detail">Phone:</span> <span class="js-checkout-review-phone sessioncamhidetext"></span></li>
             </ul>
@@ -18,12 +17,20 @@
     </div>
     @productData.paper.map { p =>
         <div class="review-details__item">
-            <span class="review-details__heading">Delivery details</span>
+            <span class="review-details__heading">Delivery address</span>
             <div class="js-checkout-review-delivery-address sessioncamhidetext"></div>
             <div><span class="review-details__detail">Delivery instructions:</span> <span class="js-checkout-review-delivery-instructions sessioncamhidetext"></span></div>
             <div><span class="review-details__detail">Date of first paper delivery:</span> <span class="js-checkout-review-delivery-start-date"></span></div>
         </div>
     }
+    <div class="review-details__item">
+        <span class="review-details__heading">Billing address</span>
+        <div class="review-details__list">
+            <ul class="o-unstyled-list">
+                <li class="js-checkout-review-address sessioncamhidetext"></li>
+            </ul>
+        </div>
+    </div>
     <div class="review-details__item">
         <span class="review-details__heading">Payment details</span>
         <div class="review-details__list js-payment-type-direct-debit">

--- a/assets/javascripts/modules/checkout/addressFields.js
+++ b/assets/javascripts/modules/checkout/addressFields.js
@@ -29,6 +29,7 @@ define([], function () {
     var textInput = function (required, name) {
         var input = formField(required, name, 'input');
         input.classList.add('input-text');
+        input.classList.add('js-input');
         input.type = 'text';
         return input;
     };
@@ -36,6 +37,7 @@ define([], function () {
     var selectInput = function (required, name, values) {
         var select = formField(required, name, 'select');
         select.classList.add('select--wide');
+        select.classList.add('js-input');
         select.appendChild(document.createElement('option'));
         values.forEach(function(value) {
             var o = document.createElement('option');

--- a/assets/javascripts/modules/checkout/fieldSwitcher.js
+++ b/assets/javascripts/modules/checkout/fieldSwitcher.js
@@ -28,26 +28,35 @@ define([
             });
         };
 
+        var redrawAddressField = function($container, newField, modelValue) {
+
+            $('.js-input', $container).replaceWith(newField.input);
+            $('label', $container).replaceWith(newField.label);
+
+            if (newField.label.textContent === '') {
+                newField.input.value = '';
+                $container.hide();
+            } else {
+                newField.input.value = modelValue;
+                $container.show();
+            }
+        };
+
         var redrawAddressFields = function(model) {
 
             var newPostcode = addressFields.postcode(
-                addressObject.$POSTCODE.attr('name'),
+                addressObject.getPostcode$().attr('name'),
                 model.postcodeRules.required,
                 model.postcodeRules.label);
 
             var newSubdivision = addressFields.subdivision(
-                $('input, select', $subdivision).attr('name'),
+                addressObject.getSubdivision$().attr('name'),
                 model.subdivisionRules.required,
                 model.subdivisionRules.label,
                 model.subdivisionRules.values);
 
-            newPostcode.input.value = model.postcode;
-
-            $('input', $postcode).replaceWith(newPostcode.input);
-            $('label', $postcode).replaceWith(newPostcode.label);
-
-            $('input, select', $subdivision).replaceWith(newSubdivision.input);
-            $('label', $subdivision).replaceWith(newSubdivision.label);
+            redrawAddressField($postcode, newPostcode, model.postcode);
+            redrawAddressField($subdivision, newSubdivision, model.subdivision);
         };
 
         // Change the payment method to Direct Debit for UK users,
@@ -79,6 +88,7 @@ define([
             return {
                 postcode: $('input', $postcode).val(),
                 postcodeRules: rules.postcode,
+                subdivision: $('input', $subdivision).val(),
                 subdivisionRules: rules.subdivision,
                 currency: currentCountryOption.attr('data-currency-choice'),
                 country: currentCountryOption.val(),

--- a/assets/javascripts/modules/checkout/formElements.js
+++ b/assets/javascripts/modules/checkout/formElements.js
@@ -20,7 +20,8 @@ define(['$'], function ($) {
         var container = $CONTAINER[0];
         var $ADDRESS1_CONTAINER = $('.js-checkout-house', container);
         var $ADDRESS2_CONTAINER = $('.js-checkout-street', container);
-        var $ADDRESS3_CONTAINER = $('.js-checkout-town', container);
+        var $TOWN_CONTAINER = $('.js-checkout-town', container);
+        var $COUNTRY_CONTAINER = $('.js-checkout-country', container);
         var $SUBDIVISION_CONTAINER = $('.js-checkout-subdivision', container);
         var $POSTCODE_CONTAINER = $('.js-checkout-postcode', container);
 
@@ -28,16 +29,17 @@ define(['$'], function ($) {
             $CONTAINER: $CONTAINER,
             $ADDRESS1_CONTAINER: $ADDRESS1_CONTAINER,
             $ADDRESS2_CONTAINER: $ADDRESS2_CONTAINER,
-            $ADDRESS3_CONTAINER: $ADDRESS3_CONTAINER,
+            $TOWN_CONTAINER: $TOWN_CONTAINER,
+            $COUNTRY_CONTAINER: $COUNTRY_CONTAINER,
             $SUBDIVISION_CONTAINER: $SUBDIVISION_CONTAINER,
             $POSTCODE_CONTAINER: $POSTCODE_CONTAINER,
 
             $ADDRESS1: $('.js-input', $ADDRESS1_CONTAINER[0]),
             $ADDRESS2: $('.js-input', $ADDRESS2_CONTAINER[0]),
-            $ADDRESS3: $('.js-input', $ADDRESS3_CONTAINER[0]),
-            $POSTCODE: $('.js-input', $POSTCODE_CONTAINER[0]),
-            $SUBDIVISION: $('select', $SUBDIVISION_CONTAINER[0]),
-            $COUNTRY_SELECT: $('.js-country', container)
+            $TOWN: $('.js-input', $TOWN_CONTAINER[0]),
+            $COUNTRY_SELECT: $('.js-country', $COUNTRY_CONTAINER[0]),
+            getPostcode$: function() { return $('.js-input', $POSTCODE_CONTAINER[0]); },
+            getSubdivision$: function() { return $('.js-input', $SUBDIVISION_CONTAINER[0]); }
         };
     };
 

--- a/assets/javascripts/modules/checkout/reviewDetails.js
+++ b/assets/javascripts/modules/checkout/reviewDetails.js
@@ -39,22 +39,27 @@ define([
             ], ' '));
 
             var BILLING_COUNTRY_SELECT = formEls.BILLING.$COUNTRY_SELECT[0];
-
-            formEls.$REVIEW_ADDRESS.text(textUtils.mergeValues([
-                formEls.BILLING.$ADDRESS1.val(),
-                formEls.BILLING.$ADDRESS2.val(),
-                formEls.BILLING.$ADDRESS3.val(),
-                formEls.BILLING.$POSTCODE.val(),
-                BILLING_COUNTRY_SELECT.options[BILLING_COUNTRY_SELECT.selectedIndex].text
-            ], ', '));
-
+            if (BILLING_COUNTRY_SELECT.disabled) {
+                formEls.$REVIEW_ADDRESS.text('Same as Delivery address');
+            } else {
+                formEls.$REVIEW_ADDRESS.text(textUtils.mergeValues([
+                    formEls.BILLING.$ADDRESS1.val(),
+                    formEls.BILLING.$ADDRESS2.val(),
+                    formEls.BILLING.$TOWN.val(),
+                    formEls.BILLING.getSubdivision$().val(),
+                    formEls.BILLING.getPostcode$().val(),
+                    BILLING_COUNTRY_SELECT.options[BILLING_COUNTRY_SELECT.selectedIndex].text
+                ], ', '));
+            }
+            
             var DELIVERY_COUNTRY_SELECT = formEls.DELIVERY.$COUNTRY_SELECT[0];
 
             formEls.$REVIEW_DELIVERY_ADDRESS.text(textUtils.mergeValues([
                 formEls.DELIVERY.$ADDRESS1.val(),
                 formEls.DELIVERY.$ADDRESS2.val(),
-                formEls.DELIVERY.$ADDRESS3.val(),
-                formEls.DELIVERY.$POSTCODE.val(),
+                formEls.DELIVERY.$TOWN.val(),
+                formEls.DELIVERY.getSubdivision$().val(),
+                formEls.DELIVERY.getPostcode$().val(),
                 DELIVERY_COUNTRY_SELECT.options[DELIVERY_COUNTRY_SELECT.selectedIndex].text
             ], ', '));
 

--- a/test/js/spec/modules/checkout/AddressFields.spec.js
+++ b/test/js/spec/modules/checkout/AddressFields.spec.js
@@ -14,7 +14,7 @@ define(['modules/checkout/addressFields'], function (addressFields) {
             var output = addressFields.postcode('personal.address.postcode', true, 'Postcode');
 
             expect(output.input.isEqualNode(dom(
-                '<input type="text" id="personal-address-postcode" name="personal.address.postcode" class="input-text" required="required">'
+                '<input type="text" id="personal-address-postcode" name="personal.address.postcode" class="input-text js-input" required="required">'
             ))).toBeTruthy();
 
             expect(output.label.isEqualNode(dom(
@@ -25,7 +25,7 @@ define(['modules/checkout/addressFields'], function (addressFields) {
         it('should generate an optional postcode field with the right label', function () {
             var output = addressFields.postcode('personal.address.postcode', false, 'Zipcode');
             expect(output.input.isEqualNode(dom(
-                '<input type="text" id="personal-address-postcode" class="input-text" name="personal.address.postcode">'
+                '<input type="text" id="personal-address-postcode" class="input-text js-input" name="personal.address.postcode">'
             ))).toBeTruthy();
 
             expect(output.label.isEqualNode(dom(
@@ -37,7 +37,7 @@ define(['modules/checkout/addressFields'], function (addressFields) {
             var output = addressFields.subdivision('personal.address.subdivision', true, 'Province', []);
 
             expect(output.input.isEqualNode(dom(
-                '<input type="text" id="personal-address-subdivision" name="personal.address.subdivision" class="input-text" required="required">'
+                '<input type="text" id="personal-address-subdivision" name="personal.address.subdivision" class="input-text js-input" required="required">'
             ))).toBeTruthy();
 
             expect(output.label.isEqualNode(dom(
@@ -49,7 +49,7 @@ define(['modules/checkout/addressFields'], function (addressFields) {
             var output = addressFields.subdivision('personal.address.subdivision', true, 'Province', ['Bromley']);
 
             expect(output.input.isEqualNode(dom(
-                '<select id="personal-address-subdivision" name="personal.address.subdivision" class="select--wide" required="required">' +
+                '<select id="personal-address-subdivision" name="personal.address.subdivision" class="select--wide js-input" required="required">' +
                     '<option></option>' +
                     '<option value="Bromley">Bromley</option>' +
                 '</select>'


### PR DESCRIPTION
- Moved country select up above the fields it affects. This creates a better UX when filling out the form.
- For digipack and paper: Fixed bug where county/state was missing in review address section.
- For paper subs: Added note to confirm that billing address is same as delivery.
- Made review sections be in same order as form.

![picture 142](https://cloud.githubusercontent.com/assets/1515970/16654777/3ca8a676-444f-11e6-8932-bd0f3193ce9a.png)
![picture 141](https://cloud.githubusercontent.com/assets/1515970/16654776/3ca32142-444f-11e6-9abc-a7c3e81088a1.png)

cc @tomverran @nlindblad 

