### PR TITLE
Support tracking codes on the subs checkout

### DIFF
--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -1,10 +1,10 @@
 package forms
 
 import com.gu.i18n.{CountryGroup, Title}
-import com.gu.memsub.promo.PromoCode
+import com.gu.memsub.promo.{NewUsers, PromoCode, ValidPromotion}
 import com.gu.memsub.{Address, BillingPeriod, Current}
 import com.gu.memsub.Subscription.ProductRatePlanId
-import com.gu.memsub.services.CatalogService
+import com.gu.memsub.services.{CatalogService, PromoService}
 import com.gu.subscriptions.{DigipackPlan, DigitalProducts, PhysicalProducts, ProductPlan}
 import model._
 import play.api.data.format.Formats._

--- a/app/model/error/CheckoutService.scala
+++ b/app/model/error/CheckoutService.scala
@@ -1,7 +1,7 @@
 package model.error
 
 import com.gu.identity.play.IdMinimalUser
-import com.gu.memsub.promo.PromoCode
+import com.gu.memsub.promo.{NewUsers, PromoCode, ValidPromotion}
 import com.gu.salesforce.ContactId
 import com.gu.zuora.soap.models.Results.SubscribeResult
 import com.gu.zuora.soap.models.errors.PaymentGatewayError
@@ -13,11 +13,11 @@ object CheckoutService {
   sealed trait CheckoutResult
 
   case class CheckoutSuccess(
-      salesforceMember: ContactId,
-      userIdData: Option[UserIdData],
-      subscribeResult: SubscribeResult,
-      validPromoCode: Option[PromoCode],
-      nonFatalErrors: Seq[SubsError]) extends CheckoutResult
+    salesforceMember: ContactId,
+    userIdData: Option[UserIdData],
+    subscribeResult: SubscribeResult,
+    validPromotion: Option[ValidPromotion[NewUsers]],
+    nonFatalErrors: Seq[SubsError]) extends CheckoutResult
 
   case class CheckoutIdentityFailure(
       msg: String,

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -69,7 +69,7 @@ class CheckoutService(identityService: IdentityService,
       withPromo = validPromotion.map(v => p.apply(v, subscribe, catalogService.digipackCatalog.unsafeFindPaid, promoPlans)).getOrElse(subscribe)
       result <- EitherT(createSubscription(withPromo, purchaserIds))
       out <- postSubscribeSteps(authenticatedUserOpt, memberId, result, subscriptionData, validPromotion)
-    } yield CheckoutSuccess(memberId, out._1, result, validPromotion.map(_.code), out._2)).run
+    } yield CheckoutSuccess(memberId, out._1, result, validPromotion, out._2)).run
   }
 
   def postSubscribeSteps(user: Option[AuthenticatedIdUser],


### PR DESCRIPTION
It doesn't look like the subs checkout ever worked with tracking codes(!)

Hence this PR

 - Puts tracking codes from `?promoCode=blah` into the session
 - Fills in `suppliedPromoCode` with the tracking code if there's no promo code
 - Filters out tracking codes on the thank you page