### PR TITLE
Fix section payment jump

### DIFF
--- a/assets/javascripts/modules/checkout.js
+++ b/assets/javascripts/modules/checkout.js
@@ -10,7 +10,8 @@ define([
     'modules/checkout/promoCode',
     'modules/checkout/billingDetails',
     'modules/checkout/deliveryDetails',
-    'modules/checkout/deliveryAsBilling'
+    'modules/checkout/deliveryAsBilling',
+    'bean'
 ], function (
     optionMirror,
     formElements,
@@ -21,7 +22,8 @@ define([
     promoCode,
     billingAddress,
     deliveryDetails,
-    deliveryAsBilling
+    deliveryAsBilling,
+    bean
 ) {
     'use strict';
     function init() {
@@ -44,6 +46,13 @@ define([
                     voucherFields.default.init();
                 });
             }
+            // Prevent form submit on enter
+            bean.on(formElements.$CHECKOUT_FORM[0], 'keypress', function (event) {
+                if (event.keyCode == 13) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                }
+            });
         }
 
         curl('js!stripe').then(function() {


### PR DESCRIPTION
This fixes the bug where pressing enter at the beginning of the collapsed form shows they payment section, which is a very confusing behaviour that lead users astray.

A more long term solution is to let enter trigger the partial validation for each form section (the equivalent of clicking on "Continue"), but the way the form is currently laid out, there is not enough information about how the sections fit together to do that nicely. Let's discuss how we might improve this.