### PR TITLE
A few cosmetic tweaks and voucher date chooser improvement

### DIFF
--- a/app/views/account/fragments/billingSchedule.scala.html
+++ b/app/views/account/fragments/billingSchedule.scala.html
@@ -7,7 +7,7 @@
 @(billingSchedule: BillingSchedule, currency: Currency)
 
 <div class="mma-section__schedule">
-    @for(bill <- billingSchedule.invoices.list) {
+    @for(bill <- billingSchedule.invoices.list.take(13)) {
         <div class="mma-section__calendar">
             <div class="mma-section__calendar--date">
                 <span class="mma-section__calendar--sub">@bill.date.shortDay</span>

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -1,24 +1,27 @@
-@import com.gu.memsub.PaidPS
-@import com.gu.memsub.subsv2.SubscriptionPlan
 @import com.gu.memsub.subsv2.Subscription
-@import views.support.PlanOps._
 @import views.support.Dates._
 @import views.support.Pricing._
+@import com.gu.memsub.subsv2.SubscriptionPlan.Paper
 
-@(subscription: Subscription[SubscriptionPlan.Paper])(extra: Html = Html(""))
+@(subscription: Subscription[Paper])(extra: Html = Html(""))
 <dl class="mma-section__list">
     <dt class="mma-section__list--title">Subscriber ID</dt>
     <dd class="mma-section__list--content">@subscription.name.get</dd>
 
     <dt class="mma-section__list--title">Current plan</dt>
     <dd class="mma-section__list--content">
-        <div>@subscription.plan.name</div>
+        <div>@if(subscription.plan.name == "Echo-Legacy") { Multi-day } else { subscription.plan.name }</div>
         <div>(@subscription.plan.description)</div>
         <div>@subscription.plan.charges.prettyPricing(subscription.plan.charges.price.currencies.head)</div>
     </dd>
 
     <dt class="mma-section__list--title">Start date</dt>
-    <dd class="mma-section__list--content">@prettyDate(subscription.firstPaymentDate)</dd>
-
+    <dd class="mma-section__list--content">
+    @if(subscription.plan.name == "Echo-Legacy") {
+        @prettyDate(subscription.startDate)
+    } else {
+        @prettyDate(subscription.firstPaymentDate)
+    }
+    </dd>
     @extra
 </dl>

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -1,13 +1,15 @@
 @import com.gu.memsub.BillingSchedule
 @import com.gu.subscriptions.suspendresume.SuspensionService.HolidayRefund
-@import com.gu.memsub.subsv2.{SubscriptionPlan => Plan, Subscription}
+@import com.gu.memsub.subsv2.Subscription
 @import configuration.Config.suspendableWeeks
 @import com.gu.subscriptions.suspendresume.SuspensionService.holidayToDays
 @import model.DigitalEdition.UK
 @import views.support.Dates.prettyDate
 @import views.support.AccountManagementOps._
+@import com.gu.memsub.BillingPeriod
+@import com.gu.memsub.subsv2.SubscriptionPlan.Delivery
 @(
-    subscription: Subscription[Plan.Paper],
+    subscription: Subscription[Delivery],
     holidayRefunds: Seq[HolidayRefund] = Seq.empty,
     billingSchedule: BillingSchedule,
     suspendableDays: Int,
@@ -36,7 +38,7 @@
                 }
             </section>
 
-            @if((suspendableDays - suspendedDays) > 0) {
+            @if(subscription.plan.charges.billingPeriod == BillingPeriod.month && (suspendableDays - suspendedDays) > 0) {
                 <section class="mma-section">
                     <form class="form js-suspend-form" action="@routes.AccountManagement.processSuspension().url" method="POST" novalidate>
                         <fieldset>

--- a/assets/javascripts/modules/checkout/planDateFilter.jsx
+++ b/assets/javascripts/modules/checkout/planDateFilter.jsx
@@ -12,7 +12,7 @@ define([
         let validDays = {
             voucher: {
                 sixday: (date) => date.day() === 1,
-                sunday: (date) => date.day() === 6,
+                sunday: (date) => date.day() === 0,
                 weekend: (date) => date.day() === 6,
                 allDays: (date) => date.day() === 1
             },

--- a/assets/javascripts/modules/checkout/voucherFields.jsx
+++ b/assets/javascripts/modules/checkout/voucherFields.jsx
@@ -27,7 +27,12 @@ function getFirstSelectableDate(filterFn) {
     var weeksToAdd = currentWeekday >= CUTOFF_WEEKDAY && currentHour >= CUTOFF_HOUR ? EXTRA_DELIVERY_DELAY : NORMAL_DELIVERY_DELAY;
     var firstSelectableDate = mostRecentMonday.add(weeksToAdd, 'weeks');
     while (filterFn && !filterFn(firstSelectableDate)) {
-        firstSelectableDate.add(1, 'day');
+        // Weekend / Sunday subs can have an earlier first voucher than weekday-starting books.
+        if (/Weekend|Sunday/i.test(ratePlanChoice.getSelectedRatePlanName())) {
+            firstSelectableDate.subtract(1, 'day');
+        } else {
+            firstSelectableDate.add(1, 'day');
+        }
     }
     return firstSelectableDate;
 }


### PR DESCRIPTION
A few cosmetic tweaks:
- Don't show 'Echo-Legacy' in the suspend and resume page, instead show 'Multi-day'
<img width="687" alt="picture 212" src="https://cloud.githubusercontent.com/assets/1515970/19486778/a2b315ec-9557-11e6-9d61-655d5ae08ab0.png">
- Show the correct start date for migrated subs.
- Ensure Sunday+ voucher subs choose a Sunday start date and not a Saturday.
- Allow Weekend and Sunday+ voucher subscribers to choose a date a week earlier.
- Only show 13 billing periods on the screen, rather than 14, as it fits the widest grid UX better.

cc @AWare @jayceb1 @johnduffell @pvighi @jacobwinch @JuliaBellis 