### PR TITLE
Update to latest membership common to fix billing schedule

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.291",
+    "com.gu" %% "membership-common" % "0.292",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION

There's an issue with the billing schedule displayed on the holiday suspension page, where pro-rated adjustments at term ending are not showing up. This has been fixed in membership common, and will have the following effect:

Before: 
<img width="1219" alt="picture 226" src="https://cloud.githubusercontent.com/assets/1515970/19642895/6f036e68-99df-11e6-93ff-2f4e7f0fb8fc.png">

After:
![picture 227](https://cloud.githubusercontent.com/assets/1515970/19642902/756b9f46-99df-11e6-9ab5-786371b36aa2.png)

cc @johnduffell @jacobwinch @jayceb1 
