### PR TITLE
Adding prefix to supplier redirect so we can filter in GA

### DIFF
--- a/app/controllers/Homepage.scala
+++ b/app/controllers/Homepage.scala
@@ -32,7 +32,7 @@ object Homepage extends Controller {
       val newSession = request.session - SupplierTrackingCode
       Redirect(url, request.queryString, SEE_OTHER).withSession(newSession)  // clear any supplier code
     } { supplierCode =>
-      val newQueryString = request.queryString + ("INTCMP" -> Seq(supplierCode.get))
+      val newQueryString = request.queryString + ("INTCMP" -> Seq(s"FROM_S_${supplierCode.get}"))
       Redirect(url, newQueryString, SEE_OTHER).withSession(request.session + (SupplierTrackingCode -> supplierCode.get))
     }
   }


### PR DESCRIPTION
This helps us identify requests that have come from the supplier redirect, by making the campaign codes have a prefix. This is the same as what we do for the non-landing-page promotions redirect.

cc @nlindblad @tomverran