### PR TITLE
Go live with Voucher checkout, based on the active plans in Zuora.

### DIFF
--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -32,7 +32,7 @@ object PromoLandingPage extends Controller {
         None
       else
         Some(views.html.promotion.landingPage(edition, catalog.digipack.month, promoCode, promotionWithLandingPage, Config.Zuora.paymentDelay, PegdownMarkdownRenderer))
-    } yield Ok(html)).getOrElse(Redirect("/digital" ? (internalCampaignCode -> s"FROM_P_${promoCode.get}")))
+    } yield Ok(html)).getOrElse(Redirect("/" ? (internalCampaignCode -> s"FROM_P_${promoCode.get}")))
   }
 
   def preview() = GoogleAuthenticatedStaffAction { implicit request =>

--- a/app/controllers/Shipping.scala
+++ b/app/controllers/Shipping.scala
@@ -1,11 +1,10 @@
 package controllers
 import actions.CommonActions._
 import com.gu.i18n.CountryGroup
+import com.gu.memsub.subsv2.CatalogPlan
 import model.Subscriptions._
 import play.api.mvc._
 import services.TouchpointBackend
-import com.gu.memsub.subsv2.CatalogPlan
-import scalaz.syntax.std.boolean._
 
 object Shipping extends Controller {
 
@@ -23,54 +22,21 @@ object Shipping extends Controller {
     )
 
   def viewCollectionPaperDigital() = CachedAction {
-    val plans = List.empty //catalog.voucher.productPlans.filter(_.products.others.contains(Digipack)).map(planToOptions)
     index(CollectionSubscriptionProduct(
       title = "Paper + digital voucher subscription",
       description = "Save money on your newspapers and digital content. Plus start using the daily edition and premium live news app immediately.",
       packageType = "paper-digital",
-      options = plans.nonEmpty.option(plans).getOrElse(
-        Seq(
-          SubscriptionOption("everyday",
-            "Everyday+", 11.99f, Some("36%"), 51.96f, "Guardian and Observer papers, plus tablet editions and Premium mobile access",
-            "https://www.guardiansubscriptions.co.uk/Voucher?prom=faa13&pkgcode=ukx01&title=gv7&skip=1"
-          ),
-          SubscriptionOption("sixday",
-            "Sixday+", 10.99f, Some("30%"), 47.62f, "Guardian papers, plus tablet editions and Premium mobile access",
-            "https://www.guardiansubscriptions.co.uk/Voucher?prom=faa13&pkgcode=ukx01&title=gv6&skip=1"
-          ),
-          SubscriptionOption("weekend",
-            "Weekend+", 6.79f, Some("22%"), 29.42f, "Saturday Guardian and Observer papers, plus tablet editions and Premium mobile access",
-            "https://www.guardiansubscriptions.co.uk/Voucher?prom=faa13&pkgcode=ukx01&title=gv2&skip=1"
-          ),
-          SubscriptionOption("sunday",
-            "Sunday+", 5.09f, Some("12%"), 22.06f, "Observer paper, plus tablet editions and Premium mobile access",
-            "https://www.guardiansubscriptions.co.uk/Voucher?prom=faa13&pkgcode=ukx01&title=ov1&skip=1"
-          )
-        )
-      )))
+      options = catalog.voucher.list.filter(_.charges.digipack.isDefined).map(planToOptions).sortBy(_.weeklyPrice).reverse
+    ))
   }
 
   def viewCollectionPaper() = CachedAction {
-    val plans = List.empty //catalog.voucher.productPlans.filter(_.products.others.isEmpty).map(planToOptions)
     index(CollectionSubscriptionProduct(
       title = "Paper voucher subscription",
       description = "Save money on your newspapers.",
       packageType = "paper",
-      options = plans.nonEmpty.option(plans).getOrElse(Seq(
-        SubscriptionOption("everyday",
-          "Everyday", 10.99f, Some("31%"), 47.62f, "Guardian and Observer papers",
-          "https://www.guardiansubscriptions.co.uk/Voucher?prom=faa13&pkgcode=ukx00&title=gv7&skip=1"
-        ),
-        SubscriptionOption("sixday",
-          "Sixday", 9.49f, Some("26%"), 41.12f, "Guardian papers",
-          "https://www.guardiansubscriptions.co.uk/Voucher?prom=faa13&pkgcode=ukx00&title=gv6&skip=1"
-        ),
-        SubscriptionOption("weekend",
-          "Weekend", 4.79f, Some("19%"), 20.76f, "Saturday Guardian and Observer papers",
-          "https://www.guardiansubscriptions.co.uk/Voucher?prom=faa13&pkgcode=ukx00&title=gv2&skip=1"
-        )
-      )
-      )))
+      options = catalog.voucher.list.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse
+    ))
   }
 
   def viewDeliveryPaperDigital() = CachedAction {


### PR DESCRIPTION
Change which 🚀-es Voucher acquisitions via our new checkout flow! 

cc @johnduffell @pvighi @jacobwinch @AWare @JuliaBellis @jayceb1 @mario-galic 

