### PR TITLE
Remove redundant JellyFish retargeting and conversion tags.

### DIFF
--- a/app/views/fragments/analytics/jellyfish/conversion.scala.html
+++ b/app/views/fragments/analytics/jellyfish/conversion.scala.html
@@ -43,27 +43,6 @@
             </div>
         </noscript>
 
-        <!-- Google Code for Subscription Conversion Page -->
-        <script type="text/javascript">
-            /* <![CDATA[ */
-            var google_conversion_id = 1008644981;
-            var google_conversion_language = "en";
-            var google_conversion_format = "3";
-            var google_conversion_color = "ffffff";
-            var google_conversion_label = "rdY3CPjQllcQ9eb64AM";
-            var google_conversion_value = 1.00;
-            var google_conversion_currency = "GBP";
-            var google_remarketing_only = false;
-            /* ]]> */
-        </script>
-        <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
-        </script>
-        <noscript>
-            <div style="display:inline;">
-                <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/1008644981/?value=1.00&amp;currency_code=GBP&amp;label=rdY3CPjQllcQ9eb64AM&amp;guid=ON&amp;script=0"/>
-            </div>
-        </noscript>
-
         <!-- Twitter single-event website tag code -->
         <script src="//platform.twitter.com/oct.js" type="text/javascript"></script>
         <script type="text/javascript">twttr.conversion.trackPid('nu3k4', { tw_sale_amount: 0, tw_order_quantity: 0 });</script>

--- a/assets/javascripts/modules/analytics/remarketing.js
+++ b/assets/javascripts/modules/analytics/remarketing.js
@@ -15,11 +15,6 @@ define([
             });
             // JellyFish remarketing
             window.google_trackConversion({
-                google_conversion_id: 1008644981,
-                google_custom_params: window.google_tag_params,
-                google_remarketing_only: true
-            });
-            window.google_trackConversion({
                 google_conversion_id: 995657703,
                 google_custom_params: window.google_tag_params,
                 google_remarketing_only: true


### PR DESCRIPTION
cc @johnduffell @pvighi @jacobwinch @JuliaBellis
