### PR TITLE
Remove the DLA special copy

### DIFF
--- a/app/views/fragments/checkout/promoCode.scala.html
+++ b/app/views/fragments/checkout/promoCode.scala.html
@@ -3,7 +3,7 @@
 @import com.gu.memsub.promo.PromoCode
 @import controllers.routes.Checkout.validatePromoCode
 @(promoCode: Option[PromoCode])
-@if(promoCode.exists(_.get == "DLA01")) {
+@if(false) {
     <div class="promo-code-applied">✓&nbsp; Promotion applied</div>
     <div class="promo-code-snippet">
         <ul>


### PR DESCRIPTION
Just realised in this mode it was not adjusting the quote down on screen - the alternate bit is only applicable for incentive promotions. The promotion is still getting applied correctly to the sub.

cc @tomverran @JuliaBellis 