### PR TITLE
Removed internal uses of INTCMP codes

### DIFF
--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -28,7 +28,7 @@ object PromoLandingPage extends Controller {
       promotion <- tpBackend.promoService.findPromotion(promoCode)
       promotionWithLandingPage <- promotion.asDigipack
       html <- if ((evaluateStarts && promotionWithLandingPage.starts.isAfterNow) || promotionWithLandingPage.expires.exists(_.isBeforeNow)) None else Some(views.html.promotion.landingPage(edition, catalog, promoCode, promotionWithLandingPage, Config.Zuora.paymentDelay, PegdownMarkdownRenderer))
-    } yield Ok(html)).getOrElse(Redirect("/digital" ? ("INTCMP" -> s"FROM_P_${promoCode.get}")))
+    } yield Ok(html)).getOrElse(Redirect("/digital" ? ("INTCMP" -> s"FROM_P_${promoCode.get}"))) // deliberate internal use of INTCMP code to track redirecting promos
   }
 
   def preview() = GoogleAuthenticatedStaffAction { implicit request =>

--- a/app/views/fragments/global/navigation.scala.html
+++ b/app/views/fragments/global/navigation.scala.html
@@ -5,10 +5,10 @@
 @(edition: DigitalEdition)
 <nav class="global-nav">
     <div class="global-nav__inner gs-container">
-        <a href="/?INTCMP=GU_SUBSCRIPTIONS_NAV" class="global-nav__link">home</a>
-        <a href="/@edition.id/digital?INTCMP=GU_SUBSCRIPTIONS_NAV" class="global-nav__link">digital</a>
+        <a href="/" class="global-nav__link">home</a>
+        <a href="/@edition.id/digital" class="global-nav__link">digital</a>
         @if(edition == UK) {
-            <a href="/collection/paper?INTCMP=GU_SUBSCRIPTIONS_NAV" class="global-nav__link">paper</a>
+            <a href="/collection/paper" class="global-nav__link">paper</a>
         }
         <a href="@edition.getMembershipLandingPage("GU_SUBSCRIPTIONS_NAV")" class="global-nav__link">membership</a>
     </div>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -22,7 +22,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/uk/digital?INTCMP=GU_SUBSCRIPTIONS_DIGITAL" data-test-id="subscriptions-uk-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="/uk/digital" data-test-id="subscriptions-uk-digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper-digital">
@@ -37,7 +37,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/collection/paper-digital?INTCMP=GU_SUBSCRIPTIONS_PACKAGES" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="/collection/paper-digital" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper">
@@ -52,7 +52,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/collection/paper?INTCMP=GU_SUBSCRIPTIONS_PACKAGES" data-test-id="subscriptions-uk-paper">Subscribe now</a>
+                    <a class="button button--large button--primary" href="/collection/paper" data-test-id="subscriptions-uk-paper">Subscribe now</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Removed internal uses of INTCMP codes, these should be for navigating across sites only. Google Analytics has the linkid plugin installed to solve thie "which link did the customer use" problem.

cc @ajosephides @nlindblad 