### PR TITLE
Fix holiday refund calculations

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -78,13 +78,14 @@ object AccountManagement extends Controller with LazyLogging {
       subEither <- OptionT(subscription)
       sub = subEither.fold(identity, identity)
       allHolidays <- OptionT(tpBackend.suspensionService.getHolidays(sub.name).map(_.toOption))
-      billingSchedule <- OptionT(tpBackend.commonPaymentService.billingSchedule(sub.id, numberOfBills = 12))
-      suspendableDays = Config.suspendableWeeks * sub.plan.charges.benefits.size
+      billingSchedule <- OptionT(tpBackend.commonPaymentService.billingSchedule(sub.id, numberOfBills = 13))
+      chosenPaperDays = sub.plan.charges.chargedDays.toList.sortBy(_.dayOfTheWeekIndex)
+      suspendableDays = Config.suspendableWeeks * chosenPaperDays.size
     } yield
       subEither.fold({ deliverySubscription =>
         val pendingHolidays = pendingHolidayRefunds(allHolidays)
-        val suspendedDays = SuspensionService.holidayToSuspendedDays(pendingHolidays, deliverySubscription.plan.charges.days.toList)
-        Ok(views.html.account.suspend(deliverySubscription, pendingHolidayRefunds(allHolidays), billingSchedule, suspendableDays, suspendedDays, errorCodes))
+        val suspendedDays = SuspensionService.holidayToSuspendedDays(pendingHolidays, deliverySubscription.plan.charges.chargedDays.toList)
+        Ok(views.html.account.suspend(deliverySubscription, pendingHolidayRefunds(allHolidays), billingSchedule, chosenPaperDays, suspendableDays, suspendedDays, errorCodes))
       },{ voucherSubscription =>
         Ok(views.html.account.voucher(voucherSubscription, billingSchedule))
       })
@@ -136,8 +137,8 @@ object AccountManagement extends Controller with LazyLogging {
       newBS <- EitherT(tpBackend.commonPaymentService.billingSchedule(sub.id, numberOfBills = 12).map(_ \/> "Error getting billing schedule"))
       newHolidays <- EitherT(tpBackend.suspensionService.getHolidays(sub.name)).leftMap(_ => "Error getting holidays")
       pendingHolidays = pendingHolidayRefunds(newHolidays)
-      suspendableDays = Config.suspendableWeeks * sub.plan.charges.days.size
-      suspendedDays = SuspensionService.holidayToSuspendedDays(pendingHolidays, sub.plan.charges.days.toList)
+      suspendableDays = Config.suspendableWeeks * sub.plan.charges.chargedDays.size
+      suspendedDays = SuspensionService.holidayToSuspendedDays(pendingHolidays, sub.plan.charges.chargedDays.toList)
     } yield {
       tpBackend.exactTargetService.enqueueETHolidaySuspensionEmail(sub, sub.plan.name, newBS, pendingHolidays.size, suspendableDays, suspendedDays).onFailure { case e: Throwable =>
         logger.error(s"Failed to generate data needed to enqueue ${sub.name.get}'s holiday suspension email. Reason: ${e.getMessage}")

--- a/app/views/account/fragments/suspensions.scala.html
+++ b/app/views/account/fragments/suspensions.scala.html
@@ -7,7 +7,7 @@
 
 @if(holidayRefunds.nonEmpty) {
     <div class="prose">
-        You have @suspendedDays @if(suspendedDays == 1) { day } else { days } lined up:
+        You have @suspendedDays @if(suspendedDays == 1) { day } else { days } already lined up:
         <dl class="mma-section__list">
             @for((refund, holiday) <- holidayRefunds) {
                 <dt class="mma-section__list--title">@formattedDateRange(holiday.start, holiday.finish)</dt>

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -1,18 +1,23 @@
-@import com.gu.memsub.subsv2.SubscriptionPlan
 @import com.gu.memsub.subsv2.Subscription
 @import views.support.Dates._
 @import views.support.Pricing._
 @import com.gu.memsub.subsv2.SubscriptionPlan.Paper
-
-@(subscription: Subscription[Paper])(extra: Html = Html(""))
+@import com.gu.memsub.PaperDay
+@import scala.collection.immutable.List.empty
+@(subscription: Subscription[Paper], chosenPaperDays: List[PaperDay] = empty)(extra: Html = Html(""))
 <dl class="mma-section__list">
     <dt class="mma-section__list--title">Subscriber ID</dt>
     <dd class="mma-section__list--content">@subscription.name.get</dd>
 
     <dt class="mma-section__list--title">Current plan</dt>
     <dd class="mma-section__list--content">
-        <div>@if(subscription.plan.name == "Echo-Legacy") { Multi-day } else { @subscription.plan.name }</div>
-        <div>(@subscription.plan.description)</div>
+        <div>
+        @if(subscription.plan.name == "Echo-Legacy") {
+            Multi-day (@{chosenPaperDays.map(_.id.replace("Print ", "")).mkString(", ")})
+        } else {
+            @subscription.plan.name
+        }
+        </div>
         <div>@subscription.plan.charges.prettyPricing(subscription.plan.charges.price.currencies.head)</div>
     </dd>
 

--- a/app/views/account/success.scala.html
+++ b/app/views/account/success.scala.html
@@ -27,7 +27,7 @@
                 Thank you. Your newspaper delivery will be suspended
                 @if(newRefund._2.start == newRefund._2.finish) { on @prettyDate(newRefund._2.start) } else { from @prettyDate(newRefund._2.start) to @prettyDate(newRefund._2.finish) }.
             </p>
-            <p>@Price(newRefund._1, GBP).pretty will be deducted from your next payment on or after @prettyDate(newRefund._2.start).</p>
+            <p>@Price(newRefund._1, currency).pretty will be deducted from your next payment on or after @prettyDate(newRefund._2.start).</p>
             <p>Have a great holiday.</p>
         </section>
 

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -8,10 +8,12 @@
 @import views.support.AccountManagementOps._
 @import com.gu.memsub.BillingPeriod
 @import com.gu.memsub.subsv2.SubscriptionPlan.Delivery
+@import com.gu.memsub.PaperDay
 @(
     subscription: Subscription[Delivery],
     holidayRefunds: Seq[HolidayRefund] = Seq.empty,
     billingSchedule: BillingSchedule,
+    chosenPaperDays: List[PaperDay],
     suspendableDays: Int,
     suspendedDays: Int,
     errorCodes: Set[String]
@@ -30,7 +32,7 @@
                 <h3 class="mma-section__header">
                     Your details
                 </h3>
-                @views.html.account.fragments.yourDetails(subscription) {
+                @views.html.account.fragments.yourDetails(subscription, chosenPaperDays) {
                     <dt class="mma-section__list--title">Available holiday</dt>
                     <dd class="mma-section__list--content">
                         <span class="mma-section__list--plan-title">@{

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.296",
+    "com.gu" %% "membership-common" % "0.297-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.297-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.297",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
Fixed 2 suspend and resume bugs and made 1 improvement:

1. The refund amount being wrong on a migrated sub's last term iff they have pro-rated charges. (note the After screenshot is still wrong on this issue as we have refunded the customer in a different way)
2. The number of suspendable days and the number of suspended days was wrong for multi-day subs
3. Now shows what days are being delivered on for a multi-day sub.

What will actually get billed:

<img width="1445" alt="picture 246" src="https://cloud.githubusercontent.com/assets/1515970/19855176/064c0fce-9f6b-11e6-96a4-633ec5efd87c.png">

Before - the suspend and resume page was wrong:

![picture 247](https://cloud.githubusercontent.com/assets/1515970/19855174/0238e04c-9f6b-11e6-9040-e38a4ead73ed.png)

After - the suspend and resume page is right:

![picture 245](https://cloud.githubusercontent.com/assets/1515970/19855082/927defd6-9f6a-11e6-8835-4b8582a56451.png)


cc @johnduffell @JuliaBellis @jacobwinch @pvighi @AWare @jayceb1 