### PR TITLE
Run acceptance test on voucher flow and add temporary hack for Stripe

### DIFF
--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -175,93 +175,12 @@ class CheckoutSpec extends FeatureSpec with Browser
       }
     }
 
-    scenario("Identity user subscribes with credit card through Stripe Checkout", Acceptance) {
-      withRegisteredIdentityUserFixture { testUser =>
-
-        Given("registered and signed in Identity users want to subscribe by clicking on " +
-          "'Start your free trial'")
-
-        Then("they should land on 'Checkout' page,")
-        val checkout = pages.Checkout(testUser)
-
-        checkout.setInStripeTest(true)
-        go.to(checkout.url + "?stripe=checkout")
-        assert(checkout.pageHasLoaded())
-
-        And("should be signed in with their Identity account,")
-        assert(checkout.userIsSignedIn)
-
-        And("first name, last name, and email address should be pre-filled,")
-        assert(checkout.userDetailsArePrefilled)
-
-        And("they should have Identity cookies,")
-        Seq("GU_U", "SC_GU_U", "SC_GU_LA").foreach { idCookie =>
-          assert(Driver.cookiesSet.map(_.getName).contains(idCookie))
-        }
-
-        And("the section 'Your details' should load.")
-        assert(checkout.yourDetailsSectionHasLoaded())
-
-        Then("Go along to the address details")
-        checkout.clickPersonalDetailsContinueButton()
-
-        When("they fill in the address,")
-        checkout.fillInBillingAddress()
-
-        And("click on 'Continue' button,")
-        checkout.clickBillingDetailsContinueButton()
-
-        Then("the section 'Payment Details' should load.")
-        assert(checkout.directDebitSectionHasLoaded())
-
-        When("Users select credit card payment option,")
-        checkout.selectCreditCardPaymentOption()
-
-        And("click on 'Continue' button,")
-        checkout.clickCredictCardPaymentContinueButton()
-
-        Then("the section 'Confirm and Review' should load.")
-        assert(checkout.reviewSectionHasLoaded())
-
-        When("they submit the form,")
-        checkout.submitPayment()
-
-        Then("the Stripe Checkout iframe should display")
-        assert(checkout.stripeCheckoutHasLoaded())
-
-        Then("switch to checkout iframe")
-        checkout.switchToStripe()
-
-        Then("cc?")
-        assert(checkout.stripeCheckoutHasCC())
-
-        Then("CVC")
-        assert(checkout.stripeCheckoutHasCVC())
-
-        Then("exp")
-        assert(checkout.stripeCheckoutHasExph())
-
-        Then("submit")
-        assert(checkout.stripeCheckoutHasSubmit())
-
-        And("fill in credit card payment details,")
-        checkout.fillInCreditCardPaymentDetailsStripe()
-
-        Then("they should land on 'Thank You' page,")
-        val thankYou = ThankYou(testUser)
-        assert(thankYou.pageHasLoaded())
-
-        And("they should still be signed in.")
-        assert(thankYou.userIsSignedIn)
-      }
-    }
-
-    scenario("Guest users subscribe to paper home delivery with direct debit", Acceptance) {
+    scenario("Guest users subscribe to Voucher Everyday package", Acceptance) {
       checkDependenciesAreAvailable
       val testUser = new TestUser
 
-      val checkout = Checkout(testUser, "checkout/delivery-everyday")
-      When("users visit 'Paper Home Delivery Checkout' page,")
+      val checkout = Checkout(testUser, "checkout/voucher-everyday")
+      When("users visit the 'Voucher Everyday Checkout' page,")
       go.to(checkout)
       assert(checkout.pageHasLoaded())
 
@@ -323,5 +242,87 @@ class CheckoutSpec extends FeatureSpec with Browser
       Seq("GU_U", "SC_GU_U", "SC_GU_LA").foreach { idCookie =>
         assert(Driver.cookiesSet.map(_.getName).contains(idCookie)) }
     }
+
+    scenario("Identity user subscribes with credit card through Stripe Checkout", Acceptance) {
+      withRegisteredIdentityUserFixture { testUser =>
+
+        Given("registered and signed in Identity users want to subscribe by clicking on " +
+          "'Start your free trial'")
+
+        Then("they should land on 'Checkout' page,")
+        val checkout = pages.Checkout(testUser)
+
+        checkout.setInStripeTest(true)
+        go.to(checkout.url + "?stripe=checkout")
+        assert(checkout.pageHasLoaded())
+
+        And("should be signed in with their Identity account,")
+        assert(checkout.userIsSignedIn)
+
+        And("first name, last name, and email address should be pre-filled,")
+        assert(checkout.userDetailsArePrefilled)
+
+        And("they should have Identity cookies,")
+        Seq("GU_U", "SC_GU_U", "SC_GU_LA").foreach { idCookie =>
+          assert(Driver.cookiesSet.map(_.getName).contains(idCookie))
+        }
+
+        And("the section 'Your details' should load.")
+        assert(checkout.yourDetailsSectionHasLoaded())
+
+        Then("Go along to the address details")
+        checkout.clickPersonalDetailsContinueButton()
+
+        When("they fill in the address,")
+        checkout.fillInBillingAddress()
+
+        And("click on 'Continue' button,")
+        checkout.clickBillingDetailsContinueButton()
+
+        Then("the section 'Payment Details' should load.")
+        assert(checkout.directDebitSectionHasLoaded())
+
+        When("Users select credit card payment option,")
+        checkout.selectCreditCardPaymentOption()
+
+        And("click on 'Continue' button,")
+        checkout.clickCredictCardPaymentContinueButton()
+
+        Then("the section 'Confirm and Review' should load.")
+        assert(checkout.reviewSectionHasLoaded())
+
+        When("they submit the form,")
+        checkout.submitPayment()
+
+        Then("the Stripe Checkout iframe should display")
+        assert(checkout.stripeCheckoutHasLoaded())
+
+        When("the checkout iframe is present")
+        checkout.switchToStripe()
+
+        Then("credit card field is present")
+        assert(checkout.stripeCheckoutHasCC())
+
+        Then("expiry date field is present")
+        assert(checkout.stripeCheckoutHasExph())
+
+        Then("CVC field is present")
+        assert(checkout.stripeCheckoutHasCVC())
+
+        Then("submit button is present")
+        assert(checkout.stripeCheckoutHasSubmit())
+
+        And("they fill in credit card payment details,")
+        checkout.fillInCreditCardPaymentDetailsStripe()
+
+        Then("they should land on 'Thank You' page,")
+        val thankYou = ThankYou(testUser)
+        assert(thankYou.pageHasLoaded())
+
+        And("they should still be signed in.")
+        assert(thankYou.userIsSignedIn)
+      }
+    }
+
   }
 }

--- a/test/acceptance/pages/Checkout.scala
+++ b/test/acceptance/pages/Checkout.scala
@@ -185,12 +185,13 @@ case class Checkout(testUser: TestUser, endpoint: String = "checkout") extends P
     val submitPaymentButton = cssSelector(".js-checkout-submit")
   }
 
+  // Temporary hack to identify elements on Stripe Checkout form using xpath, since the ids are no longer consistently set.
   private object StripeCheckout {
     val container = name("stripe_checkout_app")
-    val cardNumber = id("card_number")
-    val cardExp = id("cc-exp")
-    val cardCvc = id("cc-csc")
-    val submitButton = id("submitButton")
+    val cardNumber = xpath("//div[label/text() = \"Card number\"]/input")
+    val cardExp = xpath("//div[label/text() = \"Expiry\"]/input")
+    val cardCvc = xpath("//div[label/text() = \"CVC\"]/input")
+    val submitButton = xpath("//div[button]")
 
     def setInTest(inTest: Boolean) = {
 


### PR DESCRIPTION
This PR re-factors an acceptance-test so that it runs against voucher instead of home delivery, now that we handle all of this traffic ourselves.

It also introduces a temporary fix for the (currently broken) Stripe test, which now uses xpath to identify elements on Stripe Checkout form (as opposed to ids), because the ids on Stripe checkout are no longer set consistently. This is likely to be flakey - and should only be used temporarily - I will also contact Stripe and see if there is a better long-term solution for this.