### PR TITLE
Basic Guardian Weekly landing page

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -123,7 +123,7 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
           case Product.Voucher => ukMainLandSettings.copy(availableCountries = CountryWithCurrency.fromCountryGroup(ukAndIsleOfMan))
           case Product.WeeklyZoneA => getSettings(
             availableCountries = CountryWithCurrency.whitelisted(supportedCurrencies, GBP, weeklyZoneAGroups),
-            fallbackCountry = Some(Country.UK),
+            fallbackCountry = countryGroup.defaultCountry,
             fallbackCurrency = GBP
           )
           case Product.WeeklyZoneB => getSettings(

--- a/app/controllers/WeeklyLandingPage.scala
+++ b/app/controllers/WeeklyLandingPage.scala
@@ -1,0 +1,16 @@
+package controllers
+
+import actions.CommonActions._
+import model.{DigitalEdition, WeeklyRegion}
+import play.api.mvc._
+import services.TouchpointBackend
+
+object WeeklyLandingPage extends Controller {
+
+  val tpBackend = TouchpointBackend.Normal
+  val catalog = tpBackend.catalogService.unsafeCatalog
+  val edition = DigitalEdition.UK
+
+  def index = CachedAction { implicit request =>
+    Ok(views.html.weekly.weekly_landing(WeeklyRegion.all))
+}}

--- a/app/model/WeeklyRegions.scala
+++ b/app/model/WeeklyRegions.scala
@@ -17,13 +17,13 @@ object WeeklyRegion {
 object Uk extends WeeklyRegion {
   override val title = "United Kingdown"
   override val description = "Includes Isle of Man and Channel Islands"
-  override val url = Uri.parse("checkout/weeklyzonea-guardianweeklyquarterly")
+  override val url = Uri.parse("checkout/weeklyzonea-guardianweeklyquarterly?countryGroup=uk")
 }
 
 object NorthAmerica extends WeeklyRegion {
   override val title = "North America"
   override val description = "Canada and USA"
-  override val url = Uri.parse("checkout/weeklyzonea-guardianweeklyquarterly")
+  override val url = Uri.parse("checkout/weeklyzonea-guardianweeklyquarterly?countryGroup=us")
 }
 
 object Row extends WeeklyRegion {

--- a/app/model/WeeklyRegions.scala
+++ b/app/model/WeeklyRegions.scala
@@ -1,0 +1,34 @@
+package model
+
+import com.netaporter.uri.Uri
+
+trait WeeklyRegion {
+  def title: String
+
+  def description: String
+
+  def url: Uri
+}
+
+object WeeklyRegion {
+  val all = List(Uk, NorthAmerica, Row)
+}
+
+object Uk extends WeeklyRegion {
+  override val title = "United Kingdown"
+  override val description = "Includes Isle of Man and Channel Islands"
+  override val url = Uri.parse("checkout/weeklyzonea-guardianweeklyquarterly")
+}
+
+object NorthAmerica extends WeeklyRegion {
+  override val title = "North America"
+  override val description = "Canada and USA"
+  override val url = Uri.parse("checkout/weeklyzonea-guardianweeklyquarterly")
+}
+
+object Row extends WeeklyRegion {
+  override val title = "Rest of the world"
+  override val description = "Posted to you by Air Mail"
+  override val url = Uri.parse("checkout/weeklyzoneb-guardianweeklyquarterly")
+}
+

--- a/app/views/weekly/weekly_landing.scala.html
+++ b/app/views/weekly/weekly_landing.scala.html
@@ -1,0 +1,26 @@
+@import com.gu.memsub.subsv2._
+
+@import model.WeeklyRegion
+@(options: List[WeeklyRegion])
+
+@main(title = "Guardian Weekly") {
+    <main class="page-container gs-container">
+
+        @fragments.page.header("Guardian Weekly", Some("Subscribe to a unique blend of international news, politics, culture and comment from award-winning journalists around the globe"), Nil)
+
+        <section class="section-slice">
+
+            <h2 class="page-heading">Where do you live?</h2>
+
+            @for(option <- options) {
+                <a href="@option.url.toString" class="package">
+                    <div class="package__info">
+                        <span class="package__title">@option.title</span>
+                        <span class="package__description">@option.description</span>
+                    </div>
+                </a>
+            }
+        </section>
+
+    </main>
+}

--- a/app/views/weekly/weekly_landing.scala.html
+++ b/app/views/weekly/weekly_landing.scala.html
@@ -10,7 +10,7 @@
 
         <section class="section-slice">
 
-            <h2 class="page-heading">Where do you live?</h2>
+            <h2 class="page-heading">Where do you want the Guardian Weekly delivered?</h2>
 
             @for(option <- options) {
                 <a href="@option.url.toString" class="package">

--- a/conf/routes
+++ b/conf/routes
@@ -36,6 +36,7 @@ GET         /collection/paper-digital        controllers.Shipping.viewCollection
 GET         /collection/paper                controllers.Shipping.viewCollectionPaper
 GET         /delivery/paper-digital          controllers.Shipping.viewDeliveryPaperDigital
 GET         /delivery/paper                  controllers.Shipping.viewDeliveryPaper
+GET         /weekly                          controllers.WeeklyLandingPage.index
 
 # Staff signin (note, done by OAuth, in addition to regular signin)
 GET         /staff/login                     controllers.OAuth.login


### PR DESCRIPTION
Just a basic landing page. asks the user where they want to deliver the guardian and links to the quarterly package for the correct zone and currency. 
It doesn't show prices or present the option to go straight to the annual package checkout.
![weeklylanding](https://cloud.githubusercontent.com/assets/15324270/19810471/7d09b64a-9d25-11e6-9416-b06fc27160cb.png)
