### PR TITLE
Refresh promotions faster

### DIFF
--- a/app/services/TouchpointBackend.scala
+++ b/app/services/TouchpointBackend.scala
@@ -82,7 +82,7 @@ object TouchpointBackend {
       lazy val commonPaymentService = new CommonPaymentService(_stripeService, zuoraService, this.catalogService.unsafeCatalog.productMap)
       lazy val zuoraProperties = config.zuoraProperties
       lazy val promoService = new PromoService(promoCollection, new Discounter(this.discountRatePlanIds))
-      lazy val promoCollection = new DynamoPromoCollection(this.promoStorage)
+      lazy val promoCollection = new DynamoPromoCollection(this.promoStorage, 15.seconds)
       lazy val promoStorage = JsonDynamoService.forTable[AnyPromotion](DynamoTables.promotions(Config.config, config.environmentName))
       lazy val discountRatePlanIds = Config.discountRatePlanIds(config.environmentName)
       lazy val suspensionService = new SuspensionService[Future](Config.holidayRatePlanIds(config.environmentName), simpleRestClient)

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.289",
+    "com.gu" %% "membership-common" % "0.291",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
Updating to the latest membership-common in order to refresh promotions faster - every 15 seconds instead of every 5 minutes. Membership will remain at 5 minutes (the DynamoPromoCollection empty-argument default) for now.

I think we have enough head room to go straight for 15s. If not I can double capacity, because it's not too expensive at the moment. 

<img width="905" alt="picture 216" src="https://cloud.githubusercontent.com/assets/1515970/19561065/00a963cc-96cf-11e6-9c7f-ce6791570687.png">

<img width="597" alt="picture 217" src="https://cloud.githubusercontent.com/assets/1515970/19561140/44abdb36-96cf-11e6-93dd-9ee618a3b396.png">

cc @jacobwinch 