### PR TITLE
Improvements to suspend and resume page

### DIFF
--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -1,15 +1,8 @@
-@import configuration.Config.Identity._
-@import com.gu.memsub.images.ResponsiveImageGroup
-@import com.gu.memsub.images.ResponsiveImageGenerator
-
 @import model.DigitalEdition.UK
+@import configuration.Config.Identity.idWebAppSigninUrl
 @(
     subscriberId: Option[String]
 )(implicit request: RequestHeader, flash: Flash, touchpointBackendResolution: services.TouchpointBackend.Resolution)
-
-@packImage = @{
-    ResponsiveImageGroup(availableImages = ResponsiveImageGenerator("05129395fe0461071f176f526d7a4ae2b1d9b9bf/0_0_5863_5116", Seq(140, 500, 1000, 2000)))
-}
 
 @main("Suspend your newspaper delivery | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -1,0 +1,25 @@
+@import com.gu.memsub.Subscription
+@import com.gu.memsub.PaidPS
+@import com.gu.subscriptions.ProductPlan
+@import com.gu.subscriptions.PhysicalProducts
+@import views.support.PlanOps._
+@import views.support.Dates._
+@import views.support.Pricing._
+
+@(subscription: Subscription with PaidPS[ProductPlan[PhysicalProducts]])(extra: Html = Html(""))
+<dl class="mma-section__list">
+    <dt class="mma-section__list--title">Subscriber ID</dt>
+    <dd class="mma-section__list--content">@subscription.name.get</dd>
+
+    <dt class="mma-section__list--title">Current plan</dt>
+    <dd class="mma-section__list--content">
+        <div>@subscription.plan.title</div>
+        <div>(@subscription.plan.description)</div>
+        <div>@subscription.plan.prettyPricing(subscription.currency)</div>
+    </dd>
+
+    <dt class="mma-section__list--title">Start date</dt>
+    <dd class="mma-section__list--content">@prettyDate(subscription.firstPaymentDate)</dd>
+
+    @extra
+</dl>

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -1,22 +1,13 @@
-@import com.gu.memsub.images.ResponsiveImageGroup
-@import com.gu.memsub.images.ResponsiveImageGenerator
 @import com.gu.memsub.Subscription
 @import com.gu.memsub.BillingSchedule
-@import views.support.PlanOps._
-@import views.support.Pricing._
 @import com.gu.subscriptions.ProductPlan
 @import com.gu.memsub.PaidPS
-@import com.gu.memsub.promo.Promotion.AnyPromotion
 @import com.gu.subscriptions.PhysicalProducts
 @import com.gu.subscriptions.suspendresume.SuspensionService.HolidayRefund
 @import configuration.Config.suspendableWeeks
 @import com.gu.subscriptions.suspendresume.SuspensionService.holidayToDays
 @import model.DigitalEdition.UK
 @import views.support.Dates.prettyDate
-@import views.support.PlanOps._
-
-@import org.joda.time.LocalDate
-@import org.joda.time.LocalDate.now
 @(
     subscription: Subscription with PaidPS[ProductPlan[PhysicalProducts]],
     holidayRefunds: Seq[HolidayRefund] = Seq.empty,
@@ -24,10 +15,6 @@
     suspendableDays: Int,
     suspendedDays: Int
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
-
-@packImage = @{
-    ResponsiveImageGroup(availableImages = ResponsiveImageGenerator("05129395fe0461071f176f526d7a4ae2b1d9b9bf/0_0_5863_5116", Seq(140, 500, 1000, 2000)))
-}
 
 @main("Suspend your newspaper delivery | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
@@ -38,33 +25,16 @@
                 <h1 class="suspend-header__title">Suspend your newspaper delivery</h1>
             </div>
 
-
             <section class="mma-section">
                 <h3 class="mma-section__header">
                     Your details
                 </h3>
-
-                <dl class="mma-section__list">
-                    <dt class="mma-section__list--title">Subscriber ID</dt>
-                    <dd class="mma-section__list--content">@subscription.name.get</dd>
-
+                @views.html.account.fragments.yourDetails(subscription) {
                     <dt class="mma-section__list--title">Available holiday</dt>
                     <dd class="mma-section__list--content">
-                        <span class="mma-section__list--plan-title">@suspendableDays days over @suspendableWeeks weeks</span>
+                        <span class="mma-section__list--plan-title">@suspendableDays days</span>
                     </dd>
-
-                    <dt class="mma-section__list--title">Current plan</dt>
-                    <dd class="mma-section__list--content">
-                        <span class="mma-section__list--plan-title">@subscription.plan.title</span>
-                        <span class="mma-section__list--plan-description">@subscription.plan.description</span>
-                    </dd>
-
-                    <dt class="mma-section__list--title">Monthly cost</dt>
-                    <dd class="mma-section__list--content">@subscription.plan.priceGBP.pretty</dd>
-
-                    <dt class="mma-section__list--title">First payment</dt>
-                    <dd class="mma-section__list--content">@prettyDate(subscription.firstPaymentDate)</dd>
-                </dl>
+                }
             </section>
 
             @if((suspendableDays - suspendedDays) > 0) {
@@ -88,19 +58,20 @@
                             </button>
                         </fieldset>
                     </form>
-                    <span class="mma-dates__request">Please give us 5 working days notice to process the suspension. All dates are inclusive.</span>
+                    <span class="mma-dates__request">Please give us 5 working days notice to process the suspension. Maximum duration is @suspendableWeeks weeks. <strong>All dates are inclusive</strong>.</span>
                 </section>
             }
+
+            <section class="mma-section">
+                <h3 class="mma-section__header">Scheduled suspensions</h3>
+                @account.fragments.suspensions(holidayRefunds, suspendableDays, suspendedDays)
+            </section>
 
             <section class="mma-section">
                 <h3 class="mma-section__header">Your billing schedule</h3>
                 @account.fragments.billingSchedule(billingSchedule, subscription.currency)
             </section>
 
-            <section class="mma-section">
-                <h3 class="mma-section__header">Scheduled suspensions</h3>
-                @account.fragments.suspensions(holidayRefunds, suspendableDays, suspendedDays)
-            </section>
         </section>
     </main>
 }

--- a/app/views/account/voucher.scala.html
+++ b/app/views/account/voucher.scala.html
@@ -1,23 +1,12 @@
-@import com.gu.memsub.images.ResponsiveImageGroup
-@import com.gu.memsub.images.ResponsiveImageGenerator
 @import com.gu.memsub.Subscription
 @import com.gu.memsub.BillingSchedule
-@import views.support.PlanOps._
-@import views.support.FloatOps._
-@import views.support.Dates._
 @import com.gu.subscriptions.ProductPlan
 @import com.gu.memsub.PaidPS
 @import com.gu.subscriptions.PhysicalProducts
 @import model.DigitalEdition.UK
-
 @(
-  subscription: Subscription with PaidPS[ProductPlan[PhysicalProducts]], billingSchedule: BillingSchedule)(
-  implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution
-)
-
-@packImage = @{
-  ResponsiveImageGroup(availableImages = ResponsiveImageGenerator("05129395fe0461071f176f526d7a4ae2b1d9b9bf/0_0_5863_5116", Seq(140, 500, 1000, 2000)))
-}
+  subscription: Subscription with PaidPS[ProductPlan[PhysicalProducts]], billingSchedule: BillingSchedule
+)(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Suspend your newspaper delivery | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
@@ -32,18 +21,10 @@
         <h3 class="mma-section__header">
           Your details
         </h3>
+        @views.html.account.fragments.yourDetails(subscription)()
+      </section>
 
-        <dl class="mma-section__list">
-          <dt class="mma-section__list--title">Subscriber ID</dt>
-          <dd class="mma-section__list--content">@subscription.name.get</dd>
-
-          <dt class="mma-section__list--title">Current plan</dt>
-          <dd class="mma-section__list--content">
-            <span class="mma-section__list--plan-title">@subscription.plan.title</span>
-            <span class="mma-section__list--plan-description">@subscription.plan.description</span>
-          </dd>
-        </dl>
-
+      <section class="mma-section">
         <h3 class="mma-section__header">
           Your billing schedule
         </h3>

--- a/assets/stylesheets/modules/_suspend.scss
+++ b/assets/stylesheets/modules/_suspend.scss
@@ -57,14 +57,6 @@
     margin: 10px 0;
 }
 
-.mma-section__list--plan-title {
-    display: block;
-}
-
-.mma-section__list--plan-description {
-    font-style: italic;
-}
-
 .mma-section__list--title {
     margin-right: 40px;
     min-width: 120px;
@@ -103,7 +95,9 @@
 }
 
 .mma-section__calendar--amount {
-    margin-top: 4px;
+    border: 1px solid #dfdfdf;
+    border-top: none;
+    padding-top: 2px;
 }
 
 .mma-section__calendar--amount--discounted, .scheduled-suspensions__discount {


### PR DESCRIPTION
Improvements to suspend and resume page: Created a your details template used by both the voucher and suspend pages. Also made some small styling tweaks to the billing schedule, and removed some unused imports. Attached picture shows styling tweaks to billing schedule, and the additional payment frequency text in the Current plan section.

## Home delivery:

![picture 171](https://cloud.githubusercontent.com/assets/1515970/17737857/e64e84e6-6486-11e6-83f6-9c0d03660900.png)

## Voucher:

![picture 170](https://cloud.githubusercontent.com/assets/1515970/17737569/8279a032-6485-11e6-820c-1fada84af753.png)

https://trello.com/c/5Y6Nclyu/601-voucher-mma-no-means-to-create-a-suspension

cc @tomverran 