### PR TITLE
Update to latest membership common

### DIFF
--- a/app/views/support/Dates.scala
+++ b/app/views/support/Dates.scala
@@ -30,7 +30,7 @@ object Dates {
     val dt = ld.toDateTimeAtCurrentTime()
     lazy val pretty = prettyDate(dt)
     lazy val prettyWithTime = prettyDateWithTime(dt)
-    lazy val shortMonth: String = dt.toString("MMM YY")
+    lazy val shortMonth: String = dt.toString("MMM YYYY")
     lazy val shortDay: String = dt.toString("EEE")
 
   }

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.287",
+    "com.gu" %% "membership-common" % "0.288",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
- Update to latest membership common to pick up changes in: https://github.com/guardian/membership-common/pull/339
- Add full year to date  to billing preview to reduce confusion for people on quarterly or yearly plans who log in to /manage

cc @johnduffell @jacobwinch @jayceb1 