### PR TITLE
Slash voucher redirect

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -71,5 +71,8 @@ POST        /q                               controllers.PromoLandingPage.previe
 # Promotions
 GET         /s/:supplierCodeStr              controllers.Homepage.supplierRedirect(supplierCodeStr: String)
 
+# Paths from legacy redirects
+GET         /Voucher                         controllers.Homepage.index
+
 # Editions hommepage or 404
 GET         /:edition                        controllers.Homepage.landingPage(edition: String)


### PR DESCRIPTION
A useful redirect for people who may have bookmarked the now-redirected Quadrant URL: http://www.guardiansubscriptions.co.uk/Voucher

cc @JuliaBellis @jacobwinch 