### PR TITLE
Fix post-deployment tests

### DIFF
--- a/test/acceptance/pages/ThankYou.scala
+++ b/test/acceptance/pages/ThankYou.scala
@@ -16,7 +16,7 @@ case class ThankYou(val testUser: TestUser) extends Page with Browser {
     click.on(cssSelector(".js-checkout-finish-account-submit"))
   }
 
-  def pageHasLoaded(): Boolean = pageHasElement(subscriptionDetails)
+  def pageHasLoaded(): Boolean = elementIsPresent(subscriptionDetails)
 
   def userIsSignedIn: Boolean = elementHasText(userDisplayName, testUser.username.toLowerCase)
 

--- a/test/acceptance/util/Browser.scala
+++ b/test/acceptance/util/Browser.scala
@@ -20,6 +20,9 @@ trait Browser extends WebBrowser {
   def pageHasElement(q: Query): Boolean =
     waitUntil(ExpectedConditions.visibilityOfElementLocated(q.by))
 
+  def elementIsPresent(q: Query): Boolean =
+    waitUntil(ExpectedConditions.presenceOfElementLocated(q.by))
+
   def pageHasUrl(urlFraction: String): Boolean =
     waitUntil(ExpectedConditions.urlContains(urlFraction))
 


### PR DESCRIPTION
Fix post-deployment tests by not testing for visibility of relevant thank you page element, only its presence in DOM.

cc @mario-galic 