### PR TITLE
when calculating promotion pricing only look at the plans it applies to

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -264,7 +264,9 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
     def getAdjustedRatePlans(promo: AnyPromotion): Option[Map[String, String]] = {
       case class RatePlanPrice(ratePlanId: ProductRatePlanId, chargeList: PaidChargeList)
       promo.asDiscount.map { discountPromo =>
-        catalog.allSubs.flatten.map(plan => RatePlanPrice(plan.id, plan.charges)).map { ratePlanPrice =>
+        catalog.allSubs.flatten
+          .filter(plan => promo.appliesTo.productRatePlanIds.contains(plan.id))
+          .map(plan => RatePlanPrice(plan.id, plan.charges)).map { ratePlanPrice =>
           val currency = CountryGroup.byCountryCode(country.alpha2).getOrElse(CountryGroup.UK).currency
           ratePlanPrice.ratePlanId.get -> ratePlanPrice.chargeList.prettyPricingForDiscountedPeriod(discountPromo, currency)
         }.toMap


### PR DESCRIPTION
This does fix https://sentry.io/the-guardian/subscriptions/issues/159796709/ because paper plans are getting looked at when digipack promotions get applied and they're missing some currencies