### PR TITLE
Ensure test subs are not tracked in GA

### DIFF
--- a/assets/javascripts/modules/analytics/ga.js
+++ b/assets/javascripts/modules/analytics/ga.js
@@ -95,7 +95,7 @@ define(['modules/analytics/analyticsEnabled',
     }
 
     return {
-        init: init,
+        init: analyticsEnabled(init),
         trackEvent: enqueueEvent
     };
 });


### PR DESCRIPTION
Test subscriptions, (made via Travis) are being tracked in GA due to removal of cookie/DNT check. Adding that back for now till we decide what to do with DNT header.

cc @ajosephides @mario-galic @JuliaBellis 