### PR TITLE
Let you use the manage page to log in to weekly too

### DIFF
--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -62,7 +62,7 @@ class ExactTargetService(
     val zuoraPaidSubscription: Future[Subscription[Plan.Paid]] =
       Retry(2, s"Failed to get Zuora paid subscription ${subscribeResult.subscriptionName} for ${purchaserIds.identityId}") {
         subscriptionData.productData.fold(
-          { paper => subscriptionService.get[Plan.Paper](Name(subscribeResult.subscriptionName)).map(_.get) },
+          { paper => subscriptionService.get[Plan.PaperPlan](Name(subscribeResult.subscriptionName)).map(_.get) },
           { digipack => subscriptionService.get[Plan.Digipack](Name(subscribeResult.subscriptionName)).map(_.get) })}
 
     val zuoraPaymentMethod: Future[PaymentMethod] =

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -4,28 +4,28 @@
     subscriberId: Option[String]
 )(implicit request: RequestHeader, flash: Flash, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
-@main("Cancel your papers when you're away | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
+@main("Manage your subscription | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
     <main class="page-container gs-container">
 
         <section class="suspend-container">
 
             <div class="suspend-header">
-                <h1 class="suspend-header__title">Cancel your papers while you're away</h1>
+                <h1 class="suspend-header__title">Manage your subscription</h1>
             </div>
 
             <div class="prose">
                 <p>
-                    You can use this service to temporarily suspend delivery of your newspapers.
-                    You will need your ​​Subscriber ID​, which you can find on any correspondence.
+                    To manage your subscription, you will need your ​​Subscriber ID​, which you can find on any correspondence.<br>
+                    You will also need your billing information, which we accept in either capitals or lower case.
                 </p>
                 <p>
-                    Please give us at least 5 days notice, and we will reduce the first payment after you go away by the value of the cancelled papers, including delivery.
-                </p>
-                <p>
-                    If you do not have your Subscriber ID to hand, or you have any other customer service enquir​ies,
-                    please contact us on: <a href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
-                    or email <a href="mailto:homedelivery@@theguardian.com">homedelivery@@theguardian.com</a>.
+                    If you do not have your Subscriber ID to hand, or you have any other customer service enquir​ies, you can get in touch.
+                    <ul>
+                        <li>Home delivery, please contact us on: <a href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
+                        or email <a href="mailto:homedelivery@@theguardian.com">homedelivery@@theguardian.com</a>.
+                        <li>Guardian Weekly, please contact us on: TODO
+                    </ul>
                 </p>
             </div>
 

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -4,28 +4,28 @@
     subscriberId: Option[String]
 )(implicit request: RequestHeader, flash: Flash, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
-@main("Manage your subscription | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
+@main("Cancel your papers when you're away | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
     <main class="page-container gs-container">
 
         <section class="suspend-container">
 
             <div class="suspend-header">
-                <h1 class="suspend-header__title">Manage your subscription</h1>
+                <h1 class="suspend-header__title">Cancel your papers while you're away</h1>
             </div>
 
             <div class="prose">
                 <p>
-                    To manage your subscription, you will need your ​​Subscriber ID​, which you can find on any correspondence.<br>
-                    You will also need your billing information, which we accept in either capitals or lower case.
+                    You can use this service to temporarily suspend delivery of your newspapers.
+                    You will need your ​​Subscriber ID​, which you can find on any correspondence.
                 </p>
                 <p>
-                    If you do not have your Subscriber ID to hand, or you have any other customer service enquir​ies, you can get in touch.
-                    <ul>
-                        <li>Home delivery, please contact us on: <a href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
-                        or email <a href="mailto:homedelivery@@theguardian.com">homedelivery@@theguardian.com</a>.
-                        <li>Guardian Weekly, please contact us on: TODO
-                    </ul>
+                    Please give us at least 5 days notice, and we will reduce the first payment after you go away by the value of the cancelled papers, including delivery.
+                </p>
+                <p>
+                    If you do not have your Subscriber ID to hand, or you have any other customer service enquir​ies,
+                    please contact us on: <a href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
+                    or email <a href="mailto:homedelivery@@theguardian.com">homedelivery@@theguardian.com</a>.
                 </p>
             </div>
 

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -2,9 +2,8 @@
 @import com.gu.memsub.subsv2.Subscription
 @import views.support.Dates._
 @import views.support.Pricing._
-@import com.gu.memsub.subsv2.SubscriptionPlan.Paper
 
-@(subscription: Subscription[Paper])(extra: Html = Html(""))
+@(subscription: Subscription[SubscriptionPlan.PaperPlan])(extra: Html = Html(""))
 <dl class="mma-section__list">
     <dt class="mma-section__list--title">Subscriber ID</dt>
     <dd class="mma-section__list--content">@subscription.name.get</dd>

--- a/app/views/account/renew.scala.html
+++ b/app/views/account/renew.scala.html
@@ -3,16 +3,16 @@
 @import com.gu.memsub.subsv2.Subscription
 @import model.DigitalEdition.UK
 @(
-    subscription: Subscription[SubscriptionPlan.DailyPaper], billingSchedule: BillingSchedule
+    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: BillingSchedule
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
-@main("Your Guardian subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
+@main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
     <main class="page-container gs-container">
         <section class="suspend-container">
 
             <div class="suspend-header">
-                <h1 class="suspend-header__title">Your Guardian subscription</h1>
+                <h1 class="suspend-header__title">Your Guardian Weekly subscription --- TEST PAGE</h1>
             </div>
 
             <section class="mma-section">

--- a/app/views/account/success.scala.html
+++ b/app/views/account/success.scala.html
@@ -8,7 +8,7 @@
 @(
     newRefund: HolidayRefund,
     holidayRefunds: Seq[HolidayRefund],
-    subscription: Subscription[Plan.Paper],
+    subscription: Subscription[Plan.DailyPaper],
     billingSchedule: BillingSchedule,
     suspendableDays: Int,
     suspendedDays: Int,

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -28,23 +28,6 @@
                 <h1 class="suspend-header__title">Cancel your papers while you're away</h1>
             </div>
 
-            <div class="prose">
-                <p>
-                    You can use this service to temporarily suspend delivery of your newspapers.
-                    You will need your ​​Subscriber ID​, which you can find on any correspondence.
-                </p>
-                <p>
-                    Please give us at least 5 days notice, and we will reduce the first payment after you go away by the value of the cancelled papers, including delivery.
-                </p>
-                <p>
-                    If you have any customer service enquir​ies,
-                    please contact us on: <a href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
-                    or email <a href="mailto:homedelivery@@theguardian.com">homedelivery@@theguardian.com</a>.
-                </p>
-            </div>
-
-            <br/>
-
             <section class="mma-section">
                 <h3 class="mma-section__header">
                     Your details

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -7,7 +7,7 @@
 @import views.support.Dates.prettyDate
 @import views.support.AccountManagementOps._
 @import com.gu.memsub.BillingPeriod
-@import com.gu.memsub.subsv2.SubscriptionPlan.Delivery
+@import com.gu.memsub.subsv2.SubscriptionPlan.DailyPaper
 @import com.gu.memsub.PaperDay
 @(
     subscription: Subscription[DailyPaper],

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -7,9 +7,9 @@
 @import views.support.Dates.prettyDate
 @import views.support.AccountManagementOps._
 @import com.gu.memsub.BillingPeriod
-@import com.gu.memsub.subsv2.SubscriptionPlan.Delivery
+@import com.gu.memsub.subsv2.SubscriptionPlan.DailyPaper
 @(
-    subscription: Subscription[Delivery],
+    subscription: Subscription[DailyPaper],
     holidayRefunds: Seq[HolidayRefund] = Seq.empty,
     billingSchedule: BillingSchedule,
     suspendableDays: Int,
@@ -25,6 +25,23 @@
             <div class="suspend-header">
                 <h1 class="suspend-header__title">Cancel your papers while you're away</h1>
             </div>
+
+            <div class="prose">
+                <p>
+                    You can use this service to temporarily suspend delivery of your newspapers.
+                    You will need your ​​Subscriber ID​, which you can find on any correspondence.
+                </p>
+                <p>
+                    Please give us at least 5 days notice, and we will reduce the first payment after you go away by the value of the cancelled papers, including delivery.
+                </p>
+                <p>
+                    If you have any customer service enquir​ies,
+                    please contact us on: <a href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
+                    or email <a href="mailto:homedelivery@@theguardian.com">homedelivery@@theguardian.com</a>.
+                </p>
+            </div>
+
+            <br/>
 
             <section class="mma-section">
                 <h3 class="mma-section__header">

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.296",
+    "com.gu" %% "membership-common" % "0.297-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.297-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.298-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.298-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.298",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
So as per https://github.com/guardian/membership-common/pull/347

This PR uses the new approach of pattern matching to get hold of whether the subscription is weekly rather than delivery or voucher.  We get a load of warnings from the compiler due to the horrible way I've done the pattern matching so we need to improve it.

We can remove the warnings by doing an asInstanceOf instead of pattern matching an erased type parameter, but the only reason we don't get a warning is because we know asInstanceOf isn't safe, rather than it being a surprise.  I would prefer a way to lock the type parameters together so the compiler would at least check the code makes sense.

```
[warn] /Users/jduffell/ws/subscriptions-frontend/app/controllers/AccountManagement.scala:113: non-variable type argument com.gu.memsub.subsv2.PaidSubscriptionPlan[com.gu.memsub.Product.Delivery,com.gu.memsub.subsv2.PaperCharges] in type pattern com.gu.memsub.subsv2.Subscription[com.gu.memsub.subsv2.PaidSubscriptionPlan[com.gu.memsub.Product.Delivery,com.gu.memsub.subsv2.PaperCharges]] is unchecked since it is eliminated by erasure
[warn]         case SubMatch(Product.Delivery, charges: PaperCharges, sub: Subscription[PaidSubscriptionPlan[Product.Delivery, PaperCharges]]) =>
[warn]                                                                     ^
[warn] /Users/jduffell/ws/subscriptions-frontend/app/controllers/AccountManagement.scala:117: non-variable type argument com.gu.memsub.subsv2.PaidSubscriptionPlan[com.gu.memsub.Product.Voucher,com.gu.memsub.subsv2.PaperCharges] in type pattern com.gu.memsub.subsv2.Subscription[com.gu.memsub.subsv2.PaidSubscriptionPlan[com.gu.memsub.Product.Voucher,com.gu.memsub.subsv2.PaperCharges]] is unchecked since it is eliminated by erasure
[warn]         case SubMatch(Product.Voucher, _, sub: Subscription[PaidSubscriptionPlan[Product.Voucher, PaperCharges]]) =>
[warn]                                                ^
[warn] /Users/jduffell/ws/subscriptions-frontend/app/controllers/AccountManagement.scala:119: non-variable type argument com.gu.memsub.subsv2.PaidSubscriptionPlan[com.gu.memsub.Product.Weekly,com.gu.memsub.subsv2.PaidCharge[com.gu.memsub.Weekly.type,com.gu.memsub.BillingPeriod]] in type pattern com.gu.memsub.subsv2.Subscription[com.gu.memsub.subsv2.PaidSubscriptionPlan[com.gu.memsub.Product.Weekly,com.gu.memsub.subsv2.PaidCharge[com.gu.memsub.Weekly.type,com.gu.memsub.BillingPeriod]]] is unchecked since it is eliminated by erasure
[warn]         case SubMatch(_: Product.Weekly, _, sub: Subscription[PaidSubscriptionPlan[Product.Weekly, PaidCharge[Weekly.type, BillingPeriod]]]) =>
[warn]                                                  ^
```

I slightly prefer the asInstanceOf apart from the fact it's not together with the rest of the pattern match, but those warnings are not really acceptable.

Anyway we can discuss monday and come to a conclusion.  Then we can potentially delete the either method we already have.

After login holding page:
![image](https://cloud.githubusercontent.com/assets/7304387/19815087/1b552bf0-9d39-11e6-9d2d-a8366d9f69da.png)

@pvighi @paulbrown1982 @jacobwinch 
