### PR TITLE
Promo terms and conditions

### DIFF
--- a/app/controllers/Shipping.scala
+++ b/app/controllers/Shipping.scala
@@ -25,7 +25,7 @@ object Shipping extends Controller {
     index(CollectionSubscriptionProduct(
       title = "Paper + digital voucher subscription",
       description = "Save money on your newspapers and digital content. Plus start using the daily edition and premium live news app immediately.",
-      packageType = "paper-digital",
+      altPackagePath = "/collection/paper-digital",
       options = catalog.voucher.list.filter(_.charges.digipack.isDefined).map(planToOptions).sortBy(_.weeklyPrice).reverse
     ))
   }
@@ -34,7 +34,7 @@ object Shipping extends Controller {
     index(CollectionSubscriptionProduct(
       title = "Paper voucher subscription",
       description = "Save money on your newspapers.",
-      packageType = "paper",
+      altPackagePath = "/collection/paper",
       options = catalog.voucher.list.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse
     ))
   }
@@ -44,7 +44,7 @@ object Shipping extends Controller {
       title = "Paper + digital home delivery subscription",
       description = """|If you live within the M25 you can have your papers delivered by 7am Monday - Saturday and 8.30am on Sunday.
                       |Plus you can start using the daily edition and premium live news app immediately.""".stripMargin,
-      packageType = "paper-digital",
+      altPackagePath = "/delivery/paper-digital",
       options = catalog.delivery.list.filter(_.charges.digipack.isDefined).map(planToOptions).sortBy(_.weeklyPrice).reverse
     ))
   }
@@ -53,7 +53,7 @@ object Shipping extends Controller {
     index(DeliverySubscriptionProduct(
       title = "Paper home delivery subscription",
       description = "If you live within the M25 you can have your papers delivered by 7am Monday - Saturday and 8.30 on Sunday.",
-      packageType = "paper",
+      altPackagePath = "/delivery/paper",
       options = catalog.delivery.list.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse
     ))
   }

--- a/app/model/Subscriptions.scala
+++ b/app/model/Subscriptions.scala
@@ -1,5 +1,8 @@
 package model
 
+import com.gu.memsub.Product.{Delivery, Voucher}
+import play.twirl.api.Html
+
 object Subscriptions {
 
   case class SubscriptionOption(
@@ -9,27 +12,32 @@ object Subscriptions {
     weeklySaving: Option[String],
     monthlyPrice: Float,
     description: String,
-    url: String
+    url: String,
+    paymentDetails: Option[Html] = None
   )
 
   trait SubscriptionProduct {
+    val id: String
     val title: String
     val description: String
-    val packageType: String
+    val altPackagePath: String
     val options: Seq[SubscriptionOption]
     val stepsHeading: String
     val steps: Seq[String]
     val insideM25: Boolean
+    val isDiscounted: Boolean
     def capitalizedTitle = title.split("\\s").map(_.capitalize).mkString(" ")
   }
 
   case class DeliverySubscriptionProduct(
     title: String,
     description: String,
-    packageType: String,
-    options: Seq[SubscriptionOption]
+    altPackagePath: String,
+    options: Seq[SubscriptionOption],
+    isDiscounted: Boolean = false
   ) extends SubscriptionProduct {
     override val insideM25 = true
+    override val id = Delivery.name
     val stepsHeading = "This is how direct delivery works"
     val steps = Seq(
       "Pick the perfect package for you",
@@ -41,10 +49,12 @@ object Subscriptions {
   case class CollectionSubscriptionProduct(
     title: String,
     description: String,
-    packageType: String,
-    options: Seq[SubscriptionOption]
+    altPackagePath: String,
+    options: Seq[SubscriptionOption],
+    isDiscounted: Boolean = false
   ) extends SubscriptionProduct {
     override val insideM25 = false
+    override val id = Voucher.name
     val stepsHeading = "This is how the voucher scheme works"
     val steps = Seq(
       "Pick the perfect package for you",

--- a/app/views/fragments/promotion/copyrightNotice.scala.html
+++ b/app/views/fragments/promotion/copyrightNotice.scala.html
@@ -1,0 +1,2 @@
+@()
+<p>Guardian News and Media Limited – a member of Guardian Media Group plc. Registered office: Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396</p>

--- a/app/views/fragments/promotion/discover.scala.html
+++ b/app/views/fragments/promotion/discover.scala.html
@@ -3,8 +3,8 @@
 @import com.gu.memsub.subsv2.CatalogPlan
 @import com.gu.memsub.Month
 @import model.DigitalEdition
-@import org.joda.time.Days
-@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month], promoCode: PromoCode, promotion: AnyPromotion, defaultTrial: Days)
+
+@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month], promoCode: PromoCode, promotion: AnyPromotion)
 <div>
     <div class="digital-tablet-previews hide-above-phablet">
         <img src="@controllers.CachedAssets.hashedPathFor("images/backgrounds/bg-digital-tablet-previews.jpg")"/>
@@ -44,7 +44,7 @@
                     <h3>Every day; every section; every supplement</h3>
                     <div class="feature__text">The Guide; Cook; and food Monthly plus our daily crossword tailored for your tablet.</div>
                     <div class="feature__cta">
-                        @fragments.promotion.pricingCta(defaultTrial, edition, plan, promoCode, promotion)
+                        @fragments.promotion.pricingCta(edition, plan, promoCode, promotion)
                         @fragments.promotion.subscribeNow(edition, promoCode)
                     </div>
                 </div>

--- a/app/views/fragments/promotion/incentiveLegalTerms.scala.html
+++ b/app/views/fragments/promotion/incentiveLegalTerms.scala.html
@@ -3,4 +3,4 @@
 @import views.support.LandingPageOps._
 
 @(promotion: AnyPromotion, md: MarkdownRenderer)
-@Html(md.render(promotion.getIncentiveTermsAndConditions))
+@Html(md.render(promotion.getIncentiveLegalTerms))

--- a/app/views/fragments/promotion/paymentDetails.scala.html
+++ b/app/views/fragments/promotion/paymentDetails.scala.html
@@ -1,0 +1,17 @@
+@import com.gu.memsub.subsv2.CatalogPlan
+@import com.gu.memsub.promo.Promotion._
+@import views.support.Catalog._
+
+@(plan: CatalogPlan.Paid, promotion: AnyPromotion)
+
+@promotion.asDiscount.find(_.promotionType.durationMonths.isDefined).fold {
+    Monthly price <strong>@formatPrice(plan, promotion)</strong>
+} { p =>
+    @if(p.promotionType.durationMonths.get > 1) {
+        <strong>@formatPrice(plan, promotion)</strong> per month for @p.promotionType.durationMonths.get months
+    } else {
+        <strong>@formatPrice(plan, promotion)</strong> for 1 month
+    }
+    <br/>
+    Then <strong>@formatPrice(plan)</strong> every month thereafter
+}

--- a/app/views/fragments/promotion/pricingCta.scala.html
+++ b/app/views/fragments/promotion/pricingCta.scala.html
@@ -4,11 +4,12 @@
 @import com.gu.memsub.Month
 @import model.DigitalEdition
 @import views.support.Catalog._
-@import org.joda.time.Days
-@(defaultFreeTrialDays: Days, edition: DigitalEdition, plan: CatalogPlan.Digipack[Month], promoCode: PromoCode, promotion: AnyPromotion)
+@import configuration.Config.Zuora.paymentDelay
+
+@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month], promoCode: PromoCode, promotion: AnyPromotion)
 <div class="pricing-cta">
     <div class="pricing-cta__pricing">
-        <h4 class="pricing-cta__pricing__title">Free for @promotion.asFreeTrial.fold(defaultFreeTrialDays.getDays)(_.promotionType.duration.getDays) days</h4>
+        <h4 class="pricing-cta__pricing__title">Free for @promotion.asFreeTrial.fold(paymentDelay.getDays)(_.promotionType.duration.getDays) days</h4>
         <p class="pricing-cta__pricing__value">
             @promotion.asDiscount.find(_.promotionType.durationMonths.isDefined).fold {
                 Then @formatPrice(plan, promotion)/month

--- a/app/views/fragments/promotion/promotionCta.scala.html
+++ b/app/views/fragments/promotion/promotionCta.scala.html
@@ -4,7 +4,7 @@
 @import com.gu.memsub.Month
 @import model.DigitalEdition
 @import org.joda.time.Days
-@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month], promoCode: PromoCode, promotion: AnyPromotion, defaultTrialDays: Days)
+@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month], promoCode: PromoCode, promotion: AnyPromotion)
 <div class="promotion-cta">
     <div class="grid grid--3up-step-phablet grid--flex">
         <div class="grid__item grid__item--flex-2-columns">
@@ -14,7 +14,7 @@
         </div>
         <div class="grid__item u-vertically-center-flexbox">
             <div class="promotion-cta__pricing">
-                @fragments.promotion.pricingCta(defaultTrialDays, edition, plan, promoCode, promotion)
+                @fragments.promotion.pricingCta(edition, plan, promoCode, promotion)
                 @fragments.promotion.subscribeNow(edition, promoCode)
             </div>
         </div>

--- a/app/views/fragments/promotion/promotionDescription.scala.html
+++ b/app/views/fragments/promotion/promotionDescription.scala.html
@@ -1,11 +1,11 @@
 @import org.joda.time.DateTime.now
 @import views.support.Dates.dayInMonthWithSuffixAndMonth
-@import views.support.LandingPageOps.ForPromotionsWithALandingPage
-@import com.gu.memsub.promo.Promotion.PromoWithDigipackLandingPage
+@import views.support.LandingPageOps.ForPromoWithDigitalPackLandingPage
+@import com.gu.memsub.promo.Promotion.PromoWithDigitalPackLandingPage
 @import org.pegdown.PegDownProcessor
 @import views.support.MarkdownRenderer
 
-@(promotion: PromoWithDigipackLandingPage, md: MarkdownRenderer)
+@(promotion: PromoWithDigitalPackLandingPage, md: MarkdownRenderer)
 <div class="promotion-description @promotion.getDescriptionBorder">
     @promotion.landingPage.description.fold {
         <p>@promotion.description</p>

--- a/app/views/fragments/promotion/promotionTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/promotionTermsAndConditions.scala.html
@@ -1,0 +1,14 @@
+@import com.gu.memsub.promo.PromoCode
+@import com.gu.memsub.promo.Promotion.AnyPromotion
+@import views.support.MarkdownRenderer
+@import views.support.LandingPageOps._
+
+@(promotion: AnyPromotion, md: MarkdownRenderer)
+<h4>Promotion terms and conditions</h4>
+<p>Offer subject to availability. Guardian News and Media Limited ("GNM") reserves the right to withdraw this promotion at any time.</p>
+
+@promotion.asIncentive.map { p =>
+    @if(p.promotionType.termsAndConditions.isDefined) {
+        @Html(md.render(p.getIncentiveTermsAndConditions))
+    }
+}

--- a/app/views/fragments/promotion/promotionWithImage.scala.html
+++ b/app/views/fragments/promotion/promotionWithImage.scala.html
@@ -1,7 +1,7 @@
-@import com.gu.memsub.promo.Promotion.PromoWithDigipackLandingPage
+@import com.gu.memsub.promo.Promotion.PromoWithDigitalPackLandingPage
 @import com.gu.memsub.images.ResponsiveImageGroup
 @import views.support.MarkdownRenderer
-@(promotion: PromoWithDigipackLandingPage, img: ResponsiveImageGroup, md: MarkdownRenderer)
+@(promotion: PromoWithDigitalPackLandingPage, img: ResponsiveImageGroup, md: MarkdownRenderer)
 
 <div class="promotion grid grid--2up-step grid--flex grid--no-clearfix-before">
     <div class="grid__item u-vertically-center-flexbox">

--- a/app/views/fragments/promotion/subscriptionTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/subscriptionTermsAndConditions.scala.html
@@ -1,18 +1,28 @@
-@import com.gu.memsub.subsv2.CatalogPlan
-@import com.gu.memsub.Month
-@import com.gu.memsub.promo.Promotion._
+@import com.gu.memsub.subsv2.Catalog
+@import com.gu.memsub.promo.Promotion.AnyPromotion
 @import views.support.Catalog._
-@import org.joda.time.Days
+@import configuration.Links
+@import configuration.Config.Zuora.paymentDelay
 
-@(defaultFreeTrialDays: Days, catalog: CatalogPlan.Digipack[Month], promotion: AnyPromotion)
-<h4>Subscription terms and conditions</h4>
-<p>Subscriptions available to people aged 18 and over with a valid email address.
-  Free trial open to new digital pack subscribers only. Free trial period lasts
-  @promotion.asFreeTrial.fold(defaultFreeTrialDays.getDays.toString)(_.promotionType.duration.getDays.toString)
-  days from receipt of subscriber ID, up to and including the day before your first payment falls due. At the end of the free trial,
-  the subscription is charged at @promotion.asIncentive.map { p => standard price (currently @formatPrice(catalog, promotion) a month) }
-  @promotion.asDiscount.map { p => the special price of @formatPrice(catalog, promotion) a month } unless cancelled.
-  Requires Internet connection (additional charges may apply) and an Apple, Android or Kindle Fire device.
-  For full details of the digital pack and its terms and conditions - see
-  <a class="u-link" href="//www.theguardian.com/digital-subscriptions-terms-conditions" target="_blank">theguardian.com/digital-subscriptions-terms-conditions</a>.
-</p>
+@(catalog: Catalog, promotion: AnyPromotion)
+@promotion.asDigitalPack.fold {
+    <h4>Subscription terms and conditions</h4>
+    <p>Subscriptions available to people aged 18 and over with a valid email address.</p>
+    <p>
+        For full subscription terms and conditions visit <a class="u-link" href="@Links.paperTerms.href" target="_blank">theguardian.com/subscriber-direct/subscription-terms-and-conditions</a>
+    </p>
+} { _ =>
+    <h4>Digital subscription terms and conditions</h4>
+    <p>
+        Subscriptions available to people aged 18 and over with a valid email address. Free trial open to new digital pack subscribers only. Free trial period lasts
+        @promotion.asFreeTrial.fold(paymentDelay.getDays.toString)(_.promotionType.duration.getDays.toString)
+        days from receipt of subscriber ID, up to and including the day before your first payment falls due. At the end of the free trial,
+        the subscription is charged at @promotion.asIncentive.map { p => standard price (currently @formatPrice(catalog.digipack.month, promotion) a month) }
+        @promotion.asDiscount.map { p => the special price of @formatPrice(catalog.digipack.month, promotion) a month } unless cancelled.
+        Requires Internet connection (additional charges may apply) and an Apple, Android or Kindle Fire device.
+    </p>
+    <p>
+        For full details of the digital pack and its terms and conditions - see
+        <a class="u-link" href="@Links.digipackTerms.href" target="_blank">theguardian.com/digital-subscriptions-terms-conditions</a>.
+    </p>
+}

--- a/app/views/fragments/promotion/subscriptionTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/subscriptionTermsAndConditions.scala.html
@@ -5,13 +5,7 @@
 @import configuration.Config.Zuora.paymentDelay
 
 @(catalog: Catalog, promotion: AnyPromotion)
-@promotion.asDigitalPack.fold {
-    <h4>Subscription terms and conditions</h4>
-    <p>Subscriptions available to people aged 18 and over with a valid email address.</p>
-    <p>
-        For full subscription terms and conditions visit <a class="u-link" href="@Links.paperTerms.href" target="_blank">theguardian.com/subscriber-direct/subscription-terms-and-conditions</a>
-    </p>
-} { _ =>
+@if(promotion.asDigitalPack.isDefined) {
     <h4>Digital subscription terms and conditions</h4>
     <p>
         Subscriptions available to people aged 18 and over with a valid email address. Free trial open to new digital pack subscribers only. Free trial period lasts
@@ -24,5 +18,11 @@
     <p>
         For full details of the digital pack and its terms and conditions - see
         <a class="u-link" href="@Links.digipackTerms.href" target="_blank">theguardian.com/digital-subscriptions-terms-conditions</a>.
+    </p>
+} else {
+    <h4>Subscription terms and conditions</h4>
+    <p>Subscriptions available to people aged 18 and over with a valid email address.</p>
+    <p>
+        For full subscription terms and conditions visit <a class="u-link" href="@Links.paperTerms.href" target="_blank">theguardian.com/subscriber-direct/subscription-terms-and-conditions</a>
     </p>
 }

--- a/app/views/fragments/shipping/shipping.scala.html
+++ b/app/views/fragments/shipping/shipping.scala.html
@@ -1,0 +1,51 @@
+@import utils.Prices._
+@(subscription: model.Subscriptions.SubscriptionProduct)
+<section class="section-slice">
+    <h2 class="page-heading">@subscription.stepsHeading</h2>
+    <ol class="steps">
+    @for(step <- subscription.steps) {
+        <li class="steps__item">@step</li>
+    }
+    </ol>
+</section>
+
+<section class="section-slice">
+
+    @if(subscription.insideM25) {
+        <h3 class="u-display-only-mobile">Live outside the M25?</h3>
+        <a href="@subscription.altPackagePath" class="button button--large button--secondary button--m25" data-test-id="choose-package-outside-m25">
+            <span class="u-hide-until-tablet">Live outside the M25?</span>
+            Subscribe to <span class="u-hide-until-tablet">our</span> voucher scheme
+        </a>
+    } else {
+        <h3 class="u-display-only-mobile">Do you live inside the M25?</h3>
+        <a href="@subscription.altPackagePath" class="button button--large button--secondary button--m25" data-test-id="choose-package-inside-m25">
+            <span class="u-hide-until-tablet">Do you live inside the M25?</span>
+            Get the paper delivered <span class="u-hide-until-tablet">to your door</span>
+        </a>
+    }
+
+    <h2 class="page-heading">Choose a package</h2>
+
+    @for(option <- subscription.options) {
+        <a href="@option.url" class="package" data-test-id="subscription-package-@option.id">
+            <div class="package__info">
+                <span class="package__title">@option.title</span>
+                <strong class="package__price">
+                    @if(subscription.isDiscounted) { From }
+                    @option.weeklyPrice.pretty per week
+                    @for(saving <- option.weeklySaving) { &mdash; save @saving }
+                </strong>
+                <span class="package__description">@option.description</span>
+                <span class="package__monthly">
+                    @if(subscription.isDiscounted) {
+                        @option.paymentDetails
+                    } else {
+                        Monthly price <strong>@option.monthlyPrice.pretty</strong>
+                    }
+                </span>
+            </div>
+        </a>
+    }
+
+</section>

--- a/app/views/promotion/digitalpackLandingPage.scala.html
+++ b/app/views/promotion/digitalpackLandingPage.scala.html
@@ -1,16 +1,12 @@
 @import com.gu.memsub.promo.PromoCode
-@import com.gu.memsub.promo.Promotion.PromoWithDigipackLandingPage
-@import com.gu.memsub.promo.Promotion.asAnyPromotion
-@import com.gu.memsub.promo._
+@import com.gu.memsub.promo.Promotion.{PromoWithDigitalPackLandingPage, asAnyPromotion}
+@import com.gu.memsub.subsv2.Catalog
 @import model.DigitalEdition
-@import views.support.Dates._
-@import com.gu.memsub.subsv2.CatalogPlan
 @import views.support.LandingPageOps._
-@import org.joda.time.Days
 @import views.support.MarkdownRenderer
-@import com.gu.memsub.Month
 
-@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month], promoCode: PromoCode, promotion: PromoWithDigipackLandingPage, defaultTrial: Days, md: MarkdownRenderer)
+@(edition: DigitalEdition, catalog: Catalog, promoCode: PromoCode, promotion: PromoWithDigitalPackLandingPage, md: MarkdownRenderer)
+@plan = @{catalog.digipack.month}
 @anyPromotion = @{asAnyPromotion(promotion)}
 @main(
     title = "Subscribe to the Guardian Digital Pack offer | The Guardian (${edition.name})",
@@ -34,7 +30,7 @@
             <div class="gs-container gs-container--slim page-slice">
                 <div class="page-slice__content">
                     <h2 class="promo-landing-page__section-head">Discover the Guardian Daily Edition</h2>
-                    @fragments.promotion.discover(edition, plan, promoCode, anyPromotion, defaultTrial)
+                    @fragments.promotion.discover(edition, plan, promoCode, anyPromotion)
                 </div>
             </div>
         </section>
@@ -66,18 +62,17 @@
             <div class="gs-container gs-container--slim page-slice page-slice">
                 <div class="page-slice__content">
                     <h2 class="promo-landing-page__section-head">Subscribe&nbsp;to&nbsp;the Digital&nbsp;Pack</h2>
-                    @fragments.promotion.promotionCta(edition, plan, promoCode, anyPromotion, defaultTrial)
+                    @fragments.promotion.promotionCta(edition, plan, promoCode, anyPromotion)
                 </div>
             </div>
         </section>
         <section class="section-white section--dark-sides promotion-terms">
             <div class="gs-container gs-container--slim page-slice">
                 <div class="page-slice__content">
-                    <h4>Terms and conditions</h4>
-                    <p>@promotion.expires.map { e => Customers must subscribe by @prettyDate(e.minusSeconds(1)) to be eligible for the offer. } Offer subject to availability. Guardian News and Media Limited ("GNM") reserves the right to withdraw this promotion at any time.</p>
-                    @fragments.promotion.incentiveTermsAndConditions(anyPromotion, md)
-                    @fragments.promotion.subscriptionTermsAndConditions(defaultTrial, plan, anyPromotion)
-                    <p>Guardian News and Media Limited – a member of Guardian Media Group plc. Registered office: Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396</p>
+                    @fragments.promotion.promotionTermsAndConditions(anyPromotion, md)
+                    <p>For full promotion terms and conditions visit <a class="u-link" href="/p/@promoCode.get/terms">subscribe.theguardian.com/p/@promoCode.get/terms</a></p>
+                    @fragments.promotion.subscriptionTermsAndConditions(catalog, anyPromotion)
+                    @fragments.promotion.copyrightNotice()
                 </div>
             </div>
         </section>

--- a/app/views/promotion/newspaperLandingPage.scala.html
+++ b/app/views/promotion/newspaperLandingPage.scala.html
@@ -1,0 +1,92 @@
+@import com.gu.memsub.promo.PromoCode
+@import com.gu.memsub.promo.Promotion.PromoWithNewspaperLandingPage
+@import com.gu.memsub.promo.Promotion.asAnyPromotion
+@import views.support.LandingPageOps._
+@import views.support.MarkdownRenderer
+@import com.gu.memsub.subsv2.Catalog
+@import model.Subscriptions._
+
+@(catalog: Catalog, promoCode: PromoCode, promotion: PromoWithNewspaperLandingPage, md: MarkdownRenderer)
+@voucherPlans = @{catalog.voucher.list.filter(p => promotion.appliesTo.productRatePlanIds.contains(p.id))}
+@deliveryPlans = @{catalog.delivery.list.filter(p => promotion.appliesTo.productRatePlanIds.contains(p.id))}
+@anyPromotion = @{asAnyPromotion(promotion)}
+@title = @{"Subscribe to the Guardian and Observer"}
+@hash = @{s"#${promotion.landingPage.defaultProduct}"}
+@products = @{
+    val adapter = planToOptions(promoCode, anyPromotion) _
+    val voucherProduct = CollectionSubscriptionProduct(
+        title = "",
+        description = "",
+        altPackagePath = "#delivery",
+        options = {
+            voucherPlans.filter(_.charges.digipack.isEmpty).map(adapter).sortBy(_.weeklyPrice).reverse ++
+            voucherPlans.filter(_.charges.digipack.isDefined).map(adapter).sortBy(_.weeklyPrice).reverse
+        },
+        isDiscounted = promotion.asDiscount.isDefined
+    )
+    val deliveryProduct = DeliverySubscriptionProduct(
+        title = "",
+        description = "",
+        altPackagePath = "#voucher",
+        options = {
+            deliveryPlans.filter(_.charges.digipack.isEmpty).map(adapter).sortBy(_.weeklyPrice).reverse ++
+            deliveryPlans.filter(_.charges.digipack.isDefined).map(adapter).sortBy(_.weeklyPrice).reverse
+        },
+        isDiscounted = promotion.asDiscount.isDefined
+    )
+    if (promotion.landingPage.defaultProduct == "voucher") {
+        Seq(voucherProduct, deliveryProduct).filterNot(_.options.isEmpty)
+    } else {
+        Seq(deliveryProduct, voucherProduct).filterNot(_.options.isEmpty)
+    }
+}
+@main(
+    title = s"$title | The Guardian"
+) {
+    <main class="page-container gs-container">
+
+        @fragments.page.header(title)
+
+        <section class="promotion-description">
+            <p>@promotion.description</p>
+
+            @promotion.asIncentive.map { p =>
+                <h4>Redemption instructions</h4>
+                <p>@p.promotionType.redemptionInstructions</p>
+            }
+        </section>
+
+        @for(product <- products) {
+            <div class="product" id="@product.id" style="display: none">
+                @fragments.shipping.shipping(product)
+            </div>
+        }
+
+        <section class="section-slice promotion-terms">
+            @fragments.promotion.promotionTermsAndConditions(anyPromotion, md)
+            <p>For full promotion terms and conditions visit <a class="u-link" href="/p/@promoCode.get/terms">subscribe.theguardian.com/p/@promoCode.get/terms</a></p>
+            @fragments.promotion.subscriptionTermsAndConditions(catalog, anyPromotion)
+            @fragments.promotion.copyrightNotice()
+        </section>
+
+    </main>
+    <script>
+        window.onhashchange = function () {
+            if (location.hash === '' || location.hash === '#') { return; }
+
+            var sectionMatchingHash = document.querySelector(location.hash);
+            if (sectionMatchingHash) {
+                [].forEach.call(document.querySelectorAll('.product'), function(el) {
+                    el.style.display = 'none';
+                });
+                sectionMatchingHash.style.display = 'block';
+            }
+        };
+
+        if (location.hash === '' || location.hash === '#') {
+            location.hash = '@hash';
+        }
+
+        window.onhashchange();
+    </script>
+}

--- a/app/views/promotion/termsPage.scala.html
+++ b/app/views/promotion/termsPage.scala.html
@@ -1,51 +1,62 @@
+@import com.gu.i18n.CountryGroup.UK
 @import com.gu.memsub.promo.PromoCode
 @import com.gu.memsub.promo.Promotion.AnyPromotion
-@import views.support.Dates._
+@import com.gu.memsub.subsv2.Catalog
+@import org.joda.time.Days
+@import views.support.Dates.prettyDate
 @import views.support.MarkdownRenderer
-
-@(promoCode: PromoCode, promotion: AnyPromotion, md: MarkdownRenderer)
+@(promoCode: PromoCode, promotion: AnyPromotion, md: MarkdownRenderer, catalog: Catalog)
+@title = @{s"Promo code: ${promoCode.get}"}
 @main(
-    title = s"$promoCode Promotion Details | The Guardian",
-    bodyClasses = Seq("is-wide")
+    title = s"$title | The Guardian"
 ) {
 
-    <main class="page-container promo-landing-page">
-        <section class="section-white section--dark-sides">
-            <div class="gs-container gs-container--slim page-slice">
-                <div class="page-slice__content">
-                @fragments.page.header("Promotion Details", Some(promotion.description))
-                @promotion.asIncentive.map { i =>
-                    <h4>Redemption instructions</h4>
-                    <p>@i.promotionType.redemptionInstructions</p>
+    <main class="page-container gs-container">
+
+        @fragments.page.header(title)
+
+        <section class="promotion-description">
+
+            <h4>Promotion details</h4>
+            <p>@promotion.description</p>
+
+            @promotion.expires.map { expiryDate =>
+                <h4>Valid until</h4>
+                <div>@prettyDate(expiryDate)</div>
+            }
+
+            <br/>
+
+            <h4>Applies to products</h4>
+            <ul class="promotion-applies-to">
+                @catalog.allSubs.flatten.filter(plan => promotion.appliesTo.productRatePlanIds.contains(plan.id)).map { plan =>
+                    <li><a href="@routes.Checkout.renderCheckout(UK, None, None, plan.slug).url">@{plan.product.toString.replace("Digipack", "")} @plan.name</a></li>
                 }
-                @if(promotion.starts.isAfterNow) {
-                    <h4>Launches</h4>
-                    <div>@prettyDate(promotion.starts)</div>
-                } else {
-                    <h4>Launched</h4>
-                    <div>@prettyDate(promotion.starts)</div>
-                }
-                @promotion.expires.map { e =>
-                    <h4>Expires</h4>
-                    <div>@prettyDate(e)</div>
-                }
-                @if(promotion.expires.isEmpty || promotion.expires.exists(_.isAfterNow)) {
-                    <div>
-                        <a href="/p/@promoCode">See more</a>
+            </ul>
+
+            <br/>
+
+            @promotion.asIncentive.map { i =>
+                <h4>Redemption instructions</h4>
+                <p>@i.promotionType.redemptionInstructions</p>
+            }
+
+            @if(promotion.expires.isEmpty || promotion.expires.exists(_.isAfterNow)) {
+                <div class="pricing-cta">
+                    <div class="pricing-cta__action">
+                        <a class="button button--large button--primary"
+                        href="/p/@promoCode.get"
+                        >Get this offer</a>
                     </div>
-                }
                 </div>
-            </div>
+                <br/>
+            }
         </section>
-        <section class="section-white section--dark-sides promotion-terms">
-            <div class="gs-container gs-container--slim page-slice">
-                <div class="page-slice__content">
-                    <h4>Terms and conditions</h4>
-                    <p>Subscriptions available to people aged 18 and over with a valid email address. @promotion.expires.map { e => Customers must subscribe by @prettyDate(e.minusSeconds(1)) to be eligible for the offer. } Offer subject to availability. Guardian News and Media Limited ("GNM") reserves the right to withdraw this promotion at any time.</p>
-                    @fragments.promotion.incentiveTermsAndConditions(promotion, md)
-                    <p>Guardian News and Media Limited – a member of Guardian Media Group plc. Registered office: Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396</p>
-                </div>
-            </div>
+        <section class="section-slice promotion-terms">
+            @fragments.promotion.subscriptionTermsAndConditions(catalog, promotion)
+            @fragments.promotion.promotionTermsAndConditions(promotion, md)
+            @fragments.promotion.incentiveLegalTerms(promotion, md)
+            @fragments.promotion.copyrightNotice()
         </section>
     </main>
 }

--- a/app/views/promotion/termsPage.scala.html
+++ b/app/views/promotion/termsPage.scala.html
@@ -1,0 +1,51 @@
+@import com.gu.memsub.promo.PromoCode
+@import com.gu.memsub.promo.Promotion.AnyPromotion
+@import views.support.Dates._
+@import views.support.MarkdownRenderer
+
+@(promoCode: PromoCode, promotion: AnyPromotion, md: MarkdownRenderer)
+@main(
+    title = s"$promoCode Promotion Details | The Guardian",
+    bodyClasses = Seq("is-wide")
+) {
+
+    <main class="page-container promo-landing-page">
+        <section class="section-white section--dark-sides">
+            <div class="gs-container gs-container--slim page-slice">
+                <div class="page-slice__content">
+                @fragments.page.header("Promotion Details", Some(promotion.description))
+                @promotion.asIncentive.map { i =>
+                    <h4>Redemption instructions</h4>
+                    <p>@i.promotionType.redemptionInstructions</p>
+                }
+                @if(promotion.starts.isAfterNow) {
+                    <h4>Launches</h4>
+                    <div>@prettyDate(promotion.starts)</div>
+                } else {
+                    <h4>Launched</h4>
+                    <div>@prettyDate(promotion.starts)</div>
+                }
+                @promotion.expires.map { e =>
+                    <h4>Expires</h4>
+                    <div>@prettyDate(e)</div>
+                }
+                @if(promotion.expires.isEmpty || promotion.expires.exists(_.isAfterNow)) {
+                    <div>
+                        <a href="/p/@promoCode">See more</a>
+                    </div>
+                }
+                </div>
+            </div>
+        </section>
+        <section class="section-white section--dark-sides promotion-terms">
+            <div class="gs-container gs-container--slim page-slice">
+                <div class="page-slice__content">
+                    <h4>Terms and conditions</h4>
+                    <p>Subscriptions available to people aged 18 and over with a valid email address. @promotion.expires.map { e => Customers must subscribe by @prettyDate(e.minusSeconds(1)) to be eligible for the offer. } Offer subject to availability. Guardian News and Media Limited ("GNM") reserves the right to withdraw this promotion at any time.</p>
+                    @fragments.promotion.incentiveTermsAndConditions(promotion, md)
+                    <p>Guardian News and Media Limited – a member of Guardian Media Group plc. Registered office: Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396</p>
+                </div>
+            </div>
+        </section>
+    </main>
+}

--- a/app/views/shipping/shipping.scala.html
+++ b/app/views/shipping/shipping.scala.html
@@ -9,50 +9,7 @@
 
         @fragments.page.header(subscription.title, Some(subscription.description), Nil)
 
-
-        <section class="section-slice">
-            <h2 class="page-heading">@subscription.stepsHeading</h2>
-            <ol class="steps">
-                @for(step <- subscription.steps) {
-                    <li class="steps__item">@step</li>
-                }
-            </ol>
-        </section>
-
-        <section class="section-slice">
-
-            @if(subscription.insideM25) {
-                <h3 class="u-display-only-mobile">Live outside the M25?</h3>
-                <a href="/collection/@subscription.packageType" class="button button--large button--secondary button--m25" data-test-id="choose-package-outside-m25">
-                    <span class="u-hide-until-tablet">Live outside the M25?</span>
-                    Subscribe to <span class="u-hide-until-tablet">our</span> voucher scheme
-                </a>
-            } else {
-                <h3 class="u-display-only-mobile">Do you live inside the M25?</h3>
-                <a href="/delivery/@subscription.packageType" class="button button--large button--secondary button--m25" data-test-id="choose-package-inside-m25">
-                    <span class="u-hide-until-tablet">Do you live inside the M25?</span>
-                    Get the paper delivered <span class="u-hide-until-tablet">to your door</span>
-                </a>
-            }
-
-            <h2 class="page-heading">Choose a package</h2>
-
-            @for(option <- subscription.options) {
-                <a href="@option.url" class="package" data-test-id="subscription-package-@option.id">
-                    <div class="package__info">
-                        <span class="package__title">@option.title</span>
-                        <strong class="package__price">
-                            @option.weeklyPrice.pretty per week
-                            @for(saving <- option.weeklySaving) {
-                                &mdash; save @saving
-                            }
-                        </strong>
-                        <span class="package__description">@option.description</span>
-                        <span class="package__monthly">Monthly price <strong>@option.monthlyPrice.pretty</strong></span>
-                    </div>
-                </a>
-            }
-        </section>
+        @fragments.shipping.shipping(subscription)
 
     </main>
 }

--- a/app/views/support/Catalog.scala
+++ b/app/views/support/Catalog.scala
@@ -3,13 +3,13 @@ package views.support
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.promo.PercentDiscount._
 import com.gu.memsub.promo.Promotion.AnyPromotion
+import com.gu.memsub.subsv2.{CatalogPlan, Catalog => Cat}
 import com.gu.memsub.{Price, BillingPeriod => Period}
-import com.gu.memsub.subsv2.{Catalog => Cat, CatalogPlan}
-import com.gu.memsub.Month
-import scalaz.{NonEmptyList, \/}
+
 import scalaz.std.option._
 import scalaz.syntax.applicative._
 import scalaz.syntax.std.option._
+import scalaz.{NonEmptyList, \/}
 
 object Catalog {
   type Val[A] = NonEmptyList[String] \/ A
@@ -68,11 +68,14 @@ object Catalog {
         ).some, _ => None)
   }
 
-  def formatPrice(plan: CatalogPlan.Digipack[Month], promotion: AnyPromotion): String = {
-    promotion.asDiscount.fold(plan.charges.gbpPrice.pretty)(_.promotionType.applyDiscount(plan.charges.gbpPrice, plan.charges.billingPeriod).pretty)
+  def adjustPrice(plan: CatalogPlan.Paid, promotion: AnyPromotion): Price =
+    promotion.asDiscount.fold(plan.charges.gbpPrice)(_.promotionType.applyDiscount(plan.charges.gbpPrice, plan.charges.billingPeriod))
+  
+  def formatPrice(plan: CatalogPlan.Paid, promotion: AnyPromotion): String = {
+    adjustPrice(plan, promotion).pretty
   }
 
-  def formatPrice(plan: CatalogPlan.Digipack[Month]): String = {
+  def formatPrice(plan: CatalogPlan.Paid): String = {
     plan.charges.gbpPrice.pretty
   }
 }

--- a/app/views/support/LandingPageOps.scala
+++ b/app/views/support/LandingPageOps.scala
@@ -1,15 +1,19 @@
 package views.support
 
+import com.gu.i18n.CountryGroup
 import com.gu.memsub.promo.Promotion._
 import com.gu.memsub.promo._
+import com.gu.memsub.subsv2.CatalogPlan
+import controllers.routes
+import model.Subscriptions.SubscriptionOption
 import org.joda.time.DateTime.now
-import scalaz.Id._
+import views.support.Catalog._
 
 object LandingPageOps {
 
   private def getSectionColour(landingPage: DigitalPackLandingPage) = landingPage.sectionColour.getOrElse(Blue)
 
-  implicit class ForPromotionsWithALandingPage(promotion: PromoWithDigipackLandingPage) {
+  implicit class ForPromoWithDigitalPackLandingPage(promotion: PromoWithDigitalPackLandingPage) {
     def landingPageSectionColour: String = {
       getSectionColour(promotion.landingPage) match {
         case Blue => "section-blue"
@@ -35,6 +39,24 @@ object LandingPageOps {
     def getIncentiveTermsAndConditions: String = {
       promotion.asIncentive.fold("") { p => p.promotionType.termsAndConditions.mkString }
     }
+    def getIncentiveLegalTerms: String = {
+      promotion.asIncentive.fold("") { p => p.promotionType.legalTerms.mkString }
+    }
   }
 
+  def planToOptions(promoCode: PromoCode, promotion: AnyPromotion)(in: CatalogPlan.Paid): SubscriptionOption = {
+    val planPrice = promotion.asDiscount.fold(in.charges.gbpPrice)(adjustPrice(in, _))
+    val saving = promotion.asDiscount.fold(in.saving)(_ => None)
+    val paymentDetails = promotion.asDiscount.map(views.html.fragments.promotion.paymentDetails(in, _))
+
+    SubscriptionOption(in.id.get,
+      in.name,
+      planPrice.amount * 12 / 52,
+      saving.map(_.toString + "%"),
+      planPrice.amount,
+      in.description,
+      routes.Checkout.renderCheckout(CountryGroup.UK, Some(promoCode), None, in.slug).url,
+      paymentDetails
+    )
+  }
 }

--- a/app/views/support/LandingPageOps.scala
+++ b/app/views/support/LandingPageOps.scala
@@ -37,16 +37,16 @@ object LandingPageOps {
 
   implicit class ForAnyPromotions(promotion: AnyPromotion) {
     def getIncentiveTermsAndConditions: String = {
-      promotion.asIncentive.fold("") { p => p.promotionType.termsAndConditions.mkString }
+      promotion.asIncentive.flatMap(_.promotionType.termsAndConditions).mkString
     }
     def getIncentiveLegalTerms: String = {
-      promotion.asIncentive.fold("") { p => p.promotionType.legalTerms.mkString }
+      promotion.asIncentive.flatMap(_.promotionType.legalTerms).mkString
     }
   }
 
   def planToOptions(promoCode: PromoCode, promotion: AnyPromotion)(in: CatalogPlan.Paid): SubscriptionOption = {
-    val planPrice = promotion.asDiscount.fold(in.charges.gbpPrice)(adjustPrice(in, _))
-    val saving = promotion.asDiscount.fold(in.saving)(_ => None)
+    val planPrice = promotion.asDiscount.map(adjustPrice(in, _)).getOrElse(in.charges.gbpPrice)
+    val saving = if (promotion.asDiscount.isDefined) None else in.saving
     val paymentDetails = promotion.asDiscount.map(views.html.fragments.promotion.paymentDetails(in, _))
 
     SubscriptionOption(in.id.get,

--- a/assets/stylesheets/modules/_promotion.scss
+++ b/assets/stylesheets/modules/_promotion.scss
@@ -209,6 +209,19 @@
     padding-top: ($gs-baseline / 3);
 }
 
+.promotion-applies-to {
+    @include mq(mobileLandscape) {
+        columns: 2;
+        -webkit-columns: 2;
+        -moz-columns: 2;
+    }
+    @include mq(phablet) {
+        columns: 3;
+        -webkit-columns: 3;
+        -moz-columns: 3;
+    }
+}
+
 .promotion-description--bordered {
     border-color: $c-neutral2;
     border-style: dotted;
@@ -234,6 +247,11 @@
 .promotion-terms {
     @include fs-textSans(2);
     color: $c-neutral2;
+
+    h3, h4 {
+        font-size: 1em;
+        font-weight: 900;
+    }
 
     .page-slice__content {
         margin-top: $gs-baseline * 2;

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.294",
+    "com.gu" %% "membership-common" % "0.295",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/conf/routes
+++ b/conf/routes
@@ -63,6 +63,7 @@ GET         /test-users                      controllers.Testing.testUser
 
 # Promotions
 GET         /p/:promoCodeStr                 controllers.PromoLandingPage.render(promoCodeStr: String)
+GET         /p/:promoCodeStr/terms           controllers.PromoLandingPage.terms(promoCodeStr: String)
 
 # NOCSRF
 POST        /q                               controllers.PromoLandingPage.preview


### PR DESCRIPTION
- Added a new landing page type under /p/<promo_code> for newspaper subscription promotions (not a very pretty one - it just reuses the grey bars from the standard catalog pages - I had to break apart some 'shipping' templates to reuse them)
- Added a new /p/[promo_code]/terms endpoint which shows a summary of the promotion and what products it applies to,  including the new long terms and conditions. The page will remain permanent and not redirect when the promotion expires or hasn't started yet.
- Lots of refactoring of the terms and conditions sections, ready for how they want to manage the new process. Nothing removed, just sentences shifted around a bit or re-titled.
- Eventually we can add previewing capability to the newspaper landing page, but that's deliberately absent right now.
- There's a bit of collateral from membership-common's renaming PromoWithDigipackLandingPage to PromoWithDigitalPackLandingPage

![picture 237](https://cloud.githubusercontent.com/assets/1515970/19771897/5772564a-9c5c-11e6-9952-c7f962f89dbb.png)

cc @johnduffell @pvighi @AWare @jacobwinch @jayceb1 