### PR TITLE
Exact target changes for paper delivery

### DIFF
--- a/app/model/exactTarget/DataExtensionRow.scala
+++ b/app/model/exactTarget/DataExtensionRow.scala
@@ -9,7 +9,7 @@ import utils.Dates
 
 import scala.math.BigDecimal.decimal
 
-object SubscriptionDataExtensionRow extends LazyLogging {
+object DataExtensionRow extends LazyLogging {
 
   def apply(
              personalData: PersonalData,
@@ -18,7 +18,7 @@ object SubscriptionDataExtensionRow extends LazyLogging {
              gracePeriod: Days,
              subscriptionDetails: String,
              promotionDescription: Option[String] = None
-  ): SubscriptionDataExtensionRow = {
+  ): DataExtensionRow = {
 
 
     val address = personalData.address
@@ -39,7 +39,7 @@ object SubscriptionDataExtensionRow extends LazyLogging {
 
     val promotionFields = promotionDescription.map(d => "Promotion description" -> d.substring(0, Math.min(d.length, 255)))
 
-    SubscriptionDataExtensionRow(
+    DataExtensionRow(
       personalData.email,
       Seq(
         "ZuoraSubscriberId" -> subscription.name.get,
@@ -88,8 +88,4 @@ object SubscriptionDataExtensionRow extends LazyLogging {
     sortCode.filter(_.isDigit).grouped(2).mkString("-")
 }
 
-trait DataExtensionRow {
-  def fields: Seq[(String, String)]
-}
-
-case class SubscriptionDataExtensionRow(email: String, fields: Seq[(String, String)]) extends DataExtensionRow
+case class DataExtensionRow(email: String, fields: Seq[(String, String)])

--- a/app/model/exactTarget/DataExtensionRow.scala
+++ b/app/model/exactTarget/DataExtensionRow.scala
@@ -1,69 +1,30 @@
 package model.exactTarget
-import com.gu.memsub.Subscription
+
+import java.lang.Math.min
+
+import com.gu.memsub._
+import com.gu.exacttarget._
 import com.gu.memsub.Subscription._
 import com.typesafe.scalalogging.LazyLogging
-import com.gu.memsub.PaymentMethod
+import model.exactTarget.DataExtensionRowHelpers._
 import org.joda.time.{Days, LocalDate}
-import model.PersonalData
+import model.{PaperData, PersonalData}
+import org.joda.time.Days.daysBetween
 import utils.Dates
 
 import scala.math.BigDecimal.decimal
 
-object DataExtensionRow extends LazyLogging {
+trait DataExtensionRow {
+  def email: String
+  def fields: Seq[(String, String)]
+  def forExtension: DataExtension
+}
 
-  def apply(
-             personalData: PersonalData,
-             subscription: Subscription with Paid,
-             paymentMethod: PaymentMethod,
-             gracePeriod: Days,
-             subscriptionDetails: String,
-             promotionDescription: Option[String] = None
-  ): DataExtensionRow = {
+object DataExtensionRowHelpers {
+  val dd = "Direct Debit"
+  val card = "Credit/Debit Card"
 
-
-    val address = personalData.address
-    val paymentDelay = Days.daysBetween(subscription.startDate, subscription.firstPaymentDate).minus(gracePeriod)
-
-    val paymentFields = paymentMethod match {
-      case com.gu.memsub.GoCardless(mandateId, accName, accNumber, sortCode) => Seq(
-          "Account number" -> formatAccountNumber(accNumber),
-          "Sort Code" -> formatSortCode(sortCode),
-          "Account Name" -> accName,
-          "Default payment method" -> "Direct Debit",
-          "MandateID" -> mandateId
-        )
-      case _: com.gu.memsub.PaymentCard => Seq(
-        "Default payment method" -> "Credit/Debit Card"
-      )
-    }
-
-    val promotionFields = promotionDescription.map(d => "Promotion description" -> d.substring(0, Math.min(d.length, 255)))
-
-    DataExtensionRow(
-      personalData.email,
-      Seq(
-        "ZuoraSubscriberId" -> subscription.name.get,
-        "SubscriberKey" -> personalData.email,
-        "EmailAddress" -> personalData.email,
-        "Subscription term" -> subscription.plan.billingPeriod.noun,
-        "Payment amount" -> formatPrice(subscription.recurringPrice.amount),
-        "First Name" -> personalData.first,
-        "Last Name" -> personalData.last,
-        "Address 1" -> address.lineOne,
-        "Address 2" -> address.lineTwo,
-        "City" -> address.town,
-        "Post Code" -> address.postCode,
-        "Country" -> address.country.fold(address.countryName)(_.name),
-        "Date of first payment" -> formatDate(subscription.firstPaymentDate),
-        "Currency" -> personalData.currency.glyph,
-        "Trial period" -> paymentDelay.getDays.toString,
-        "Email" -> personalData.email,
-        "Subscription details" -> subscriptionDetails
-      ) ++ paymentFields ++ promotionFields
-    )
-  }
-
-  private def formatDate(dateTime: LocalDate) = {
+  def formatDate(dateTime: LocalDate) = {
     val day = dateTime.dayOfMonth.get
 
     val dayWithSuffix = Dates.getOrdinalDay(day)
@@ -75,17 +36,134 @@ object DataExtensionRow extends LazyLogging {
     s"$dayWithSuffix $month $year"
   }
 
-  private def formatPrice(price: Float): String = {
+  def formatPrice(price: Float): String = {
     decimal(price).bigDecimal.stripTrailingZeros.toPlainString
   }
 
-  private def formatAccountNumber(AccountNumber: String): String = {
+  def formatAccountNumber(AccountNumber: String): String = {
     val lastFour = AccountNumber takeRight 4
     s"****$lastFour"
   }
 
-  private def formatSortCode(sortCode: String): String =
+  def formatSortCode(sortCode: String): String =
     sortCode.filter(_.isDigit).grouped(2).mkString("-")
+
+  def trimPromotionDescription(p: String): String = p.substring(0, min(p.length, 255))
 }
 
-case class DataExtensionRow(email: String, fields: Seq[(String, String)])
+object DigipackWelcome1DataExtensionRow extends LazyLogging {
+
+  def apply(
+             personalData: PersonalData,
+             subscription: Subscription with Paid,
+             paymentMethod: PaymentMethod,
+             gracePeriod: Days,
+             subscriptionDetails: String,
+             promotionDescription: Option[String] = None
+           ): DigipackWelcome1DataExtensionRow = {
+
+    val paymentDelay = daysBetween(subscription.startDate, subscription.firstPaymentDate).minus(gracePeriod)
+
+    val paymentFields = paymentMethod match {
+      case GoCardless(mandateId, accName, accNumber, sortCode) => Seq(
+        "Account number" -> formatAccountNumber(accNumber),
+        "Sort Code" -> formatSortCode(sortCode),
+        "Account Name" -> accName,
+        "Default payment method" -> dd,
+        "MandateID" -> mandateId
+      )
+      case _: PaymentCard => Seq("Default payment method" -> card)
+    }
+
+    val promotionFields = promotionDescription.map(d => "Promotion description" -> trimPromotionDescription(d))
+
+    DigipackWelcome1DataExtensionRow(
+      personalData.email,
+      Seq(
+        "ZuoraSubscriberId" -> subscription.name.get,
+        "SubscriberKey" -> personalData.email,
+        "EmailAddress" -> personalData.email,
+        "Subscription term" -> subscription.plan.billingPeriod.noun,
+        "Payment amount" -> formatPrice(subscription.recurringPrice.amount),
+        "First Name" -> personalData.first,
+        "Last Name" -> personalData.last,
+        "Address 1" -> personalData.address.lineOne,
+        "Address 2" -> personalData.address.lineTwo,
+        "City" -> personalData.address.town,
+        "Post Code" -> personalData.address.postCode,
+        "Country" -> personalData.address.country.fold(personalData.address.countryName)(_.name),
+        "Date of first payment" -> formatDate(subscription.firstPaymentDate),
+        "Currency" -> personalData.currency.glyph,
+        "Trial period" -> paymentDelay.getDays.toString,
+        "Subscription details" -> subscriptionDetails
+      ) ++ paymentFields ++ promotionFields
+    )
+  }
+
+
+}
+
+object PaperHomeDeliveryWelcome1DataExtensionRow {
+  def apply(
+             paperData: PaperData,
+             personalData: PersonalData,
+             subscription: Subscription with Paid,
+             paymentMethod: PaymentMethod,
+             subscriptionDetails: String,
+             promotionDescription: Option[String] = None
+           ): PaperHomeDeliveryWelcome1DataExtensionRow = {
+
+    val paymentFields = paymentMethod match {
+      case GoCardless(mandateId, accName, accNumber, sortCode) => Seq(
+        "bank_account_no" -> formatAccountNumber(accNumber),
+        "bank_sort_code" -> formatSortCode(sortCode),
+        "account_holder" -> accName,
+        "payment_method" -> dd,
+        "mandate_id" -> mandateId
+      )
+      case _: PaymentCard => Seq("payment_method" -> card)
+    }
+
+    val promotionFields = promotionDescription.map(d => "promotion_details" -> trimPromotionDescription(d))
+
+    val billingAddressFields =
+      if (!personalData.address.equals(paperData.deliveryAddress)) Seq(
+        "billing_address_line_1" -> personalData.address.lineOne,
+        "billing_address_line_2" -> personalData.address.lineTwo,
+        "billing_address_town" -> personalData.address.town,
+        "billing_county" -> personalData.address.countyOrState,
+        "billing_postcode" -> personalData.address.postCode,
+        "billing_country" -> personalData.address.country.fold(personalData.address.countryName)(_.name)
+      ) else Seq.empty
+
+    PaperHomeDeliveryWelcome1DataExtensionRow(
+      personalData.email,
+      Seq(
+        "SubscriberKey" -> personalData.email,
+        "EmailAddress" -> personalData.email,
+        "subscriber_id" -> subscription.name.get,
+        "includes_digipack" -> paperData.plan.products.others.contains(Digipack).toString,
+        "title" -> personalData.title.fold("")(_.title),
+        "first_name" -> personalData.first,
+        "last_name" -> personalData.last,
+        "delivery_address_line_1" -> paperData.deliveryAddress.lineOne,
+        "delivery_address_line_2" -> paperData.deliveryAddress.lineTwo,
+        "delivery_address_town" -> paperData.deliveryAddress.town,
+        "delivery_county" -> paperData.deliveryAddress.countyOrState,
+        "delivery_postcode" -> paperData.deliveryAddress.postCode,
+        "delivery_country" -> paperData.deliveryAddress.country.fold(paperData.deliveryAddress.countryName)(_.name),
+        "date_of_first_payment" -> formatDate(subscription.firstPaymentDate),
+        "subscription_package" -> paperData.plan.name,
+        "subscription_rate" -> subscriptionDetails
+      ) ++ billingAddressFields ++ paymentFields ++ promotionFields
+    )
+  }
+}
+
+case class DigipackWelcome1DataExtensionRow(email: String, fields: Seq[(String, String)]) extends DataExtensionRow {
+  override def forExtension = DigipackDataExtension
+}
+
+case class PaperHomeDeliveryWelcome1DataExtensionRow(email: String, fields: Seq[(String, String)]) extends DataExtensionRow {
+  override def forExtension = PaperDeliveryDataExtension
+}

--- a/app/model/exactTarget/DataExtensionRow.scala
+++ b/app/model/exactTarget/DataExtensionRow.scala
@@ -139,6 +139,7 @@ object PaperHomeDeliveryWelcome1DataExtensionRow {
     PaperHomeDeliveryWelcome1DataExtensionRow(
       personalData.email,
       Seq(
+        "ZuoraSubscriberId" -> subscription.name.get,
         "SubscriberKey" -> personalData.email,
         "EmailAddress" -> personalData.email,
         "subscriber_id" -> subscription.name.get,

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -14,7 +14,7 @@ import com.gu.zuora.soap.models.Results.SubscribeResult
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import model.SubscribeRequest
-import model.exactTarget.SubscriptionDataExtensionRow
+import model.exactTarget.DataExtensionRow
 import org.joda.time.Days
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
@@ -63,7 +63,7 @@ trait ExactTargetService extends LazyLogging {
     for {
       sub <- subscription
       pm <- paymentMethod
-      row = SubscriptionDataExtensionRow(
+      row = DataExtensionRow(
         personalData = subscriptionData.genericData.personalData,
         subscription = sub,
         paymentMethod = pm,
@@ -85,7 +85,7 @@ object SqsClient extends LazyLogging {
   private val sqsClient = new AmazonSQSClient()
   sqsClient.setRegion(Region.getRegion(Regions.EU_WEST_1))
 
-  def sendWelcomeEmailToQueue(row: SubscriptionDataExtensionRow): Future[Try[SendMessageResult]] = {
+  def sendWelcomeEmailToQueue(row: DataExtensionRow): Future[Try[SendMessageResult]] = {
     Future {
       val payload = Json.obj(
         "To" -> Json.obj(

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -112,7 +112,7 @@ object SqsClient extends LazyLogging {
       ).toString()
 
       def sendToQueue(msg: String): SendMessageResult = {
-        val queueUrl = sqsClient.createQueue(new CreateQueueRequest(Config.welcomeEmailQueue)).getQueueUrl()
+        val queueUrl = sqsClient.createQueue(new CreateQueueRequest(Config.welcomeEmailQueue)).getQueueUrl
         sqsClient.sendMessage(new SendMessageRequest(queueUrl, msg))
       }
 


### PR DESCRIPTION
Put the relevantly formatted JSON message onto the subs-welcome-email queue, plus a field to determine which type of message it is, so that the workflow service can broker it to the right Exact 
Target Data Extension.

cc @mario-galic @tomverran 