### PR TITLE
Fix post code and delivery date selectors

### DIFF
--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -37,7 +37,7 @@ class SubscriptionsForm(catalogService: CatalogService) {
   (DigipackData)(DigipackData.unapply))
 
   val paperForm = Form(mapping(
-    "startDate" -> jodaLocalDate("d MMMM y"),
+    "startDate" -> jodaLocalDate("EEEE d MMMM y"),
     "delivery" -> addressDataMapping,
     "deliveryInstructions" -> optional(text(0, 250)),
     "ratePlanId" -> of[ProductPlan[PhysicalProducts]]

--- a/app/views/fragments/checkout/fieldsPaper.scala.html
+++ b/app/views/fragments/checkout/fieldsPaper.scala.html
@@ -16,7 +16,7 @@
     </div>
     <div class="form-field js-checkout-delivery">
         <label class="label" for="address-town">Date of first paper</label>
-        <div id="deliveryDatePicker" ratePlanName="@data.plans.default.name"></div>
+        <div id="deliveryDatePicker"></div>
     </div>
     <input type="hidden" name="voucher" value="false">
     <input type="hidden" name="digipack" value="false">

--- a/app/views/fragments/checkout/fieldsPaper.scala.html
+++ b/app/views/fragments/checkout/fieldsPaper.scala.html
@@ -16,7 +16,7 @@
     </div>
     <div class="form-field js-checkout-delivery">
         <label class="label" for="address-town">Date of first paper</label>
-        <div id="deliveryDatePicker"></div>
+        <div id="deliveryDatePicker" class="form-field__react-datepicker"></div>
     </div>
     <input type="hidden" name="voucher" value="false">
     <input type="hidden" name="digipack" value="false">

--- a/assets/javascripts/modules/checkout/deliveryDetails.js
+++ b/assets/javascripts/modules/checkout/deliveryDetails.js
@@ -47,12 +47,12 @@ define([
     }
 
     function validatePostCode(e) {
-        if ( e.key === 'Control' || e.key === 'Shift' ||  e.key === 'Alt' || e.key === ' ') {
+        if (e.key === 'Control' || e.key === 'Shift' ||  e.key === 'Alt' || e.key === ' ') {
             return;
         }
 
         var $e = $(e.target),
-            postCodeStr = $e.val().trim().toUpperCase();
+            postCodeStr = $e.val().replace(/^\s+/, '').toUpperCase(); // trim only leading spaces
 
         $e.val(postCodeStr); // update display as soon as possible
 
@@ -62,6 +62,9 @@ define([
             errorMessage = $deliveryPostcodeContainer.data('error-message'),
             validationUrl = $deliveryPostcodeContainer.data('validation-url');
             ORIGINAL_ERROR_MESSAGE = ORIGINAL_ERROR_MESSAGE || $errorLabel.text();
+
+        // remove all whitespace for the lookup
+        postCodeStr = postCodeStr.replace(/\s+/g, '');
 
         if (postCodeStr.length < 2) {
             POSTCODE_ELIGIBLE = true;

--- a/assets/javascripts/modules/checkout/deliveryDetails.js
+++ b/assets/javascripts/modules/checkout/deliveryDetails.js
@@ -47,12 +47,15 @@ define([
     }
 
     function validatePostCode(e) {
-        if (e.key === 'Control' || e.key === 'Shift' ||  e.key === 'Alt' || e.key === ' ') {
+        // Don't react on key presses that don't affect the text, or is just whitespace that'll get trimmed
+        if (e.key     === 'Control' || e.key     === 'Shift' || e.key     === 'Alt' || e.key     ===  ' ' ||
+            e.keyCode === 17        || e.keyCode === 16      || e.keyCode === 18    || e.keyCode === 32
+        ) {
             return;
         }
 
         var $e = $(e.target),
-            postCodeStr = $e.val().replace(/^\s+/, '').toUpperCase(); // trim only leading spaces
+            postCodeStr = $e.val().replace(/^\s+/, '').replace(/\s+/g, ' ').toUpperCase(); // trim only leading spaces
 
         $e.val(postCodeStr); // update display as soon as possible
 

--- a/assets/javascripts/modules/checkout/paperFields.jsx
+++ b/assets/javascripts/modules/checkout/paperFields.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-
+import moment from 'moment'
 import formElements from './formElements'
 import CustomDatePicker from '../react/customDatePicker'
 import CharacterCountedTextArea from './characterCountedTextArea'

--- a/assets/javascripts/modules/checkout/paperFields.jsx
+++ b/assets/javascripts/modules/checkout/paperFields.jsx
@@ -4,14 +4,18 @@ import ReactDOM from 'react-dom';
 import formElements from './formElements'
 import CustomDatePicker from '../react/customDatePicker'
 import CharacterCountedTextArea from './characterCountedTextArea'
-import moment from 'moment-business-days'
+import reviewDetails from './reviewDetails'
 
 require('react-datepicker/dist/react-datepicker.css');
 
 const NUMBER_OF_DAYS_IN_ADVANCE = 5;
 const MAX_WEEKS_AVAILABLE = 4;
 
-function filterDate(packageName) {
+function filterDate() {
+    // Get the package name from the checked $PLAN_INPUTS
+    var packageName = '';
+    formElements.$PLAN_INPUTS.each((el) => (el.checked) && (packageName = el.getAttribute('data-option-mirror-package')));
+
     switch (true) {
         case /Sunday/i.test(packageName):
             return (date) => date.day() === 0;
@@ -25,7 +29,7 @@ function filterDate(packageName) {
 }
 
 function getFirstSelectableDate(filterFn) {
-    var firstSelectableDate = moment().businessAdd(NUMBER_OF_DAYS_IN_ADVANCE);
+    var firstSelectableDate = moment().add(NUMBER_OF_DAYS_IN_ADVANCE);
     while (filterFn && !filterFn(firstSelectableDate)) {
         firstSelectableDate.add(1, 'day');
     }
@@ -37,6 +41,18 @@ function getLastSelectableDate(firstSelectableDate) {
     return moment(startDate).add(MAX_WEEKS_AVAILABLE, 'weeks');
 }
 
+function getDefaultProps() {
+    const filterDateFn = filterDate(),
+        firstSelectableDate = getFirstSelectableDate(filterDateFn),
+        lastSelectableDate = getLastSelectableDate(firstSelectableDate);
+
+    return {
+        filterDate: filterDateFn,
+        minDate: firstSelectableDate,
+        maxDate: lastSelectableDate
+    };
+}
+
 export default {
     renderDeliveryInstructions () {
         ReactDOM.render(
@@ -44,22 +60,41 @@ export default {
             document.getElementById(formElements.DELIVERY_INSTRUCTIONS_ID)
         )
     },
-    renderDatePicker () {
-        const container = document.getElementById(formElements.PAPER_CHECKOUT_DATE_PICKER_ID),
-              filterDateFn = filterDate(container.getAttribute('ratePlanName')),
-              firstSelectableDate = getFirstSelectableDate(filterDateFn),
-              lastSelectableDate = getLastSelectableDate(firstSelectableDate);
+    renderDatePicker (container, defaultState) {
+        if (!(container && defaultState)) return;
 
-        ReactDOM.render(
-            <CustomDatePicker name="startDate" className="input-text" dateFormat="D MMMM YYYY" locale="en-gb"
-                              minDate={firstSelectableDate} maxDate={lastSelectableDate}
-                              filterDate={filterDateFn} />,
+        return ReactDOM.render(
+            <CustomDatePicker name="startDate" className="input-text" dateFormat="dddd D MMMM YYYY" locale="en-gb"
+                              minDate={defaultState.minDate} maxDate={defaultState.maxDate}
+                              filterDate={defaultState.filterDate} />,
             container
-        )
+        );
+    },
+    registerRatePlanChangeEvent (datePickerContainer, datePickerComponent) {
+        if (!(datePickerContainer && datePickerComponent)) return; // don't register handlers if no component to update
 
+        const self = this;
+
+        formElements.$PLAN_INPUTS.each((el) => el.addEventListener('change', () => {
+
+            // Reset the startDate (i.e. date of first paper) to the new minDate
+            // iff the current selection is not in the new filter
+            const defaultState = getDefaultProps();
+            if (!defaultState.filterDate(datePickerComponent.state.startDate)) {
+                datePickerComponent.handleChange(defaultState.minDate);
+                reviewDetails.repopulateDetails();
+            }
+
+            self.renderDatePicker(datePickerContainer, defaultState);
+        }));
     },
     init: function() {
         this.renderDeliveryInstructions();
-        this.renderDatePicker();
+
+        const datePickerContainer = document.getElementById(formElements.PAPER_CHECKOUT_DATE_PICKER_ID);
+        const datePickerComponent = this.renderDatePicker(datePickerContainer, getDefaultProps());
+
+        // if the chosen rate plan changes, we need to reset the state in the datePickerComponent
+        this.registerRatePlanChangeEvent(datePickerContainer, datePickerComponent);
     }
 }

--- a/assets/javascripts/modules/checkout/reviewDetails.js
+++ b/assets/javascripts/modules/checkout/reviewDetails.js
@@ -31,54 +31,56 @@ define([
     }
 
     function populateDetails() {
-        clickHelper(formEls.$PAYMENT_DETAILS_SUBMIT, function() {
-            formEls.$REVIEW_NAME.text(textUtils.mergeValues([
-                formEls.$TITLE.val(),
-                formEls.$FIRST_NAME.val(),
-                formEls.$LAST_NAME.val()
-            ], ' '));
+        formEls.$REVIEW_NAME.text(textUtils.mergeValues([
+            formEls.$TITLE.val(),
+            formEls.$FIRST_NAME.val(),
+            formEls.$LAST_NAME.val()
+        ], ' '));
 
-            var BILLING_COUNTRY_SELECT = formEls.BILLING.$COUNTRY_SELECT[0];
-            if (BILLING_COUNTRY_SELECT.disabled) {
-                formEls.$REVIEW_ADDRESS.text('Same as Delivery address');
-            } else {
-                formEls.$REVIEW_ADDRESS.text(textUtils.mergeValues([
-                    formEls.BILLING.$ADDRESS1.val(),
-                    formEls.BILLING.$ADDRESS2.val(),
-                    formEls.BILLING.$TOWN.val(),
-                    formEls.BILLING.getSubdivision$().val(),
-                    formEls.BILLING.getPostcode$().val(),
-                    BILLING_COUNTRY_SELECT.options[BILLING_COUNTRY_SELECT.selectedIndex].text
-                ], ', '));
-            }
-
-            var DELIVERY_COUNTRY_SELECT = formEls.DELIVERY.$COUNTRY_SELECT[0];
-
-            formEls.$REVIEW_DELIVERY_ADDRESS.text(textUtils.mergeValues([
-                formEls.DELIVERY.$ADDRESS1.val(),
-                formEls.DELIVERY.$ADDRESS2.val(),
-                formEls.DELIVERY.$TOWN.val(),
-                formEls.DELIVERY.getSubdivision$().val(),
-                formEls.DELIVERY.getPostcode$().val(),
-                DELIVERY_COUNTRY_SELECT.options[DELIVERY_COUNTRY_SELECT.selectedIndex].text
+        var BILLING_COUNTRY_SELECT = formEls.BILLING.$COUNTRY_SELECT[0];
+        if (BILLING_COUNTRY_SELECT.disabled) {
+            formEls.$REVIEW_ADDRESS.text('Same as Delivery address');
+        } else {
+            formEls.$REVIEW_ADDRESS.text(textUtils.mergeValues([
+                formEls.BILLING.$ADDRESS1.val(),
+                formEls.BILLING.$ADDRESS2.val(),
+                formEls.BILLING.$TOWN.val(),
+                formEls.BILLING.getSubdivision$().val(),
+                formEls.BILLING.getPostcode$().val(),
+                BILLING_COUNTRY_SELECT.options[BILLING_COUNTRY_SELECT.selectedIndex].text
             ], ', '));
+        }
 
-            formEls.$REVIEW_EMAIL.text(formEls.$EMAIL.val());
-            formEls.$REVIEW_PHONE.text(formEls.$PHONE.val());
-            formEls.$REVIEW_ACCOUNT.text(formEls.$ACCOUNT.val());
-            formEls.$REVIEW_SORTCODE.text(formEls.$SORTCODE.val());
-            formEls.$REVIEW_HOLDER.text(formEls.$HOLDER.val());
+        var DELIVERY_COUNTRY_SELECT = formEls.DELIVERY.$COUNTRY_SELECT[0];
 
-            var obscuredCardNumber = textUtils.obscure(formEls.$CARD_NUMBER.val(), 4, '*');
-            formEls.$REVIEW_CARD_NUMBER.text(obscuredCardNumber);
-            formEls.$REVIEW_CARD_EXPIRY.text(textUtils.mergeValues([
-                formEls.$CARD_EXPIRY_MONTH.val(),
-                formEls.$CARD_EXPIRY_YEAR.val()
-            ], '/'));
+        formEls.$REVIEW_DELIVERY_ADDRESS.text(textUtils.mergeValues([
+            formEls.DELIVERY.$ADDRESS1.val(),
+            formEls.DELIVERY.$ADDRESS2.val(),
+            formEls.DELIVERY.$TOWN.val(),
+            formEls.DELIVERY.getSubdivision$().val(),
+            formEls.DELIVERY.getPostcode$().val(),
+            DELIVERY_COUNTRY_SELECT.options[DELIVERY_COUNTRY_SELECT.selectedIndex].text
+        ], ', '));
 
-            formEls.$REVIEW_DELIVERY_INSTRUCTIONS.text(formEls.getDeliveryInstructions().val());
-            formEls.$REVIEW_DELIVERY_START_DATE.text(formEls.getPaperCheckoutField().val());
-        });
+        formEls.$REVIEW_EMAIL.text(formEls.$EMAIL.val());
+        formEls.$REVIEW_PHONE.text(formEls.$PHONE.val());
+        formEls.$REVIEW_ACCOUNT.text(formEls.$ACCOUNT.val());
+        formEls.$REVIEW_SORTCODE.text(formEls.$SORTCODE.val());
+        formEls.$REVIEW_HOLDER.text(formEls.$HOLDER.val());
+
+        var obscuredCardNumber = textUtils.obscure(formEls.$CARD_NUMBER.val(), 4, '*');
+        formEls.$REVIEW_CARD_NUMBER.text(obscuredCardNumber);
+        formEls.$REVIEW_CARD_EXPIRY.text(textUtils.mergeValues([
+            formEls.$CARD_EXPIRY_MONTH.val(),
+            formEls.$CARD_EXPIRY_YEAR.val()
+        ], '/'));
+
+        formEls.$REVIEW_DELIVERY_INSTRUCTIONS.text(formEls.getDeliveryInstructions().val());
+        formEls.$REVIEW_DELIVERY_START_DATE.text(formEls.getPaperCheckoutField().val());
+    }
+
+    function registerPopulateDetails() {
+        clickHelper(formEls.$PAYMENT_DETAILS_SUBMIT, populateDetails);
     }
 
     function submitHandler() {
@@ -129,12 +131,13 @@ define([
     }
 
     function init() {
-        populateDetails();
+        registerPopulateDetails();
         submitHandler();
     }
 
     return {
-        init: init
+        init: init,
+        repopulateDetails: populateDetails
     };
 
 });

--- a/assets/stylesheets/modules/_forms.scss
+++ b/assets/stylesheets/modules/_forms.scss
@@ -270,6 +270,11 @@ input[type=number] {
         border-color: guss-colour(error);
     }
 }
+.form-field__react-datepicker {
+    .react-datepicker__input-container {
+        display: block;
+    }
+}
 
 /**
  * Option groups


### PR DESCRIPTION
- Switch businessAdd back to normal days add, as it was disadvantaging weekend customers.
- Make the available days in the CustomDatePicker flex when the user upgrades or downgrades their package. Correcting the selected date to the first available date if it's no longer applicable.
- Added the day of the week to the 'Date of first paper' display to make it more obvious.
- Update the 'Date of first paper' on the Review details section too (with a lot of whitespace collateral)
- Fixed postcode interaction and formatting so it works same in Chrome as it does in Firefox.

cc @tomverran 