### PR TITLE
Updating to latest membership-common to allow a CountryGroup of ie

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.295",
+    "com.gu" %% "membership-common" % "0.296",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
Updating to latest membership-common to allow &countryGroup=ie to be specified on the checkout page.

cc @jacobwinch 