### PR TITLE
Revert "Follow riffraff advice"

### DIFF
--- a/conf/deploy.json
+++ b/conf/deploy.json
@@ -4,8 +4,7 @@
     "frontend":{
       "type":"autoscaling",
       "data":{
-        "bucket": "subscriptions-dist",
-        "publicReadAcl": false
+        "bucket": "subscriptions-dist"
       }
     }
   },


### PR DESCRIPTION
Reverts guardian/subscriptions-frontend#608

* publicReadAcl is still needed to let the box download the artifact. Looks like some new IAM roles need setting up before we can remove this.