### PR TITLE
Fix deployment tests by re-instating the hidden subscriptionDetails on thank you page

### DIFF
--- a/app/views/fragments/checkout/reviewPanel.scala.html
+++ b/app/views/fragments/checkout/reviewPanel.scala.html
@@ -7,6 +7,9 @@
 
 @(subscriptionId: String, plan: CatalogPlan.Paid, promotion: Option[AnyPromotion] = None, currency: Currency)
 <div class="review-panel">
+    <input type="hidden" name="subscriptionDetails"
+           data-amount="@plan.charges.gbpPrice.amount"
+           data-number-of-months="@plan.charges.billingPeriod.numberOfMonths">
     <div class="review-panel__item">
         <h4 class="review-panel__label">Subscriber ID:</h4>
         <div class="review-panel__details">@subscriptionId</div>


### PR DESCRIPTION
Fix deployment tests by re-instating the hidden subscriptionDetails input. Previously it was a CSS-hidden radio (because it was read by the tracking.js).

cc @mario-galic @johnduffell @jacobwinch 