### PR TITLE
Fixed bug when paper sub contains digipack

### DIFF
--- a/app/model/exactTarget/DataExtensionRow.scala
+++ b/app/model/exactTarget/DataExtensionRow.scala
@@ -143,7 +143,7 @@ object PaperHomeDeliveryWelcome1DataExtensionRow {
         "SubscriberKey" -> personalData.email,
         "EmailAddress" -> personalData.email,
         "subscriber_id" -> subscription.name.get,
-        "IncludesDigipack" -> paperData.plan.products.others.contains(Digipack).toString,
+        "IncludesDigipack" -> paperData.plan.products.others.map(_._1).contains(Digipack).toString,
         "title" -> personalData.title.fold("")(_.title),
         "first_name" -> personalData.first,
         "last_name" -> personalData.last,


### PR DESCRIPTION
Fixed bug where flag was never true to indicate whether a paper sub contains a digipack bolt-on, and so 'instructions' part of ExactTarget email template is not being rendered.

cc @tomverran 
