### PR TITLE
Tweaks for Google Analytics ready for migration

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -121,4 +121,6 @@ object Config {
   val previewXFrameOptionsOverride = config.getString("subscriptions.preview-x-frame-options-override")
 
   val welcomeEmailQueue = config.getString("aws.queue.welcome-email")
+
+  val googleAnalyticsTrackingId = config.getString("google.analytics.tracking.id")
 }

--- a/app/views/fragments/javascriptFirstSteps.scala.html
+++ b/app/views/fragments/javascriptFirstSteps.scala.html
@@ -17,6 +17,10 @@
     guardian.analyticsEnabled = true;
     guardian.buildNumber = '@app.BuildInfo.buildNumber';
     guardian.isDev = @(Config.stage == "DEV");
+    guardian.googleAnalytics = {
+        trackingId: '@Config.googleAnalyticsTrackingId',
+        cookieDomain: @if(Config.stage == "PROD") { 'auto' } else { 'none' }
+    };
     guardian.isModernBrowser =  (
         'querySelector' in document
         && 'addEventListener' in window

--- a/assets/javascripts/modules/analytics/ga.js
+++ b/assets/javascripts/modules/analytics/ga.js
@@ -21,6 +21,9 @@ define(['utils/cookie',
             'cookieDomain': guardian.googleAnalytics.cookieDomain
         });
 
+        ga('require', 'linker');
+        ga('linker:autoLink', ['eventbrite.co.uk'] ); // for consistency with the rest of membership sites
+
         /**
          * Enable enhanced link attribution
          * https://support.google.com/analytics/answer/2558867?hl=en-GB

--- a/assets/javascripts/modules/analytics/ga.js
+++ b/assets/javascripts/modules/analytics/ga.js
@@ -16,9 +16,19 @@ define(['utils/cookie',
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
         /*eslint-enable */
 
-        ga('create', 'UA-51507017-5', 'auto');
-        ga('set', 'dimension1', identitySignedIn.toString());
-        ga('set', 'dimension2', identitySignedOut.toString());
+        ga('create', guardian.googleAnalytics.trackingId, {
+            'allowLinker': true,
+            'cookieDomain': guardian.googleAnalytics.cookieDomain
+        });
+
+        /**
+         * Enable enhanced link attribution
+         * https://support.google.com/analytics/answer/2558867?hl=en-GB
+         */
+        ga('require', 'linkid', 'linkid.js');
+
+        ga('set', 'dimension1', identitySignedIn.toString());   // deprecated
+        ga('set', 'dimension2', identitySignedOut.toString());  // deprecated
         ga('send', 'pageview');
 
         ga('create', 'UA-44575989-1', 'auto', 'jellyfishGA');

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -31,4 +31,4 @@ qa {
 //aws.queue.welcome-email = "subs-welcome-email-dev"
 aws.queue.welcome-email = "subs-welcome-email"
 
-google.analytics.tracking.id="UA-51507017-4"
+google.analytics.tracking.id="UA-33592456-4"

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -30,3 +30,5 @@ qa {
 
 //aws.queue.welcome-email = "subs-welcome-email-dev"
 aws.queue.welcome-email = "subs-welcome-email"
+
+google.analytics.tracking.id="UA-51507017-4"

--- a/conf/PROD.conf
+++ b/conf/PROD.conf
@@ -18,3 +18,5 @@ touchpoint.backend.default=PROD
 touchpoint.backend.test=UAT
 
 aws.queue.welcome-email = "subs-welcome-email"
+
+google.analytics.tracking.id = "UA-51507017-5"


### PR DESCRIPTION
- Make the tracking ID configurable.
- Enable the linker.
- Added eventbrite linker (to be consistent with other membership sites).
- Used Alexis's suggested sandbox UA account when in dev mode.

cc @tomverran