### PR TITLE
Include email address when creating Zuora subscription

### DIFF
--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -188,6 +188,7 @@ class CheckoutService(identityService: IdentityService,
       ratePlans = NonEmptyList(plan),
       name = personalData,
       address = personalData.address,
+      email = personalData.email,
       paymentDelay = paymentDelay,
       ipAddress = requestData.ipAddress.map(_.getHostAddress),
       supplierCode = requestData.supplierCode

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.293",
+    "com.gu" %% "membership-common" % "0.294",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
Tiny change which allows us to add a user's email address when creating a new subscription in Zuora (rather than relying on an unreliable Salesforce sync).