### PR TITLE
Move plan sensitive date filter to its own module and use it for voucher

### DIFF
--- a/assets/javascripts/modules/checkout/deliveryFields.jsx
+++ b/assets/javascripts/modules/checkout/deliveryFields.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import moment from 'moment'
 import formElements from './formElements'
+import planDateFilter from './planDateFilter'
 import CustomDatePicker from '../react/customDatePicker'
 import CharacterCountedTextArea from './characterCountedTextArea'
 import reviewDetails from './reviewDetails'
@@ -10,23 +11,6 @@ require('react-datepicker/dist/react-datepicker.css');
 
 const NUMBER_OF_DAYS_IN_ADVANCE = 5;
 const MAX_WEEKS_AVAILABLE = 4;
-
-function filterDate() {
-    // Get the package name from the checked $PLAN_INPUTS
-    var packageName = '';
-    formElements.$PLAN_INPUTS.each((el) => (el.checked) && (packageName = el.getAttribute('data-option-mirror-package')));
-
-    switch (true) {
-        case /Sunday/i.test(packageName):
-            return (date) => date.day() === 0;
-        case /Sixday/i.test(packageName):
-            return (date) => date.day() !== 0;
-        case /Weekend/i.test(packageName):
-            return (date) => date.day() === 6 || date.day() === 0;
-        default:
-            return (date) => true;
-    }
-}
 
 function getFirstSelectableDate(filterFn) {
     var firstSelectableDate = moment().add(NUMBER_OF_DAYS_IN_ADVANCE, 'days');
@@ -42,7 +26,7 @@ function getLastSelectableDate(firstSelectableDate) {
 }
 
 function getDefaultProps() {
-    const filterDateFn = filterDate(),
+    const filterDateFn = planDateFilter(),
         firstSelectableDate = getFirstSelectableDate(filterDateFn),
         lastSelectableDate = getLastSelectableDate(firstSelectableDate);
 

--- a/assets/javascripts/modules/checkout/planDateFilter.jsx
+++ b/assets/javascripts/modules/checkout/planDateFilter.jsx
@@ -1,0 +1,22 @@
+define([
+    'modules/checkout/formElements',
+], function (formElements) {
+    'use strict';
+
+    return function() {
+        // Get the package name from the checked $PLAN_INPUTS
+        var packageName = '';
+        formElements.$PLAN_INPUTS.each((el) => (el.checked) && (packageName = el.getAttribute('data-option-mirror-package')));
+
+        switch (true) {
+            case /Sunday/i.test(packageName):
+                return (date) => date.day() === 0;
+            case /Sixday/i.test(packageName):
+                return (date) => date.day() !== 0;
+            case /Weekend/i.test(packageName):
+                return (date) => date.day() === 6 || date.day() === 0;
+            default:
+                return (date) => true;
+        }
+    };
+});


### PR DESCRIPTION
Voucher now adheres to showing the first day you could actually get the paper using your voucher:

![screen shot 2016-08-16 at 14 10 36](https://cloud.githubusercontent.com/assets/164991/17700686/c949883c-63be-11e6-8ac7-538cae64ddb5.png)
![screen shot 2016-08-16 at 14 09 43](https://cloud.githubusercontent.com/assets/164991/17700688/c95c10c4-63be-11e6-9bc4-042cd1743dac.png)
