### PR TITLE
Login link in the email lookup error message

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -287,8 +287,8 @@ object Checkout extends Controller with LazyLogging with ActivityTracking with C
     }
   }
 
-  def validateDelivery(postCode: String) = NoCacheAction { implicit request =>
-    HomeDeliveryPostCodes.findDistrict(postCode).fold(NotAcceptable(""))(_ => Ok(""))
+  def validateDelivery(postCode: String) = CachedAction { implicit request =>
+    HomeDeliveryPostCodes.findDistrict(postCode).fold(NotAcceptable(""))(pc => Ok(Json.obj("availableDistrict" -> pc)))
   }
 
   def checkIdentity(email: String) = CachedAction.async { implicit request =>

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -135,7 +135,7 @@
                                     <a href="@idWebAppSignOutUrl(routes.Checkout.renderCheckout(countryGroup, promoCode, productData.plans.default.slug))">Sign out</a>
                                 } else {
                                     <span class="field-note__label">Already have a Guardian account?</span>
-                                    <a href="@idWebAppSigninUrl(routes.Checkout.renderCheckout(countryGroup, promoCode, productData.plans.default.slug))">Sign in</a>
+                                    <a class="js-sign-in-link" href="@idWebAppSigninUrl(routes.Checkout.renderCheckout(countryGroup, promoCode, productData.plans.default.slug))">Sign in</a>
                                 }
                             </div>
                         </div>

--- a/app/views/fragments/checkout/fieldsPersonal.scala.html
+++ b/app/views/fragments/checkout/fieldsPersonal.scala.html
@@ -37,8 +37,8 @@
 @* ===== Email ===== *@
 <div class="form-field @if(form.isEmpty) {js-checkout-email}">
     <label class="label" for="email">Email address</label>
-    <input type="email" class="input-text js-input" name="personal.emailValidation.email" id="email"
-        value="@form.map(_.email)" maxlength="80" @signedInAttrs>
+    <input type="email" class="input-text js-input"  name="personal.emailValidation.email" id="email"
+        value="@form.map(_.email)" maxlength="80" @signedInAttrs data-validation-url="@{routes.Checkout.checkIdentity("").path.replaceFirst("\\?.*", "")}">
     @fragments.forms.errorMessage("")
 </div>
 <div class="form-field @if(form.isEmpty) {js-checkout-confirm-email}">

--- a/assets/javascripts/modules/checkout/deliveryDetails.js
+++ b/assets/javascripts/modules/checkout/deliveryDetails.js
@@ -66,8 +66,8 @@ define([
             validationUrl = $deliveryPostcodeContainer.data('validation-url');
             ORIGINAL_ERROR_MESSAGE = ORIGINAL_ERROR_MESSAGE || $errorLabel.text();
 
-        // remove all whitespace for the lookup
-        postCodeStr = postCodeStr.replace(/\s+/g, '');
+        // remove all whitespace for the lookup and trim to at most 4 characters for more user privacy
+        postCodeStr = postCodeStr.replace(/\s+/g, '').substring(0, 4);
 
         if (postCodeStr.length < 2) {
             POSTCODE_ELIGIBLE = true;

--- a/assets/javascripts/modules/checkout/formElements.js
+++ b/assets/javascripts/modules/checkout/formElements.js
@@ -56,6 +56,8 @@ define(['$'], function ($) {
         $CHECKOUT_FORM: $('.js-checkout-form'),
         $NOTICES: $('.js-checkout-notices'),
 
+        $SIGN_IN_LINK: $('.js-sign-in-link'),
+
         BILLING: addressFields('.js-billing-address'),
         DELIVERY: addressFields('.js-checkout-delivery'),
 

--- a/assets/javascripts/modules/checkout/personalDetails.js
+++ b/assets/javascripts/modules/checkout/personalDetails.js
@@ -29,7 +29,7 @@ define([
         toggleError(formEls.$EMAIL_CONTAINER, validity.isEmailInUse);
 
         if(validity.emailMessage) {
-            formEls.$EMAIL_ERROR.text(validity.emailMessage);
+            formEls.$EMAIL_ERROR.html(validity.emailMessage);
             toggleError(formEls.$EMAIL_CONTAINER, true);
         }
     }
@@ -50,7 +50,7 @@ define([
     }
 
     function handleValidation(personalDetails) {
-        
+
         var basicValidity = checkFields.checkRequiredFields(formEls.$FIELDSET_YOUR_DETAILS);
         loader.setLoaderElem(document.querySelector('.js-personal-details-validating'));
         loader.startLoader();

--- a/assets/javascripts/modules/checkout/validatePersonal.js
+++ b/assets/javascripts/modules/checkout/validatePersonal.js
@@ -1,12 +1,20 @@
 define([
     'utils/ajax',
+    'modules/checkout/formElements',
     'modules/forms/regex',
     'modules/raven'
-], function (ajax, regex, raven) {
+], function (ajax, formElements, regex, raven) {
     'use strict';
 
     function emailCheck(email) {
-        return ajax({ url: '/checkout/check-identity?email=' + encodeURIComponent(email) }).then(function (response) {
+        return ajax({
+            method: 'GET',
+            type: 'json',
+            url: formElements.$EMAIL.data('validation-url'),
+            data: {
+                'email': email
+            }
+        }).then(function (response) {
             return response.emailInUse;
         }).fail(function (err) {
             raven.Raven.captureException(err);
@@ -17,8 +25,8 @@ define([
 
         var MESSAGES = {
             emailInvalid: 'Please enter a valid email address.',
-            emailTaken: 'Your email is already in use. Please sign in or use another email address.',
-            emailFailure: 'There has been a problem. Please try again later.'
+            emailTaken: 'You already have a Guardian account. Please <a class="u-nowrap" href="' + formElements.$SIGN_IN_LINK.attr('href') + '">sign in</a> or use another email address.',
+            emailFailure: 'Sorry there has been a problem. Please try again later.'
         };
 
         /**
@@ -43,11 +51,11 @@ define([
                 requiredFieldValues: data.requiredFieldValues,
                 hasValidEmail: hasValidEmail,
                 hasConfirmedEmail: hasConfirmedEmail,
-                emailMessage: (hasValidEmail) ? false : MESSAGES.emailInvalid,
+                emailMessage: hasValidEmail ? false : MESSAGES.emailInvalid,
                 isEmailInUse: false
             };
-            
-            
+
+
             /**
              * If the user is signed in we do not need to
              * validate their email address


### PR DESCRIPTION
- Added a link to the error message which appears when the email address is already assigned to an Identity account. This should hopefully encourage users to really log in.
- Made the URL for the email validation come from reverse routing than be specified in the JavaScript file.
- Trimmed the postcode lookup to just 4 characters as that's the longest district code in the lookup - adds a bit more privacy. Also added a cache header to that response.

cc @tomverran @nlindblad @mario-galic 