### PR TITLE
More Google Analytics dimensions and better redirects

### DIFF
--- a/app/controllers/DigitalPack.scala
+++ b/app/controllers/DigitalPack.scala
@@ -1,33 +1,31 @@
 package controllers
 
-import actions.CommonActions.{CachedAction, NoCacheAction}
-import com.gu.i18n.CountryGroup
-import com.netaporter.uri.{PathPart, StringPathPart, Uri}
-import com.netaporter.uri.dsl._
+import actions.CommonActions._
+import com.gu.i18n.CountryGroup.UK
 import model.DigitalEdition
 import model.DigitalEdition._
 import play.api.mvc._
 import services.TouchpointBackend
-import views.support.Pricing._
 import utils.RequestCountry._
+import views.support.Pricing._
 
 object DigitalPack extends Controller {
-  def uk = landingPage(UK)
-  def us = landingPage(US)
-  def au = landingPage(AU)
-  def int = landingPage(INT)
+
+  private def redirectResult(digitalEdition: DigitalEdition)(implicit request: Request[AnyContent]) =
+    Redirect(routes.DigitalPack.landingPage(digitalEdition.id).url, request.queryString, SEE_OTHER)
 
   def redirect = NoCacheAction { implicit request =>
-    val countryGroup = request.getFastlyCountry.getOrElse(CountryGroup.UK)
-    val baseUri = Uri.parse(request.uri)
-    val redirectUri = baseUri.copy(pathParts = baseUri.pathParts.+:(StringPathPart(getForCountryGroup(countryGroup).id)))
-    Redirect(request.toUriWithCampaignParams(redirectUri), SEE_OTHER)
+    val countryGroup = request.getFastlyCountry.getOrElse(UK)     // UK fallback for when no GEO-IP country (test env)
+    val digitalEdition = getById(countryGroup.id).getOrElse(INT)
+    redirectResult(digitalEdition)
   }
 
-  def landingPage(digitalEdition: DigitalEdition) = CachedAction {
-    val plan = TouchpointBackend.Normal.catalogService.digipackCatalog.digipackMonthly
-    val price = plan.pricing.getPrice(digitalEdition.countryGroup.currency).getOrElse(plan.gbpPrice)
-    Ok(views.html.digitalpack.info(digitalEdition, price))
+  def landingPage(code: String) = CachedAction { implicit request =>
+    getById(code).fold(redirectResult(INT)) { digitalEdition =>
+      val plan = TouchpointBackend.Normal.catalogService.digipackCatalog.digipackMonthly
+      val price = plan.pricing.getPrice(digitalEdition.countryGroup.currency).getOrElse(plan.gbpPrice)
+      Ok(views.html.digitalpack.info(digitalEdition, price))
+    }
   }
 
 }

--- a/app/controllers/DigitalPack.scala
+++ b/app/controllers/DigitalPack.scala
@@ -16,7 +16,7 @@ object DigitalPack extends Controller {
 
   def redirect = NoCacheAction { implicit request =>
     val countryGroup = request.getFastlyCountry.getOrElse(UK)     // UK fallback for when no GEO-IP country (test env)
-    val digitalEdition = getById(countryGroup.id).getOrElse(INT)
+    val digitalEdition = getForCountryGroup(countryGroup)
     redirectResult(digitalEdition)
   }
 

--- a/app/controllers/Homepage.scala
+++ b/app/controllers/Homepage.scala
@@ -2,9 +2,6 @@ package controllers
 
 import actions.CommonActions._
 import com.gu.i18n.CountryGroup
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
-import model.DigitalEdition
 import model.DigitalEdition._
 import utils.RequestCountry._
 import play.api.mvc._
@@ -13,17 +10,16 @@ object Homepage extends Controller {
 
   def index = NoCacheAction { implicit request =>
     val countryGroup = request.getFastlyCountry.getOrElse(CountryGroup.UK)
-    val redirectUri = Uri.parse(request.uri) / getForCountryGroup(countryGroup).id
-    Redirect(request.toUriWithCampaignParams(redirectUri), SEE_OTHER)
+    val digitalEdition = getById(countryGroup.id).getOrElse(INT)
+    Redirect(routes.Homepage.landingPage(digitalEdition.id).url, request.queryString, SEE_OTHER)
   }
 
-  def indexUk = CachedAction(Ok(views.html.index()))
-
-  def internationalHomepage(edition: DigitalEdition) = CachedAction(Ok(views.html.index_intl(edition)))
-
-  def indexAu = internationalHomepage(AU)
-
-  def indexUs = internationalHomepage(US)
-
-  def indexInt = internationalHomepage(INT)
+  def landingPage(code: String) = CachedAction {
+    getById(code).fold {
+      NotFound(views.html.error404())
+    } {
+      case UK => Ok(views.html.index())
+      case digitalEdition => Ok(views.html.index_intl(digitalEdition))
+    }
+  }
 }

--- a/app/controllers/Homepage.scala
+++ b/app/controllers/Homepage.scala
@@ -13,7 +13,7 @@ object Homepage extends Controller {
 
   def index = NoCacheAction { implicit request =>
     val countryGroup = request.getFastlyCountry.getOrElse(CountryGroup.UK)
-    val redirectUri = Uri(request.uri) / getForCountryGroup(countryGroup).id
+    val redirectUri = Uri.parse(request.uri) / getForCountryGroup(countryGroup).id
     Redirect(request.toUriWithCampaignParams(redirectUri), SEE_OTHER)
   }
 

--- a/app/model/DigitalEdition.scala
+++ b/app/model/DigitalEdition.scala
@@ -18,4 +18,6 @@ object DigitalEdition {
       case _ => None
     }
   }
+
+  def getForCountryGroup(countryGroup: CountryGroup) = getById(countryGroup.id).getOrElse(INT)
 }

--- a/app/model/DigitalEdition.scala
+++ b/app/model/DigitalEdition.scala
@@ -9,12 +9,13 @@ object DigitalEdition {
   object INT extends DigitalEdition(CountryGroup.RestOfTheWorld, "int", "International", "dis_2378")
   object AU extends DigitalEdition(CountryGroup.Australia, "au", "Australia", "dis_2379")
 
-  def getForCountryGroup(countryGroup: CountryGroup): DigitalEdition = {
-    countryGroup match {
-      case CountryGroup.UK => UK
-      case CountryGroup.US => US
-      case CountryGroup.Australia => AU
-      case _ => INT
+  def getById(id: String): Option[DigitalEdition] = {
+    id match {
+      case UK.id => Some(UK)
+      case US.id => Some(US)
+      case AU.id => Some(AU)
+      case INT.id => Some(INT)
+      case _ => None
     }
   }
 }

--- a/app/utils/RequestCountry.scala
+++ b/app/utils/RequestCountry.scala
@@ -11,7 +11,7 @@ object RequestCountry {
     def toUriWithCampaignParams(defaultUri: Uri) = Seq("INTCMP", "CMP", "mcopy").foldLeft[Uri](defaultUri) { (url, param) =>
       // No need to filter out the params that aren't present because if the `?` method gets a key-value tuple
       // with value of None, that parameter will not be rendered when toString is called
-      url ? (param -> r.getQueryString(param))
+      url.removeParams(param) ? (param -> r.getQueryString(param))
     }
   }
 }

--- a/app/utils/RequestCountry.scala
+++ b/app/utils/RequestCountry.scala
@@ -8,11 +8,6 @@ import play.api.mvc.Request
 object RequestCountry {
   implicit class RequestWithFastlyCountry(r: Request[_]) {
     def getFastlyCountry = r.headers.get("X-GU-GeoIP-Country-Code").flatMap(CountryGroup.byFastlyCountryCode)
-    def toUriWithCampaignParams(defaultUri: Uri) = Seq("INTCMP", "CMP", "mcopy").foldLeft[Uri](defaultUri) { (url, param) =>
-      // No need to filter out the params that aren't present because if the `?` method gets a key-value tuple
-      // with value of None, that parameter will not be rendered when toString is called
-      url.removeParams(param) ? (param -> r.getQueryString(param))
-    }
   }
 }
 

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -23,11 +23,15 @@
 <script type="text/javascript">
     guardian.pageInfo.slug="GuardianDigiPack:Order Complete";
     guardian.pageInfo.productData = {
+        // Omniture - TODO - fix the type field
         source: 'Subscriptions and Membership',
         type: 'GUARDIAN_DIGIPACK',
         eventName: 'purchase',
         amount: @{plan.gbpPrice.amount},
-        frequency: @{plan.billingPeriod.numberOfMonths}
+        frequency: @{plan.billingPeriod.numberOfMonths},
+        // Google Analtics
+        zuoraId: '@subscriptionName',
+        productPurchased: '@plan.name'
     };
 </script>
 

--- a/assets/javascripts/modules/analytics/ga.js
+++ b/assets/javascripts/modules/analytics/ga.js
@@ -45,7 +45,7 @@ define(['modules/analytics/analyticsEnabled',
                 ga('membershipPropertyTracker.set', 'dimension9', productData.zuoraId);   // zuoraId
             }
             if (productData.productPurchased) {
-                ga('membershipPropertyTracker.set', 'dimension11', guardian.productData.productPurchased);  // productPurchased
+                ga('membershipPropertyTracker.set', 'dimension11', productData.productPurchased);  // productPurchased
             }
         }
 

--- a/assets/javascripts/modules/analytics/ga.js
+++ b/assets/javascripts/modules/analytics/ga.js
@@ -9,6 +9,8 @@ define(['modules/analytics/analyticsEnabled',
         var identitySignedIn = user.isLoggedIn();
         var identitySignedOut = !!cookie.getCookie('GU_SO') && !identitySignedIn;
         var ophanBrowserId = cookie.getCookie('bwid');
+        var productData = guardian.productData;
+        var intcmp = new RegExp('INTCMP=([^&]*)').exec(location.search);
 
         /* Google analytics snippet */
         /*eslint-disable */
@@ -37,6 +39,19 @@ define(['modules/analytics/analyticsEnabled',
         ga('membershipPropertyTracker.set', 'dimension5', 'subscriptions');               // platform
         (identitySignedIn) && ga('membershipPropertyTracker.set', 'dimension6', user.getUserFromCookie().id); // identityId
         ga('membershipPropertyTracker.set', 'dimension7', identitySignedIn.toString());   // isLoggedOn
+
+        if (productData) {
+            if (productData.zuoraId) {
+                ga('membershipPropertyTracker.set', 'dimension9', productData.zuoraId);   // zuoraId
+            }
+            if (productData.productPurchased) {
+                ga('membershipPropertyTracker.set', 'dimension11', guardian.productData.productPurchased);  // productPurchased
+            }
+        }
+
+        if (intcmp && intcmp[1]) {
+            ga('membershipPropertyTracker.set', 'dimension12', intcmp[1]);  // internalCampCode
+        }
 
         ga('membershipPropertyTracker.send', 'pageview');
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val root = (project in file(".")).enablePlugins(
     )
   .settings(play.sbt.routes.RoutesKeys.routesImport ++= Seq(
       "controllers.Binders._",
+      "model.DigitalEdition",
       "com.gu.i18n.CountryGroup",
       "com.gu.i18n.Country",
       "com.gu.memsub.promo.PromoCode",

--- a/conf/routes
+++ b/conf/routes
@@ -7,10 +7,6 @@ GET         /favicon.ico                     controllers.CacheBustedAssets.at(pa
 
 # Editions homepage
 GET         /                                controllers.Homepage.index
-GET         /uk                              controllers.Homepage.indexUk
-GET         /au                              controllers.Homepage.indexAu
-GET         /us                              controllers.Homepage.indexUs
-GET         /int                             controllers.Homepage.indexInt
 
 # Health check
 GET         /healthcheck                     controllers.Management.healthcheck
@@ -19,10 +15,7 @@ GET         /management/manifest             controllers.Management.manifest
 
 # Digital pack
 GET         /digital                         controllers.DigitalPack.redirect
-GET         /uk/digital                      controllers.DigitalPack.uk
-GET         /us/digital                      controllers.DigitalPack.us
-GET         /au/digital                      controllers.DigitalPack.au
-GET         /int/digital                     controllers.DigitalPack.int
+GET         /:code/digital                   controllers.DigitalPack.landingPage(code: String)
 
 # Checkout AJAX endpoints
 POST        /checkout                        controllers.Checkout.handleCheckout
@@ -72,3 +65,6 @@ GET         /p/:promoCodeStr                 controllers.PromoLandingPage.render
 POST        /q                               controllers.PromoLandingPage.preview
 
 GET         /manage                          controllers.Testing.manageHoldingPage
+
+# Editions hommepage or 404
+GET         /:edition                        controllers.Homepage.landingPage(edition: String)


### PR DESCRIPTION
- Added the product name, the zuora ID and the internal campaign code dimensions when relevant, to Google Analytics pageviews.
- Also fixed redirects for INTCMP which added two copies of the parameter to the query string when redirecting, so instead we just preserve all query parameters when redirecting.  All ready for the new Google Analytics 'utm_' external campaign codes.
- Changed how the homepage and /digital edition redirects work, removing the edition enumerations from the routes and controller files.

cc @ajosephides @AWare @rtyley 