### PR TITLE
Email billing schedule after suspend

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -125,7 +125,7 @@ object Config {
 
   val welcomeEmailQueue = config.getString("aws.queue.welcome-email")
 
-  val holidaySuspensionEmailQueue = config.getString("aws.queue.holiday-suspension")
+  val holidaySuspensionEmailQueue = config.getString("aws.queue.holiday-suspension-email")
 
   val googleAnalyticsTrackingId = config.getString("google.analytics.tracking.id")
 

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -125,6 +125,8 @@ object Config {
 
   val welcomeEmailQueue = config.getString("aws.queue.welcome-email")
 
+  val holidaySuspensionEmailQueue = config.getString("aws.queue.holiday-suspension")
+
   val googleAnalyticsTrackingId = config.getString("google.analytics.tracking.id")
 
   val suspendableWeeks = 6

--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -114,7 +114,7 @@ object AccountManagement extends Controller with LazyLogging {
       oldBS <- EitherT(tpBackend.commonPaymentService.billingSchedule(sub, 12).map(_ \/> "Error getting billing schedule"))
       result <- EitherT(tpBackend.suspensionService.addHoliday(newHoliday, oldBS)).leftMap(userFacingError)
       newBS <- EitherT(tpBackend.commonPaymentService.billingSchedule(sub, 12).map(_ \/> "Error getting billing schedule"))
-      newHolidays <- EitherT(tpBackend.suspensionService.getHolidays(sub.name))
+      newHolidays <- EitherT(tpBackend.suspensionService.getHolidays(sub.name)).leftMap(_ => "Error getting holidays")
       pendingHolidays = pendingHolidayRefunds(newHolidays)
       suspendableDays = Config.suspendableWeeks * sub.plan.products.without(Delivery).size
       suspendedDays = SuspensionService.holidayToSuspendedDays(pendingHolidays, sub.plan.products.physicalProducts.list)

--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -120,7 +120,7 @@ object AccountManagement extends Controller with LazyLogging {
       suspendedDays = SuspensionService.holidayToSuspendedDays(pendingHolidays, sub.plan.products.physicalProducts.list)
     } yield {
       tpBackend.exactTargetService.enqueueETHolidaySuspensionEmail(sub, sub.plan.name, newBS, pendingHolidays.size, suspendableDays, suspendedDays).onFailure { case e: Throwable =>
-        logger.error(s"Failed to generate data to create ${sub.name.get}'s data extension", e.getMessage)
+        logger.error(s"Failed to generate data needed to enqueue ${sub.name.get}'s holiday suspension email. Reason: ${e.getMessage}")
       }
       Ok(views.html.account.success(
         newRefund = (result.refund, newHoliday),
@@ -130,6 +130,10 @@ object AccountManagement extends Controller with LazyLogging {
         suspendedDays = suspendedDays
       )).withNewSession
     }).valueOr(BadRequest(_))
+  }
+
+  def redirect = NoCacheAction { implicit request =>
+    Redirect(routes.AccountManagement.login(None).url)
   }
 }
 

--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -119,7 +119,7 @@ object AccountManagement extends Controller with LazyLogging {
       suspendableDays = Config.suspendableWeeks * sub.plan.products.without(Delivery).size
       suspendedDays = SuspensionService.holidayToSuspendedDays(pendingHolidays, sub.plan.products.physicalProducts.list)
     } yield {
-      tpBackend.exactTargetService.sendETDataExtensionRow(sub, sub.plan.name, newBS, pendingHolidays.size, suspendableDays, suspendedDays).onFailure { case e: Throwable =>
+      tpBackend.exactTargetService.enqueueETHolidaySuspensionEmail(sub, sub.plan.name, newBS, pendingHolidays.size, suspendableDays, suspendedDays).onFailure { case e: Throwable =>
         logger.error(s"Failed to generate data to create ${sub.name.get}'s data extension", e.getMessage)
       }
       Ok(views.html.account.success(

--- a/app/model/exactTarget/DataExtensionRow.scala
+++ b/app/model/exactTarget/DataExtensionRow.scala
@@ -1,16 +1,20 @@
 package model.exactTarget
 
 import java.lang.Math.min
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 
-import com.gu.memsub._
 import com.gu.exacttarget._
+import com.gu.i18n.Currency
 import com.gu.memsub.Subscription._
+import com.gu.memsub._
 import com.typesafe.scalalogging.LazyLogging
 import model.exactTarget.DataExtensionRowHelpers._
-import org.joda.time.{Days, LocalDate}
 import model.{PaperData, PersonalData}
 import org.joda.time.Days.daysBetween
+import org.joda.time.{Days, LocalDate}
 import utils.Dates
+import views.support.Dates.prettyDate
 
 import scala.math.BigDecimal.decimal
 
@@ -163,10 +167,62 @@ object PaperHomeDeliveryWelcome1DataExtensionRow {
   }
 }
 
+object HolidaySuspensionBillingScheduleDataExtensionRow {
+
+  def apply(
+           email: Option[String],
+           saltuation: String,
+           subscriptionName: String,
+           subscriptionCurrency: Currency,
+           packageName: String,
+           billingSchedule: BillingSchedule,
+           numberOfSuspensionsLinedUp: Int,
+           daysUsed: Int,
+           daysAllowed: Int
+         ): HolidaySuspensionBillingScheduleDataExtensionRow = {
+
+    val reversedSchedule = billingSchedule.invoices.reverse.list
+    val thereafterBill = reversedSchedule.takeWhile(_.amount == reversedSchedule.head.amount).last
+    val trimmedSchedule = reversedSchedule.dropWhile(_.amount == thereafterBill.amount).reverse
+    val count = new AtomicInteger()
+    val futureBills = trimmedSchedule.flatMap(bill => {
+      val number = count.incrementAndGet()
+      Seq(
+        s"future_bill_${number}_date" -> prettyDate(bill.date),
+        s"future_bill_${number}_amount" -> Price(bill.amount, subscriptionCurrency).pretty
+      )
+    })
+    val emailAddress = email.getOrElse("holiday-suspension-bounce@guardian.co.uk")
+
+    HolidaySuspensionBillingScheduleDataExtensionRow(
+      emailAddress,
+      Seq(
+        "uuid" -> UUID.randomUUID().toString,
+        "subscription_id" -> subscriptionName,
+        "email_address" -> emailAddress,
+        "customer_salutation" -> saltuation,
+        "package_name" -> packageName,
+        "days_allowed" -> daysAllowed.toString,
+        "days_used" -> daysUsed.toString,
+        "days_remaining" -> (daysAllowed - daysUsed).toString,
+        "number_of_suspensions_lined_up" -> numberOfSuspensionsLinedUp.toString,
+        "normal_price" -> Price(thereafterBill.amount, subscriptionCurrency).pretty
+      ) ++ futureBills
+    )
+  }
+
+  def constructSalutation(titleOpt: Option[String], firstNameOpt: Option[String], lastNameOpt: Option[String]): String =
+    titleOpt.flatMap(title => lastNameOpt.map(lastName => s"$title $lastName")).getOrElse(firstNameOpt.getOrElse("Subscriber"))
+}
+
 case class DigipackWelcome1DataExtensionRow(email: String, fields: Seq[(String, String)]) extends DataExtensionRow {
   override def forExtension = DigipackDataExtension
 }
 
 case class PaperHomeDeliveryWelcome1DataExtensionRow(email: String, fields: Seq[(String, String)]) extends DataExtensionRow {
   override def forExtension = PaperDeliveryDataExtension
+}
+
+case class HolidaySuspensionBillingScheduleDataExtensionRow(email: String, fields: Seq[(String, String)]) extends DataExtensionRow {
+  override def forExtension = HolidaySuspensionBillingSchedule
 }

--- a/app/model/exactTarget/DataExtensionRow.scala
+++ b/app/model/exactTarget/DataExtensionRow.scala
@@ -184,8 +184,8 @@ object HolidaySuspensionBillingScheduleDataExtensionRow {
     val (thereafterBill, trimmedSchedule) = BillingSchedule.rolledUp(billingSchedule)
     val futureBills = trimmedSchedule.zipWithIndex.flatMap { case (bill, number) =>
       Seq(
-        s"future_bill_${number}_date" -> prettyDate(bill.date),
-        s"future_bill_${number}_amount" -> Price(bill.amount, subscriptionCurrency).pretty
+        s"future_bill_${number + 1}_date" -> prettyDate(bill.date),
+        s"future_bill_${number + 1}_amount" -> Price(bill.amount, subscriptionCurrency).pretty
       )
     }
     val emailAddress = email.getOrElse("holiday-suspension-bounce@guardian.co.uk")

--- a/app/model/exactTarget/DataExtensionRow.scala
+++ b/app/model/exactTarget/DataExtensionRow.scala
@@ -181,9 +181,7 @@ object HolidaySuspensionBillingScheduleDataExtensionRow {
            daysAllowed: Int
          ): HolidaySuspensionBillingScheduleDataExtensionRow = {
 
-    val reversedSchedule = billingSchedule.invoices.reverse.list
-    val thereafterBill = reversedSchedule.takeWhile(_.amount == reversedSchedule.head.amount).last
-    val trimmedSchedule = reversedSchedule.dropWhile(_.amount == thereafterBill.amount).reverse
+    val (thereafterBill, trimmedSchedule) = BillingSchedule.rolledUp(billingSchedule)
     val count = new AtomicInteger()
     val futureBills = trimmedSchedule.flatMap(bill => {
       val number = count.incrementAndGet()

--- a/app/model/exactTarget/DataExtensionRow.scala
+++ b/app/model/exactTarget/DataExtensionRow.scala
@@ -182,14 +182,12 @@ object HolidaySuspensionBillingScheduleDataExtensionRow {
          ): HolidaySuspensionBillingScheduleDataExtensionRow = {
 
     val (thereafterBill, trimmedSchedule) = BillingSchedule.rolledUp(billingSchedule)
-    val count = new AtomicInteger()
-    val futureBills = trimmedSchedule.flatMap(bill => {
-      val number = count.incrementAndGet()
+    val futureBills = trimmedSchedule.zipWithIndex.flatMap { case (bill, number) =>
       Seq(
         s"future_bill_${number}_date" -> prettyDate(bill.date),
         s"future_bill_${number}_amount" -> Price(bill.amount, subscriptionCurrency).pretty
       )
-    })
+    }
     val emailAddress = email.getOrElse("holiday-suspension-bounce@guardian.co.uk")
 
     HolidaySuspensionBillingScheduleDataExtensionRow(

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -133,7 +133,7 @@ class CheckoutService(identityService: IdentityService,
   ): Future[NonEmptyList[SubsError] \/ Unit] =
 
     (for {
-      a <- exactTargetService.sendETDataExtensionRow(subscribeResult, subscriptionData, gracePeriodInDays, validPromotion, purchaserIds)
+      a <- exactTargetService.enqueueETWelcomeEmail(subscribeResult, subscriptionData, gracePeriodInDays, validPromotion, purchaserIds)
     } yield {
       \/.right(())
     }).recover {

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -3,24 +3,27 @@ package services
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.sqs.AmazonSQSClient
 import com.amazonaws.services.sqs.model._
-import views.support.Pricing._
 import com.gu.i18n.Currency
-import model.PurchaserIdentifiers
+import com.gu.memsub.Subscription._
+import com.gu.memsub._
 import com.gu.memsub.promo.Promotion._
 import com.gu.memsub.promo._
 import com.gu.memsub.services.{SubscriptionService, PaymentService => CommonPaymentService}
-import com.gu.memsub._
-import com.gu.memsub.Subscription._
 import com.gu.subscriptions.{DigipackCatalog, PaperCatalog}
+import com.gu.zuora.api.ZuoraService
 import com.gu.zuora.soap.models.Results.SubscribeResult
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
-import model.SubscribeRequest
+import model.exactTarget.HolidaySuspensionBillingScheduleDataExtensionRow.constructSalutation
+import model.{PurchaserIdentifiers, SubscribeRequest}
 import model.exactTarget._
 import org.joda.time.Days
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
+import views.support.Pricing._
+
 import scala.concurrent.Future
+import scala.reflect.internal.util.StringOps
 import scala.util.{Failure, Success, Try}
 import utils.Retry
 
@@ -34,6 +37,8 @@ trait ExactTargetService extends LazyLogging {
   def digiSubscriptionService: SubscriptionService[DigipackCatalog]
   def paperSubscriptionService: SubscriptionService[PaperCatalog]
   def paymentService: CommonPaymentService
+  def zuoraService: ZuoraService
+  def salesforceService: SalesforceService
 
   private def getPlanDescription(validPromotion: Option[ValidPromotion[NewUsers]], currency: Currency, plan: PaidPlan[Status, BillingPeriod]): String = {
     (for {
@@ -104,20 +109,52 @@ trait ExactTargetService extends LazyLogging {
 
     for {
       row <- buildETDataExtensionRow(subscribeResult, subscriptionData, gracePeriod, validPromotion, purchaserIds)
-      response <- SqsClient.sendWelcomeEmailToQueue(row)
+      response <- SqsClient.sendDataExtensionToQueue(Config.welcomeEmailQueue, row)
     } yield {
       response match {
-        case Success(sendMsgResult) => logger.info(s"Successfully sent ${subscribeResult.subscriptionName} welcome email to user ${purchaserIds.identityId}.")
-        case Failure(e) => logger.error(s"Failed to send ${subscribeResult.subscriptionName} welcome email to user ${purchaserIds.identityId}.", e)
+        case Success(sendMsgResult) => logger.info(s"Successfully enqueued ${subscribeResult.subscriptionName} welcome email for user ${purchaserIds.identityId}.")
+        case Failure(e) => logger.error(s"Failed to enqueue ${subscribeResult.subscriptionName} welcome email for user ${purchaserIds.identityId}.", e)
       }
     }
+
+  def sendETDataExtensionRow(
+      subscription: Subscription,
+      packageName: String,
+      billingSchedule: BillingSchedule,
+      numberOfSuspensionsLinedUp: Int,
+      daysUsed: Int,
+      daysAllowed: Int): Future[Unit] = {
+
+    for {
+      zuoraAccount <- zuoraService.getAccount(subscription.accountId)
+      sfContactId <- zuoraAccount.sfContactId.fold[Future[String]](Future.failed(new IllegalStateException(s"Zuora record for ${subscription.accountId} has no sfContactId")))(Future.successful)
+      salesforceContact <- salesforceService.repo.get(sfContactId).map(_.getOrElse(throw new IllegalStateException(s"Cannot find salesforce contact for $sfContactId")))
+      row = HolidaySuspensionBillingScheduleDataExtensionRow(
+        email = StringOps.oempty(salesforceContact.email).headOption,
+        saltuation = constructSalutation(salesforceContact.title, salesforceContact.firstName, Some(salesforceContact.lastName)),
+        subscriptionName = subscription.name.get,
+        subscriptionCurrency = subscription.currency,
+        packageName = packageName,
+        billingSchedule = billingSchedule,
+        numberOfSuspensionsLinedUp,
+        daysUsed,
+        daysAllowed
+      )
+      response <- SqsClient.sendDataExtensionToQueue(Config.holidaySuspensionEmailQueue, row)
+    } yield {
+      response match {
+        case Success(sendMsgResult) => logger.info(s"Successfully enqueued ${subscription.name.get}'s updated billing schedule email.")
+        case Failure(e) => logger.error(s"Failed to enqueue ${subscription.name.get}'s updated billing schedule email. Details were: " + row.toString, e)
+      }
+    }
+  }
 }
 
 object SqsClient extends LazyLogging {
   private val sqsClient = new AmazonSQSClient()
   sqsClient.setRegion(Region.getRegion(Regions.EU_WEST_1))
 
-  def sendWelcomeEmailToQueue(row: DataExtensionRow): Future[Try[SendMessageResult]] = {
+  def sendDataExtensionToQueue(queueName: String, row: DataExtensionRow): Future[Try[SendMessageResult]] = {
     Future {
       val payload = Json.obj(
         "To" -> Json.obj(
@@ -131,7 +168,7 @@ object SqsClient extends LazyLogging {
       ).toString()
 
       def sendToQueue(msg: String): SendMessageResult = {
-        val queueUrl = sqsClient.createQueue(new CreateQueueRequest(Config.welcomeEmailQueue)).getQueueUrl
+        val queueUrl = sqsClient.createQueue(new CreateQueueRequest(queueName)).getQueueUrl
         sqsClient.sendMessage(new SendMessageRequest(queueUrl, msg))
       }
 

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -132,7 +132,7 @@ trait ExactTargetService extends LazyLogging {
         }
         sfContactId <- zuoraAccount.sfContactId.fold[Future[String]](Future.failed(new IllegalStateException(s"Zuora record for ${subscription.accountId} has no sfContactId")))(Future.successful)
         salesforceContact <- Retry(2, s"Failed to get Salesforce Contact for sfContactId: $sfContactId") {
-          salesforceService.repo.get(sfContactId).map(_.getOrElse(throw new IllegalStateException(s"Cannot find salesforce contact for $sfContactId")))
+          salesforceService.repo.getByContactId(sfContactId).map(_.getOrElse(throw new IllegalStateException(s"Cannot find salesforce contact for $sfContactId")))
         }
       } yield HolidaySuspensionBillingScheduleDataExtensionRow(
         email = StringOps.oempty(salesforceContact.email).headOption,

--- a/app/services/TouchpointBackend.scala
+++ b/app/services/TouchpointBackend.scala
@@ -138,10 +138,12 @@ case class TouchpointBackend(environmentName: String,
 
   private val that = this
 
-  private val exactTargetService = new ExactTargetService {
+  val exactTargetService = new ExactTargetService {
     override def digiSubscriptionService = that.subscriptionService
     override def paperSubscriptionService = that.subscriptionServicePaper
     override def paymentService = that.commonPaymentService
+    override def zuoraService = that.zuoraService
+    override def salesforceService = that.salesforceService
   }
 
   val checkoutService =

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.253",
+    "com.gu" %% "membership-common" % "0.254",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.254",
+    "com.gu" %% "membership-common" % "0.255",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -29,6 +29,6 @@ qa {
 }
 
 aws.queue.welcome-email = "subs-welcome-email"
-aws.queue.holiday-suspension = "subs-holiday-suspension"
+aws.queue.holiday-suspension = "subs-holiday-suspension-email"
 
 google.analytics.tracking.id="UA-33592456-4"

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -29,6 +29,6 @@ qa {
 }
 
 aws.queue.welcome-email = "subs-welcome-email"
-aws.queue.holiday-suspension = "subs-holiday-suspension-email"
+aws.queue.holiday-suspension-email = "subs-holiday-suspension-email"
 
 google.analytics.tracking.id="UA-33592456-4"

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -28,7 +28,7 @@ qa {
   passthrough-cookie-value = "qa-passthrough-dev"
 }
 
-//aws.queue.welcome-email = "subs-welcome-email-dev"
 aws.queue.welcome-email = "subs-welcome-email"
+aws.queue.holiday-suspension = "subs-holiday-suspension"
 
 google.analytics.tracking.id="UA-33592456-4"

--- a/conf/PROD.conf
+++ b/conf/PROD.conf
@@ -18,6 +18,6 @@ touchpoint.backend.default=PROD
 touchpoint.backend.test=UAT
 
 aws.queue.welcome-email = "subs-welcome-email"
-aws.queue.holiday-suspension = "subs-holiday-suspension"
+aws.queue.holiday-suspension = "subs-holiday-suspension-email"
 
 google.analytics.tracking.id = "UA-51507017-5"

--- a/conf/PROD.conf
+++ b/conf/PROD.conf
@@ -18,6 +18,6 @@ touchpoint.backend.default=PROD
 touchpoint.backend.test=UAT
 
 aws.queue.welcome-email = "subs-welcome-email"
-aws.queue.holiday-suspension = "subs-holiday-suspension-email"
+aws.queue.holiday-suspension-email = "subs-holiday-suspension-email"
 
 google.analytics.tracking.id = "UA-51507017-5"

--- a/conf/PROD.conf
+++ b/conf/PROD.conf
@@ -18,5 +18,6 @@ touchpoint.backend.default=PROD
 touchpoint.backend.test=UAT
 
 aws.queue.welcome-email = "subs-welcome-email"
+aws.queue.holiday-suspension = "subs-holiday-suspension"
 
 google.analytics.tracking.id = "UA-51507017-5"

--- a/conf/routes
+++ b/conf/routes
@@ -54,7 +54,7 @@ GET         /oauth2callback                  controllers.OAuth.oauth2Callback
 # Manage my account
 GET         /mma                             controllers.AccountManagement.login(subscriberId: Option[String])
 POST        /mma                             controllers.AccountManagement.processLogin
-GET         /mma/suspend                     controllers.AccountManagement.login(subscriberId: Option[String])
+GET         /mma/suspend                     controllers.AccountManagement.redirect
 POST        /mma/suspend                     controllers.AccountManagement.processSuspension
 
 # Pattern Library


### PR DESCRIPTION
- Send the ExactTarget data extension JSON onto an SQS queue, using the new HolidaySuspensionBillingScheduleDataExtensionRow for formatting.
- Separate out building of data extension row from the enqueuing of the message.
- Use the new getByContactId and BillingSchedule.rollup from membership-common-0.255

cc @tomverran @mario-galic 