### PR TITLE
exclude disabled elements when serializing them

### DIFF
--- a/assets/javascripts/utils/serializer.js
+++ b/assets/javascripts/utils/serializer.js
@@ -11,7 +11,7 @@ define(['lodash/object/extend'], function (extend) {
     var serializer = function (elems, mixin) {
         var data = extend({}, mixin);
         elems.filter(function (elem) {
-            return elem.name !== '' && elem.type && (elem.type !== 'checkbox' && elem.type !== 'radio' || elem.checked);
+            return elem.name !== '' && !elem.disabled && elem.type && (elem.type !== 'checkbox' && elem.type !== 'radio' || elem.checked);
         }).map(function (elem) {
             data[elem.name] = elem.value;
         });


### PR DESCRIPTION
When serializing forms for ajax omit disabled fields
The only other instance of disabled fields I could find are.
https://github.com/guardian/subscriptions-frontend/blob/master/app/views/fragments/checkout/fieldsVoucher.scala.html#L20
and 
https://github.com/guardian/subscriptions-frontend/blob/master/app/views/fragments/checkout/fieldsDelivery.scala.html#L35

But they seem to only be used from javascript as far as I can see.  