### PR TITLE
Fix typos

### DIFF
--- a/app/views/fragments/global/footer.scala.html
+++ b/app/views/fragments/global/footer.scala.html
@@ -27,14 +27,14 @@
             } else {
                 <p>
                   For help with Guardian and Observer subscription services please email
-                      <a href="mailto:@plan.fold("subscriptions@theguardian.com")(_.email)">@plan.fold("subscriptions@theguardian.com")(_.email)</a> or call @plan.fold("+44 (0) 330 333 6767.")(_.phone). Open BST 8am to 8pm, Monday to Sunday.
+                      <a href="mailto:@plan.fold("subscriptions@theguardian.com")(_.email)">@plan.fold("subscriptions@theguardian.com")(_.email)</a> or call @plan.fold("+44 (0) 330 333 6767")(_.phone). Open BST 8am to 8pm, Monday to Sunday.
                 </p>
                 <p>
                     You may also find help in our
                     <a href="@Links.guardianSubscriptionFaqs.href"
                        title="@Links.guardianSubscriptionFaqs.title">
-                       @Links.guardianSubscriptionFaqs.title
-                    </a>.
+                       @Links.guardianSubscriptionFaqs.title.
+                    </a>
                 </p>
             }
             <small class="global-footer__copyright">


### PR DESCRIPTION
Remove extra period and an extra space in the footer:

![image](https://cloud.githubusercontent.com/assets/13835317/16956189/5b8970c8-4dcf-11e6-8688-9dd259a5147c.png)
