### PR TITLE
Billing schedule on first page

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -73,11 +73,12 @@ object AccountManagement extends Controller with LazyLogging {
     (for {
       sub <- OptionT(subscription)
       allHolidays <- OptionT(tpBackend.suspensionService.getHolidays(sub.name).map(_.toOption))
+      billingSchedule <- OptionT(tpBackend.commonPaymentService.billingSchedule(sub))
       promo = sub.promoCode.flatMap(tpBackend.promoService.findPromotion)
       pendingHolidays = pendingHolidayRefunds(allHolidays)
       suspendableDays = Config.suspendableWeeks * sub.plan.products.without(Delivery).size
       suspendedDays = SuspensionService.holidayToSuspendedDays(pendingHolidays, sub.plan.products.physicalProducts.list)
-    } yield Ok(views.html.account.suspend(sub, promo, pendingHolidayRefunds(allHolidays), suspendableDays, suspendedDays)))
+    } yield Ok(views.html.account.suspend(sub, promo, pendingHolidayRefunds(allHolidays), billingSchedule, suspendableDays, suspendedDays)))
       .getOrElse(Ok(views.html.account.details(subscriberId)))
   }
 

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -3,13 +3,15 @@
 @import com.gu.memsub.images.ResponsiveImageGenerator
 
 @import model.DigitalEdition.UK
-@(subscriberId: Option[String])(implicit request: RequestHeader, flash: Flash)
+@(
+    subscriberId: Option[String]
+)(implicit request: RequestHeader, flash: Flash, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @packImage = @{
     ResponsiveImageGroup(availableImages = ResponsiveImageGenerator("05129395fe0461071f176f526d7a4ae2b1d9b9bf/0_0_5863_5116", Seq(140, 500, 1000, 2000)))
 }
 
-@main("Suspend your newspaper delivery | The Guardian", edition = UK) {
+@main("Suspend your newspaper delivery | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
     <main class="page-container gs-container">
 

--- a/app/views/account/fragments/billingSchedule.scala.html
+++ b/app/views/account/fragments/billingSchedule.scala.html
@@ -1,9 +1,14 @@
 @import com.gu.memsub.BillingSchedule
+@import com.gu.memsub.BillingSchedule.rolledUp
 @import com.gu.memsub.Price
 @import com.gu.i18n.GBP
 @import views.support.Dates.prettyDate
+@import com.gu.i18n.Currency
 
-@(billingSchedule: BillingSchedule)
+@(billingSchedule: BillingSchedule, currency: Currency)
+
+@rolledUpBills = @{rolledUp(billingSchedule)}
+
 <table class="table table--striped suspend__table">
     <thead>
         <tr>
@@ -12,11 +17,19 @@
         </tr>
     </thead>
     <tbody>
-        @for(bill <- billingSchedule.invoices.list) {
+        @for(bill <- rolledUpBills._2) {
             <tr>
                 <td class="date">@prettyDate(bill.date)</td>
                 <td class="money">@Price(bill.amount, GBP).pretty</td>
             </tr>
         }
+        <tr>
+            @if(rolledUpBills._2.nonEmpty) {
+                <td class="date u-note">Every month thereafter</td>
+            } else {
+                <td class="date">Every month</td>
+            }
+            <td class="money">@Price(rolledUpBills._1.amount, GBP).pretty</td>
+        </tr>
     </tbody>
 </table>

--- a/app/views/account/fragments/billingSchedule.scala.html
+++ b/app/views/account/fragments/billingSchedule.scala.html
@@ -1,0 +1,22 @@
+@import com.gu.memsub.BillingSchedule
+@import com.gu.memsub.Price
+@import com.gu.i18n.GBP
+@import views.support.Dates.prettyDate
+
+@(billingSchedule: BillingSchedule)
+<table class="table table--striped suspend__table">
+    <thead>
+        <tr>
+            <th>Date</th>
+            <th>Amount</th>
+        </tr>
+    </thead>
+    <tbody>
+        @for(bill <- billingSchedule.invoices.list) {
+            <tr>
+                <td class="date">@prettyDate(bill.date)</td>
+                <td class="money">@Price(bill.amount, GBP).pretty</td>
+            </tr>
+        }
+    </tbody>
+</table>

--- a/app/views/account/fragments/suspensions.scala.html
+++ b/app/views/account/fragments/suspensions.scala.html
@@ -7,7 +7,7 @@
 
 @if(holidayRefunds.nonEmpty) {
     <div>
-        You have <strong>@suspendedDays days</strong> lined up:
+        You have <strong>@suspendedDays @if(suspendedDays == 1) { day } else { days }</strong> lined up:
         <ul>
         @for((refund, holiday) <- holidayRefunds) {
             <li>

--- a/app/views/account/success.scala.html
+++ b/app/views/account/success.scala.html
@@ -4,12 +4,15 @@
 @import com.gu.i18n.GBP
 @import views.support.Dates.prettyDate
 @import model.DigitalEdition.UK
+@import com.gu.i18n.Currency
+
 @(
     newRefund: HolidayRefund,
     holidayRefunds: Seq[HolidayRefund],
     billingSchedule: BillingSchedule,
     suspendableDays: Int,
-    suspendedDays: Int
+    suspendedDays: Int,
+    currency: Currency
 )(implicit touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Suspension success | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
@@ -37,7 +40,7 @@
 
         <div>
             <h3>Your new billing schedule</h3>
-            @account.fragments.billingSchedule(billingSchedule)
+            @account.fragments.billingSchedule(billingSchedule, currency)
         </div>
 
         <br/>

--- a/app/views/account/success.scala.html
+++ b/app/views/account/success.scala.html
@@ -1,14 +1,18 @@
-@import org.joda.time.Days.daysBetween
 @import com.gu.subscriptions.suspendresume.SuspensionService.HolidayRefund
 @import com.gu.memsub.BillingSchedule
 @import com.gu.memsub.Price
 @import com.gu.i18n.GBP
 @import views.support.Dates.prettyDate
 @import model.DigitalEdition.UK
+@(
+    newRefund: HolidayRefund,
+    holidayRefunds: Seq[HolidayRefund],
+    billingSchedule: BillingSchedule,
+    suspendableDays: Int,
+    suspendedDays: Int
+)(implicit touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
-@(newRefund: HolidayRefund, holidayRefunds: Seq[HolidayRefund], billingSchedule: BillingSchedule, suspendableDays: Int, suspendedDays: Int)
-
-@main("Suspension success | The Guardian", edition = UK) {
+@main("Suspension success | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
     <main class="page-container gs-container">
 
         <div class="suspend-header">
@@ -26,29 +30,14 @@
 
         <div>
             <h3>Your suspensions</h3>
-            <div>@account.suspensions(holidayRefunds, suspendableDays, suspendedDays)</div>
+            <div>@account.fragments.suspensions(holidayRefunds, suspendableDays, suspendedDays)</div>
         </div>
 
         <br/>
 
         <div>
             <h3>Your new billing schedule</h3>
-            <table class="table table--striped">
-                <thead>
-                    <tr>
-                        <th>Date</th>
-                        <th>Amount</th>
-                    </tr>
-                </thead>
-                <tbody>
-                @for(bill <- billingSchedule.invoices.list) {
-                    <tr>
-                        <td>@prettyDate(bill.date)</td>
-                        <td>@Price(bill.amount, GBP).pretty</td>
-                    </tr>
-                }
-                </tbody>
-            </table>
+            @account.fragments.billingSchedule(billingSchedule)
         </div>
 
         <br/>

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -16,7 +16,6 @@
 
 @(
     subscription: Subscription with PaidPS[ProductPlan[PhysicalProducts]],
-    promotion: Option[AnyPromotion] = None,
     holidayRefunds: Seq[HolidayRefund] = Seq.empty,
     billingSchedule: BillingSchedule,
     suspendableDays: Int,
@@ -39,7 +38,7 @@
 
             <div class="suspend-container__sidebar">
                 <h2>Your billing schedule</h2>
-                @account.fragments.billingSchedule(billingSchedule)
+                @account.fragments.billingSchedule(billingSchedule, subscription.currency)
             </div>
 
             <div>
@@ -47,13 +46,6 @@
                 <ul>
                     <li>Subscriber ID: <strong>@subscription.name.get</strong></li>
                     <li>You are subscribed to the <strong>@subscription.plan.title</strong></li>
-                    <li>
-                        You pay <strong>@promotion.flatMap(_.asDiscount).fold {
-                            @subscription.plan.prettyPricing(subscription.currency)
-                        } { discountPromo =>
-                            @Html(subscription.plan.prettyPricingForDiscountedPeriod(discountPromo, subscription.currency))
-                        }</strong>
-                    </li>
                     <li>You can line up <strong>@suspendableWeeks weeks</strong> worth of suspensions <span class="u-note">(Up to @suspendableDays days on the @subscription.plan.title)</span></li>
                     <li>@account.fragments.suspensions(holidayRefunds, suspendableDays, suspendedDays)</li>
                 </ul>

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -1,7 +1,7 @@
 @import com.gu.memsub.images.ResponsiveImageGroup
 @import com.gu.memsub.images.ResponsiveImageGenerator
 @import com.gu.memsub.Subscription
-@import org.joda.time.Days.daysBetween
+@import com.gu.memsub.BillingSchedule
 @import views.support.PlanOps._
 @import views.support.Pricing._
 @import com.gu.subscriptions.ProductPlan
@@ -10,21 +10,24 @@
 @import com.gu.subscriptions.PhysicalProducts
 @import com.gu.subscriptions.suspendresume.SuspensionService.HolidayRefund
 @import configuration.Config.suspendableWeeks
+@import com.gu.subscriptions.suspendresume.SuspensionService.holidayToDays
 @import model.DigitalEdition.UK
+@import views.support.Dates.prettyDate
 
 @(
     subscription: Subscription with PaidPS[ProductPlan[PhysicalProducts]],
     promotion: Option[AnyPromotion] = None,
     holidayRefunds: Seq[HolidayRefund] = Seq.empty,
+    billingSchedule: BillingSchedule,
     suspendableDays: Int,
     suspendedDays: Int
-)(implicit r: RequestHeader)
+)(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @packImage = @{
     ResponsiveImageGroup(availableImages = ResponsiveImageGenerator("05129395fe0461071f176f526d7a4ae2b1d9b9bf/0_0_5863_5116", Seq(140, 500, 1000, 2000)))
 }
 
-@main("Suspend your newspaper delivery | The Guardian", edition = UK) {
+@main("Suspend your newspaper delivery | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
     <main class="page-container gs-container">
 
@@ -32,6 +35,11 @@
 
             <div class="suspend-header">
                 <h1 class="suspend-header__title">Suspend your newspaper delivery</h1>
+            </div>
+
+            <div class="suspend-container__sidebar">
+                <h2>Your billing schedule</h2>
+                @account.fragments.billingSchedule(billingSchedule)
             </div>
 
             <div>
@@ -47,7 +55,7 @@
                         }</strong>
                     </li>
                     <li>You can line up <strong>@suspendableWeeks weeks</strong> worth of suspensions <span class="u-note">(Up to @suspendableDays days on the @subscription.plan.title)</span></li>
-                    <li>@account.suspensions(holidayRefunds, suspendableDays, suspendedDays)</li>
+                    <li>@account.fragments.suspensions(holidayRefunds, suspendableDays, suspendedDays)</li>
                 </ul>
             </div>
 
@@ -70,6 +78,7 @@
                                     <div class="form-field js-suspend-start-date">
                                         <div id="dateRangePicker"
                                         remainingDays="@{suspendableDays - suspendedDays}"
+                                        excludeExistingDays="@{holidayRefunds.flatMap(x => holidayToDays(x._2.start, x._2.finish)).map(prettyDate).mkString(",")}"
                                         ratePlanName="@subscription.plan.name"></div>
                                     </div>
                                     <button type="submit" class="js-suspend-submit button button--primary button--large u-margin-bottom">
@@ -81,7 +90,6 @@
                     </form>
                 </div>
             }
-
         </section>
     </main>
 }

--- a/assets/javascripts/modules/react/customDateRangePicker.jsx
+++ b/assets/javascripts/modules/react/customDateRangePicker.jsx
@@ -27,10 +27,11 @@ export default React.createClass({
         }
     },
     getDefaultProps () {
-        const maxWeeks = 365;
+        const maxWeeks = 6;
         return {
             remainingDays: (maxWeeks * 7),
-            firstSelectableDate: moment()
+            firstSelectableDate: moment(),
+            lastStartDate: moment().add(1, 'year')
         }
     },
     handleChange: function ({ startDate, endDate }) {
@@ -61,6 +62,7 @@ export default React.createClass({
                 <DatePicker
                     name="startDate"
                     minDate={this.state.startMinDate}
+                    maxDate={this.props.lastStartDate}
                     selected={this.state.startDate}
                     onChange={this.handleChangeStart} {...this.props} />
             </div>

--- a/assets/javascripts/modules/suspend/suspendFields.jsx
+++ b/assets/javascripts/modules/suspend/suspendFields.jsx
@@ -11,16 +11,19 @@ require('react-datepicker/dist/react-datepicker.css');
 const FIRST_SELECTABLE_DATE = moment().businessAdd(5);
 const MAX_WEEKS = 3;
 
-function filterDate(packageName) {
+function filterDate(packageName, exclusionList) {
+    const exclusions = (exclusionList || '').split(',');
+    const isNotTaken = (date) => !exclusions.includes(date.format('D MMMM YYYY'));
+
     switch (true) {
         case /Sunday/i.test(packageName):
-            return (date) => date.day() === 0;
+            return (date) => date.day() === 0 && isNotTaken(date);
         case /Sixday/i.test(packageName):
-            return (date) => date.day() !== 0;
+            return (date) => date.day() !== 0 && isNotTaken(date);
         case /Weekend/i.test(packageName):
-            return (date) => date.day() === 6 || date.day() === 0;
+            return (date) => (date.day() === 6 || date.day() === 0) && isNotTaken(date);
         default:
-            return (date) => true;
+            return isNotTaken;
     }
 }
 
@@ -29,7 +32,7 @@ export default {
     renderDatePicker () {
         const container = document.getElementById(formElements.SUSPEND_DATE_PICKER_ID),
             remainingDays = parseInt(container.getAttribute('remainingDays'), 10),
-            filterDateFn = filterDate(container.getAttribute('ratePlanName'));
+            filterDateFn = filterDate(container.getAttribute('ratePlanName'), container.getAttribute('excludeExistingDays'));
 
         ReactDOM.render(
             <CustomDateRangePicker className="input-text"

--- a/assets/javascripts/modules/suspend/suspendFields.jsx
+++ b/assets/javascripts/modules/suspend/suspendFields.jsx
@@ -4,11 +4,12 @@ import ReactDOM from 'react-dom';
 import formElements from './formElements'
 import CustomDateRangePicker from '../react/customDateRangePicker'
 
-import moment from 'moment-business-days'
+import moment from 'moment'
 
 require('react-datepicker/dist/react-datepicker.css');
 
-const FIRST_SELECTABLE_DATE = moment().businessAdd(5);
+const FIRST_SELECTABLE_DATE = moment().add(5, 'days');
+const LAST_START_DATE = moment().add(1, 'year');
 const MAX_WEEKS = 3;
 
 function filterDate(packageName, exclusionList) {
@@ -38,6 +39,7 @@ export default {
             <CustomDateRangePicker className="input-text"
                                    maxWeeks={MAX_WEEKS}
                                    firstSelectableDate={FIRST_SELECTABLE_DATE}
+                                   lastStartDate={LAST_START_DATE}
                                    dateFormat="D MMMM YYYY" locale="en-gb"
                                    filterDate={filterDateFn}
                                    remainingDays={remainingDays}

--- a/assets/stylesheets/modules/_suspend.scss
+++ b/assets/stylesheets/modules/_suspend.scss
@@ -32,13 +32,16 @@
 }
 .suspend-container__sidebar {
     position: relative;
+    display: none;
 
     @include mq(desktop) {
+        display: block;
         float: right;
         width: 35%;
         padding-left: $gs-gutter;
     }
     @include mq(wide) {
+        display: block;
         padding-left: gs-span(1.5);
     }
 }
@@ -46,101 +49,8 @@
     cursor: pointer;
 }
 
-/* Notice
-   ========================================================================== */
-
-.notices-container {
-    display: none;
-    @include mq(tablet) {
-        display: block;
-    }
-}
-.notice {
-    @include fs-textSans(2);
-    border-top: 1px dotted $c-neutral5;
-    padding-top: $gs-baseline / 2;
-    margin-bottom: $gs-baseline;
-}
-.notice__header {
-    font-weight: 900;
-}
-
-/* Review Details
-   ========================================================================== */
-
-.review-details {
-    @include fs-bodyCopy(2);
-}
-.review-details__item {
-    margin-bottom: $gs-gutter;
-
-    @include mq(tablet) {
-        display: table;
-        width: 100%
-    }
-}
-.review-details__heading,
-.review-details__list {
-    @include mq(tablet) {
-        display: table-cell;
-        vertical-align: top;
-    }
-}
-.review-details__heading {
-    @include fs-bodyHeading(2);
-
-    @include mq(tablet) {
-        width: 35%;
-        padding-right: $gs-gutter;
+.suspend__table {
+    .date, .money {
         text-align: right;
     }
-}
-.review-details__actions {
-    @include mq(tablet) {
-        margin-left: 35%;
-    }
-}
-
-
-/* ==========================================================================
-   Review Panel
-   ========================================================================== */
-
-.review-panel {
-    @include fs-bodyCopy(2);
-    background: $c-neutral7;
-    border-top: 1px solid $c-border;
-    padding: $gs-gutter / 2;
-}
-.review-panel__item {
-    padding-bottom: $gs-baseline;
-
-    @include mq(tablet) {
-        display: table;
-        width: 100%
-    }
-}
-.review-panel__label,
-.review-panel__details {
-    @include mq(tablet) {
-        display: table-cell;
-        vertical-align: top;
-    }
-}
-.review-panel__label {
-    font-weight: bold;
-
-    @include mq(tablet) {
-        text-align: right;
-        padding-right: $gs-gutter;
-        width: gs-span(3);
-    }
-}
-
-/* ==========================================================================
-   Thank you page
-   ========================================================================== */
-
-.finish-account-error {
-    color: guss-colour(error);
 }


### PR DESCRIPTION
- Put the billing schedule into its own view template, and also added the rollup logic.
- Added the template to the suspend page and the checkout page. This meant I could remove the promotion-applying-to-plan-price logic - much happier that we won't tell the customer the wrong thing now.
- Removed already-taken dates from the calendar so  the user won't accidentally pick them.
- Added a 1-year-ahead limit to the start date.
- Added the red banner to the top of the page so we are reminded what environment we are in.

cc @tomverran @nlindblad @mario-galic 