### PR TITLE
Base suspension start date off the customer acceptance date

### DIFF
--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -15,6 +15,8 @@
 @import views.support.Dates.prettyDate
 @import views.support.PlanOps._
 
+@import org.joda.time.LocalDate
+@import org.joda.time.LocalDate.now
 @(
     subscription: Subscription with PaidPS[ProductPlan[PhysicalProducts]],
     holidayRefunds: Seq[HolidayRefund] = Seq.empty,
@@ -58,7 +60,10 @@
                     </dd>
 
                     <dt class="mma-section__list--title">Monthly cost</dt>
-                    <dd class="mma-section__list--content"> @subscription.plan.priceGBP.pretty</dd>
+                    <dd class="mma-section__list--content">@subscription.plan.priceGBP.pretty</dd>
+
+                    <dt class="mma-section__list--title">First payment</dt>
+                    <dd class="mma-section__list--content">@prettyDate(subscription.firstPaymentDate)</dd>
                 </dl>
             </section>
 

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -73,6 +73,7 @@
 
                             <div class="form-field js-suspend-start-date mma-dates__fields">
                                 <div id="dateRangePicker"
+                                firstPaymentDate="@prettyDate(subscription.firstPaymentDate)"
                                 remainingDays="@{suspendableDays - suspendedDays}"
                                 excludeExistingDays="@{holidayRefunds.flatMap(x => holidayToDays(x._2.start, x._2.finish)).map(prettyDate).mkString(",")}"
                                 ratePlanName="@subscription.plan.name"></div>

--- a/assets/javascripts/modules/suspend/suspendFields.jsx
+++ b/assets/javascripts/modules/suspend/suspendFields.jsx
@@ -8,9 +8,17 @@ import moment from 'moment'
 
 require('react-datepicker/dist/react-datepicker.css');
 
-const FIRST_SELECTABLE_DATE = moment().add(5, 'days');
+const LEAD_TIME = moment().add(5, 'days');
 const LAST_START_DATE = moment().add(1, 'year');
-const MAX_WEEKS = 3;
+const MAX_WEEKS = 6;
+
+function getFirstSelectableDate(firstPaymentDate) {
+    if (firstPaymentDate && moment(LEAD_TIME).isBefore(firstPaymentDate)) {
+        return moment(firstPaymentDate);
+    } else {
+        return LEAD_TIME;
+    }
+}
 
 function filterDate(packageName, exclusionList) {
     const exclusions = (exclusionList || '').split(',');
@@ -32,13 +40,14 @@ export default {
 
     renderDatePicker () {
         const container = document.getElementById(formElements.SUSPEND_DATE_PICKER_ID),
+            firstSelectableDate = getFirstSelectableDate(container.getAttribute('firstPaymentDate')),
             remainingDays = parseInt(container.getAttribute('remainingDays'), 10),
             filterDateFn = filterDate(container.getAttribute('ratePlanName'), container.getAttribute('excludeExistingDays'));
 
         ReactDOM.render(
             <CustomDateRangePicker className="input-text"
                                    maxWeeks={MAX_WEEKS}
-                                   firstSelectableDate={FIRST_SELECTABLE_DATE}
+                                   firstSelectableDate={firstSelectableDate}
                                    lastStartDate={LAST_START_DATE}
                                    dateFormat="D MMMM YYYY" locale="en-gb"
                                    filterDate={filterDateFn}


### PR DESCRIPTION
Fixed bug where the start date for a suspension was not based off the customer acceptance date (first payment date).

cc @nlindblad @tomverran @jayceb1 