### PR TITLE
Support supplier codes to facilitate inbound channel tracking.

### DIFF
--- a/app/controllers/SessionKeys.scala
+++ b/app/controllers/SessionKeys.scala
@@ -1,0 +1,13 @@
+package controllers
+
+object SessionKeys {
+  val SubsName = "newSubs_subscriptionName"
+  val RatePlanId = "newSubs_ratePlanId"
+  val UserId = "newSubs_userId"
+  val IdentityGuestPasswordSettingToken = "newSubs_token"
+  val AppliedPromoCode = "newSubs_appliedPromoCode"
+  val PromotionTrackingCode = "newSubs_trackingCode"
+  val SupplierTrackingCode = "newSubs_supplierCode"
+  val Currency = "newSubs_currency"
+  val StartDate = "newSubs_startDate"
+}

--- a/app/controllers/Shipping.scala
+++ b/app/controllers/Shipping.scala
@@ -22,7 +22,7 @@ object Shipping extends Controller {
   def planToOptions(in: ProductPlan[PhysicalProducts]): SubscriptionOption =
     SubscriptionOption(in.slug,
       in.name, in.priceGBP.amount * 12 / 52, in.saving.map(_.toString + "%"), in.priceGBP.amount, in.description,
-      routes.Checkout.renderCheckout(CountryGroup.UK, None, in.slug).url
+      routes.Checkout.renderCheckout(CountryGroup.UK, None, None, in.slug).url
     )
 
   def viewCollectionPaperDigital() = CachedAction {

--- a/app/model/SubscriptionData.scala
+++ b/app/model/SubscriptionData.scala
@@ -4,7 +4,7 @@ import com.gu.i18n.Country.UK
 import com.gu.i18n.{Country, CountryGroup, Title}
 import com.gu.identity.play.IdUser
 import com.gu.memsub.Subscription.ProductRatePlanId
-import com.gu.memsub.{Address, BillingPeriod, Current, FullName}
+import com.gu.memsub._
 import com.gu.memsub.promo.PromoCode
 import IdUserOps._
 import com.gu.subscriptions.{DigipackPlan, DigitalProducts, PhysicalProducts, ProductPlan}
@@ -55,9 +55,9 @@ case class PersonalData(first: String,
 }
 
 case class SubscriptionData(
- personalData: PersonalData,
- paymentData: PaymentData,
- suppliedPromoCode: Option[PromoCode]
+   personalData: PersonalData,
+   paymentData: PaymentData,
+   promoCode: Option[PromoCode]
 )
 
 case class DigipackData(

--- a/app/model/SubscriptionRequestData.scala
+++ b/app/model/SubscriptionRequestData.scala
@@ -2,5 +2,6 @@ package model
 
 import java.net.InetAddress
 
-// TODO promotionCode will be added soon
-case class SubscriptionRequestData(ipAddress: Option[InetAddress])
+import com.gu.memsub.SupplierCode
+
+case class SubscriptionRequestData(ipAddress: Option[InetAddress], supplierCode: Option[SupplierCode])

--- a/app/model/exactTarget/DataExtensionRow.scala
+++ b/app/model/exactTarget/DataExtensionRow.scala
@@ -225,5 +225,5 @@ case class PaperHomeDeliveryWelcome1DataExtensionRow(email: String, fields: Seq[
 }
 
 case class HolidaySuspensionBillingScheduleDataExtensionRow(email: String, fields: Seq[(String, String)]) extends DataExtensionRow {
-  override def forExtension = HolidaySuspensionBillingSchedule
+  override def forExtension = HolidaySuspensionBillingScheduleExtension
 }

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -7,6 +7,7 @@
 @import views.support.CountryWithCurrency
 @import views.support.Pricing._
 @import com.gu.memsub.promo.PromoCode
+@import com.gu.memsub.SupplierCode
 @import model.PersonalData
 @import views.support.PlanOps._
 @import views.support.ProductPopulationData
@@ -30,6 +31,7 @@
     countriesWithCurrency: List[CountryWithCurrency],
     touchpointBackendResolution: services.TouchpointBackend.Resolution,
     promoCode: Option[PromoCode],
+    supplierCode: Option[SupplierCode],
     edition: DigitalEdition
 )(implicit request: RequestHeader)
 
@@ -75,12 +77,12 @@
 <main class="page-container gs-container">
 
     <section class="checkout-container">
+        @fragments.checkout.checkoutHeader(productData.plans.default.title)
+
         <form class="form js-checkout-form" action="" method="POST" novalidate>
             @helper.CSRF.formField
 
-            @fragments.checkout.checkoutHeader(productData.plans.default.title)
-
-            @* ===== Plan selection ===== *@
+                @* ===== Plan selection ===== *@
             <div class="checkout-container__sidebar js-basket">
                 @fragments.checkout.basketPreview(productData.plans.default)
                 @if(productData.plans.list.length > 1) {
@@ -130,12 +132,17 @@
                             <div class="field-note field-note--offset">
                                 @fragments.forms.securityNote()
                             </div>
+                            @supplierCode.map { code =>
+                                <div class="field-note field-note--offset">
+                                    <span class="field-note__label">Supplier code: @code.get</span>
+                                </div>
+                            }
                             <div class="field-note field-note--offset prose">
                                 @if(personalData.isDefined) {
-                                    <a href="@idWebAppSignOutUrl(routes.Checkout.renderCheckout(countryGroup, promoCode, productData.plans.default.slug))">Sign out</a>
+                                    <a href="@idWebAppSignOutUrl(routes.Checkout.renderCheckout(countryGroup, promoCode, None, productData.plans.default.slug))">Sign out</a>
                                 } else {
                                     <span class="field-note__label">Already have a Guardian account?</span>
-                                    <a class="js-sign-in-link" href="@idWebAppSigninUrl(routes.Checkout.renderCheckout(countryGroup, promoCode, productData.plans.default.slug))">Sign in</a>
+                                    <a class="js-sign-in-link" href="@idWebAppSigninUrl(routes.Checkout.renderCheckout(countryGroup, promoCode, None, productData.plans.default.slug))">Sign in</a>
                                 }
                             </div>
                         </div>

--- a/app/views/testing/testUsers.scala.html
+++ b/app/views/testing/testUsers.scala.html
@@ -31,7 +31,7 @@
                 <h4>@group.name</h4>
                 <dl>
                 @for(plan <- group.productPlans.sortBy(_.priceGBP.amount)) {
-                    <a href="@routes.Checkout.renderCheckout(UK, None, plan.slug)" style="margin-bottom: 10px" class="button button--primary button--large">@plan.name (@{(plan.priceGBP * 12 / 52).pretty}/w, @plan.priceGBP.pretty/m)</a>
+                    <a href="@routes.Checkout.renderCheckout(UK, None, None, plan.slug)" style="margin-bottom: 10px" class="button button--primary button--large">@plan.name (@{(plan.priceGBP * 12 / 52).pretty}/w, @plan.priceGBP.pretty/m)</a>
                 }
                 </dl>
             }
@@ -45,7 +45,7 @@
                 <h4>@group.name</h4>
                 <dl>
                     @for(plan <- group.productPlans.sortBy(_.priceGBP.amount)) {
-                        <a href="@idWebAppRegisterUrl(routes.Checkout.renderCheckout(UK, None, plan.slug))" style="margin-bottom: 10px" class="button button--primary button--large">@plan.name (@{(plan.priceGBP * 12 / 52).pretty}/w, @plan.priceGBP.pretty/m)</a>
+                        <a href="@idWebAppRegisterUrl(routes.Checkout.renderCheckout(UK, None, None, plan.slug))" style="margin-bottom: 10px" class="button button--primary button--large">@plan.name (@{(plan.priceGBP * 12 / 52).pretty}/w, @plan.priceGBP.pretty/m)</a>
                     }
                 </dl>
             }

--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ lazy val root = (project in file(".")).enablePlugins(
       "com.gu.i18n.CountryGroup",
       "com.gu.i18n.Country",
       "com.gu.memsub.promo.PromoCode",
+      "com.gu.memsub.SupplierCode",
       "com.gu.memsub.Subscription.ProductRatePlanId"
   ))
 
@@ -41,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.256",
+    "com.gu" %% "membership-common" % "0.259",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",
@@ -54,7 +55,6 @@ libraryDependencies ++= Seq(
     "com.squareup.okhttp" % "okhttp" % "2.4.0",
     "com.snowplowanalytics" % "snowplow-java-tracker" % "0.5.2-SNAPSHOT",
     "com.github.t3hnar" %% "scala-bcrypt" % "2.4",
-    "org.apache.commons" % "commons-io" % "1.3.2",
     "org.scalaz" %% "scalaz-core" % "7.1.3",
     "org.pegdown" % "pegdown" % "1.6.0",
     "com.amazonaws" % "aws-java-sdk-sqs" % "1.10.50",

--- a/conf/routes
+++ b/conf/routes
@@ -26,8 +26,8 @@ GET         /checkout/lookupPromotion        controllers.Checkout.validatePromoC
 GET         /checkout/validateDelivery       controllers.Checkout.validateDelivery(postCode: String)
 # Checkout pages
 GET         /checkout/thank-you              controllers.Checkout.thankYou()
-GET         /checkout                        controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], forThisPlan = "")
-GET         /checkout/:forThisPlan           controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], forThisPlan: String)
+GET         /checkout                        controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], supplierCode: Option[SupplierCode], forThisPlan = "")
+GET         /checkout/:forThisPlan           controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], supplierCode: Option[SupplierCode], forThisPlan: String)
 
 # collection and delivery
 GET         /collection/paper-digital        controllers.Shipping.viewCollectionPaperDigital
@@ -63,6 +63,9 @@ GET         /p/:promoCodeStr                 controllers.PromoLandingPage.render
 
 # NOCSRF
 POST        /q                               controllers.PromoLandingPage.preview
+
+# Promotions
+GET         /s/:supplierCodeStr              controllers.Homepage.supplierRedirect(supplierCodeStr: String)
 
 GET         /manage                          controllers.Testing.manageHoldingPage
 


### PR DESCRIPTION
Changes required to handle supplier codes to facilitate inbound channel tracking.

The idea is that the call centre would bookmark: https://subscribe.theguardian.com/s/:supplierCode to redirect to the homepage, or have a catalog of deep links to the checkout: https://subscribe.theguardian.com/checkout?supplierCode=:supplierCode  and then all subscriptions made by them would be tracked against their supplier code as the code would be stored in their browser session. 

- The query parameter or path value always wins over the session.
- This functionality works irrespective to promo codes and tracking promo codes which are for outbound channel tracking.
- The change requires Zuora to add a custom field called SupplierCode__c and for it to get replicated everywhere like the PromotionCode__c custom field.
- I also tidied up the error messages in Binders.scala and renamed suppliedPromoCode to just promoCode in SubscriptionData.scala

cc @tomverran @nlindblad @mario-galic 