### PR TITLE
Suspend and resume error message display

### DIFF
--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -44,7 +44,7 @@
                                 </div>
                                 <div class="field-note field-note--offset prose">
                                     <span class="field-note__label">Already have a Guardian account?</span>
-                                    <a href="@idWebAppSigninUrl(routes.AccountManagement.login(None))">Sign in</a>
+                                    <a href="@idWebAppSigninUrl(routes.AccountManagement.login(None, None))">Sign in</a>
                                 </div>
                             </div>
                             <div class="field-panel__edit">

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -15,7 +15,7 @@
     billingSchedule: BillingSchedule,
     suspendableDays: Int,
     suspendedDays: Int,
-    errorCode: Option[String]
+    errorCodes: Set[String]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Suspend your newspaper delivery | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
@@ -49,7 +49,9 @@
                             @helper.CSRF.formField
 
                             <div class="form-field js-suspend-start-date mma-dates__fields">
-                                @errorCode.map { code => <div class="form-field__error-message form-field__error-message-visible">@getMessageFromCode(code)</div> }
+                                <ul class="mma-error-list">
+                                    @errorCodes.map { code => <li class="form-field__error-message mma-error-list__item">@getMessageFromCode(code)</li> }
+                                </ul>
                                 <div id="dateRangePicker"
                                 firstPaymentDate="@prettyDate(subscription.firstPaymentDate)"
                                 remainingDays="@{suspendableDays - suspendedDays}"

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -8,12 +8,14 @@
 @import com.gu.subscriptions.suspendresume.SuspensionService.holidayToDays
 @import model.DigitalEdition.UK
 @import views.support.Dates.prettyDate
+@import views.support.AccountManagementOps._
 @(
     subscription: Subscription with PaidPS[ProductPlan[PhysicalProducts]],
     holidayRefunds: Seq[HolidayRefund] = Seq.empty,
     billingSchedule: BillingSchedule,
     suspendableDays: Int,
-    suspendedDays: Int
+    suspendedDays: Int,
+    errorCode: Option[String]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Suspend your newspaper delivery | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
@@ -47,6 +49,7 @@
                             @helper.CSRF.formField
 
                             <div class="form-field js-suspend-start-date mma-dates__fields">
+                                @errorCode.map { code => <div class="form-field__error-message form-field__error-message-visible">@getMessageFromCode(code)</div> }
                                 <div id="dateRangePicker"
                                 firstPaymentDate="@prettyDate(subscription.firstPaymentDate)"
                                 remainingDays="@{suspendableDays - suspendedDays}"

--- a/app/views/support/AccountManagementOps.scala
+++ b/app/views/support/AccountManagementOps.scala
@@ -1,0 +1,25 @@
+package views.support
+
+import com.gu.subscriptions.suspendresume.SuspensionService.{AlreadyOnHoliday, BadZuoraJson, NegativeDays, NoRefundDue, NotEnoughNotice, RefundError}
+
+object AccountManagementOps {
+  implicit class RefundErrorMessage(in: RefundError) {
+    def getMessage: String = in match {
+      case NoRefundDue => "You aren't receiving the paper on any of the days you've selected. Please select an appropriate date range and try again."
+      case NotEnoughNotice => "Unfortunately we require five days notice to suspend deliveries. Please select a later date range and try again."
+      case AlreadyOnHoliday => "It looks like you're already on holiday for some of the time. Please select a date range before or after a gap, and try again."
+      case NegativeDays => "Invalid date range. Please select an appropriate date range and try again."
+      case _ => "Unexpected error. Please try again."
+    }
+    def getCode = in.getClass.getSimpleName
+  }
+  def getMessageFromCode(code: String): String = {
+    code match {
+      case NoRefundDue.getClass.getSimpleName => NoRefundDue.getMessage
+      case NotEnoughNotice.getClass.getSimpleName => NotEnoughNotice.getMessage
+      case AlreadyOnHoliday.getClass.getSimpleName => AlreadyOnHoliday.getMessage
+      case NegativeDays.getClass.getSimpleName => NegativeDays.getMessage
+      case _ => BadZuoraJson("Unexpected error").getMessage
+    }
+  }
+}

--- a/app/views/support/AccountManagementOps.scala
+++ b/app/views/support/AccountManagementOps.scala
@@ -7,18 +7,17 @@ object AccountManagementOps {
     def getMessage: String = in match {
       case NoRefundDue => "You aren't receiving the paper on any of the days you've selected. Please select an appropriate date range and try again."
       case NotEnoughNotice => "Unfortunately we require five days notice to suspend deliveries. Please select a later date range and try again."
-      case AlreadyOnHoliday => "It looks like you're already on holiday for some of the time. Please select a date range before or after a gap, and try again."
+      case AlreadyOnHoliday => "It looks like you're already on holiday sometime during that date range. Please select a date range before or after your existing holiday, and try again."
       case NegativeDays => "Invalid date range. Please select an appropriate date range and try again."
       case _ => "Unexpected error. Please try again."
     }
-    def getCode = in.getClass.getSimpleName
   }
   def getMessageFromCode(code: String): String = {
     code match {
-      case NoRefundDue.getClass.getSimpleName => NoRefundDue.getMessage
-      case NotEnoughNotice.getClass.getSimpleName => NotEnoughNotice.getMessage
-      case AlreadyOnHoliday.getClass.getSimpleName => AlreadyOnHoliday.getMessage
-      case NegativeDays.getClass.getSimpleName => NegativeDays.getMessage
+      case NoRefundDue.code => NoRefundDue.getMessage
+      case NotEnoughNotice.code => NotEnoughNotice.getMessage
+      case AlreadyOnHoliday.code => AlreadyOnHoliday.getMessage
+      case NegativeDays.code => NegativeDays.getMessage
       case _ => BadZuoraJson("Unexpected error").getMessage
     }
   }

--- a/assets/stylesheets/modules/_suspend.scss
+++ b/assets/stylesheets/modules/_suspend.scss
@@ -152,3 +152,10 @@
         text-align: right;
     }
 }
+
+.mma-error-list {
+   list-style-type: disc;
+}
+.mma-error-list__item {
+    display: list-item;
+}

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.261",
+    "com.gu" %% "membership-common" % "0.262",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.262",
+    "com.gu" %% "membership-common" % "0.263",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/conf/routes
+++ b/conf/routes
@@ -45,7 +45,7 @@ POST        /staff/cas/token                 controllers.CAS.generateToken
 GET         /oauth2callback                  controllers.OAuth.oauth2Callback
 
 # Manage my account
-GET         /mma                             controllers.AccountManagement.login(subscriberId: Option[String])
+GET         /mma                             controllers.AccountManagement.login(subscriberId: Option[String], errorCode: Option[String])
 POST        /mma                             controllers.AccountManagement.processLogin
 GET         /mma/suspend                     controllers.AccountManagement.redirect
 POST        /mma/suspend                     controllers.AccountManagement.processSuspension


### PR DESCRIPTION
- Tidied up the error handling so that it didn't just show a white page.
- Used an interim "code" for the error to put into the URL so that I could reference it via a 302 redirect.
- Supported multiple error codes being thrown. 
- Improved customer error messages.
- Included membership common with prod Holiday Credit rate plan and charge IDs.

https://trello.com/c/5Y6Nclyu/601-voucher-mma-no-means-to-create-a-suspension

![picture 175](https://cloud.githubusercontent.com/assets/1515970/17774608/5b310868-654c-11e6-9914-170af0bc56cf.png)
![picture 174](https://cloud.githubusercontent.com/assets/1515970/17774609/5b330500-654c-11e6-9a38-ef548e864a80.png)

cc @tomverran @nlindblad @mario-galic @jayceb1 