### PR TITLE
wording changes for generic manage page for all papers

### DIFF
--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -11,20 +11,39 @@
         <section class="suspend-container">
 
             <div class="suspend-header">
-                <h1 class="suspend-header__title">Manage your subscription</h1>
+                <h1 class="suspend-header__title">Manage your Guardian subscription</h1>
             </div>
+
+            <div>
+                <h4>This section currently lets you:</h4>
+                <ul>
+                    <li>See your subscription details and billing schedule</li>
+                    <li>Create a holiday suspension, if you have a Home Delivery subscription</li>
+                    <li>See when your next book of vouchers will be delivered, if you have a Voucher subscription</li>
+                    <li>Renew your 1/2/3-year Guardian Weekly subscription</li>
+                </ul>
+                <br/>
+                <h4>Coming soon:</h4>
+                <ul>
+                    <li>Guardian Weekly subscribers will be able to browse and download digital copies</li>
+                    <li>All subscribers will be able to link their subscription to a <a class="u-link" target="_blank" href="@idWebAppSigninUrl(routes.AccountManagement.manage(None, None))">Guardian account</a></li>
+                    <li>Customers who have multiple subscriptions can manage each one independently</li>
+                    <li>Update card or Direct Debit details (will require signing in to your Guardian account)</li>
+                    <li>Update paper delivery address details (will require signing in to your Guardian account)</li>
+                    <li>Upgrade paper subscription to include the <a class="u-link" target="_blank" href="@routes.DigitalPack.redirect()">Guardian Digital Pack</a></li>
+                    <li>Online subscription cancellation</li>
+                </ul>
+            </div>
+
+            <hr/>
 
             <div class="prose">
                 <p>
-                    To manage your subscription, you will need your ​​Subscriber ID​, which you can find on any correspondence.<br>
-                    You will also need your billing information, which we accept in either capitals or lower case.
+                    Please log in below to manage your subscription. You may need your ​​Subscriber ID​, which you can find on any correspondence.
                 </p>
                 <p>
-                    Please give us at least 5 days notice, and we will reduce the first payment after you go away by the value of the cancelled papers, including delivery.
-                </p>
-                <p>
-                    If you do not have your Subscriber ID to hand, or you have any other customer service enquir​ies,
-                    please contact us on: <a class="u-link" href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
+                    If you do not have your Subscriber ID to hand, or you require any service not currently available online,
+                    please contact customer services on: <a class="u-link" href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
                     or email <a class="u-link" href="mailto:subscriptions@@theguardian.com">subscriptions@@theguardian.com</a>.
                 </p>
             </div>

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -15,14 +15,13 @@
             </div>
 
             <div>
-                <h4>This section currently lets you:</h4>
+                <p>In this section all subscribers can see their subscription details and billing schedule.</p>
                 <ul>
-                    <li>See your subscription details and billing schedule</li>
-                    <li>Create a holiday suspension, if you have a Home Delivery subscription</li>
-                    <li>See when your next book of vouchers will be delivered, if you have a Voucher subscription</li>
-                    <li>Renew your 1/2/3-year Guardian Weekly subscription</li>
+                    <li>Home Delivery subscribers can also create holiday suspensions</li>
+                    <li>Voucher subscribers can also see when they next book will be delivered</li>
+                    <li>Guardian Weekly subscribers can also renew their 1/2/3-year plans</li>
                 </ul>
-                <br/>
+                @*
                 <h4>Coming soon:</h4>
                 <ul>
                     <li>Guardian Weekly subscribers will be able to browse and download digital copies</li>
@@ -33,16 +32,17 @@
                     <li>Upgrade paper subscription to include the <a class="u-link" target="_blank" href="@routes.DigitalPack.redirect()">Guardian Digital Pack</a></li>
                     <li>Online subscription cancellation</li>
                 </ul>
+                *@
             </div>
 
-            <hr/>
+            <br/>
 
             <div class="prose">
                 <p>
-                    Please log in below to manage your subscription. You may need your ​​Subscriber ID​, which you can find on any correspondence.
+                    Please log in below using your ​​Subscriber ID​, which you can find on any correspondence.
                 </p>
                 <p>
-                    If you do not have your Subscriber ID to hand, or you require any service not currently available online,
+                    If you do not have your Subscriber ID to hand, or need anything else,
                     please contact customer services on: <a class="u-link" href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
                     or email <a class="u-link" href="mailto:subscriptions@@theguardian.com">subscriptions@@theguardian.com</a>.
                 </p>

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -4,20 +4,20 @@
     subscriberId: Option[String]
 )(implicit request: RequestHeader, flash: Flash, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
-@main("Cancel your papers when you're away | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
+@main("Manage your subscription | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
     <main class="page-container gs-container">
 
         <section class="suspend-container">
 
             <div class="suspend-header">
-                <h1 class="suspend-header__title">Cancel your papers while you're away</h1>
+                <h1 class="suspend-header__title">Manage your subscription</h1>
             </div>
 
             <div class="prose">
                 <p>
-                    You can use this service to temporarily suspend delivery of your newspapers.
-                    You will need your ​​Subscriber ID​, which you can find on any correspondence.
+                    To manage your subscription, you will need your ​​Subscriber ID​, which you can find on any correspondence.<br>
+                    You will also need your billing information, which we accept in either capitals or lower case.
                 </p>
                 <p>
                     Please give us at least 5 days notice, and we will reduce the first payment after you go away by the value of the cancelled papers, including delivery.
@@ -25,7 +25,7 @@
                 <p>
                     If you do not have your Subscriber ID to hand, or you have any other customer service enquir​ies,
                     please contact us on: <a class="u-link" href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
-                    or email <a class="u-link" href="mailto:homedelivery@@theguardian.com">homedelivery@@theguardian.com</a>.
+                    or email <a class="u-link" href="mailto:subscriptions@@theguardian.com">subscriptions@@theguardian.com</a>.
                 </p>
             </div>
 

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -32,6 +32,23 @@
                 <h1 class="suspend-header__title">Cancel your papers while you're away</h1>
             </div>
 
+            <div class="prose">
+                <p>
+                    You can use this service to temporarily suspend delivery of your newspapers.
+                    You will need your ​​Subscriber ID​, which you can find on any correspondence.
+                </p>
+                <p>
+                    Please give us at least 5 days notice, and we will reduce the first payment after you go away by the value of the cancelled papers, including delivery.
+                </p>
+                <p>
+                    If you have any customer service enquir​ies,
+                    please contact us on: <a href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
+                    or email <a href="mailto:homedelivery@@theguardian.com">homedelivery@@theguardian.com</a>.
+                </p>
+            </div>
+
+            <br/>
+
             <section class="mma-section">
                 <h3 class="mma-section__header">
                     Your details

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -35,7 +35,6 @@
             <div class="prose">
                 <p>
                     You can use this service to temporarily suspend delivery of your newspapers.
-                    You will need your ​​Subscriber ID​, which you can find on any correspondence.
                 </p>
                 <p>
                     Please give us at least 5 days notice, and we will reduce the first payment after you go away by the value of the cancelled papers, including delivery.

--- a/assets/stylesheets/modules/_suspend.scss
+++ b/assets/stylesheets/modules/_suspend.scss
@@ -6,7 +6,7 @@
     padding: ($gs-gutter / 2) 0 ($gs-baseline / 2);
 
     @include mq(desktop) {
-        padding-bottom: $gs-gutter * 2;
+        padding-bottom: $gs-gutter;
     }
 }
 .suspend-header__title {


### PR DESCRIPTION
Updated the wording for the /manage page in subscriptions to make it compatible for all subscription types. The copy needs product/commercial sign off.

Before:

![picture 5](https://cloud.githubusercontent.com/assets/1515970/21223798/09ed286a-c2c1-11e6-8fab-49e32c6afee9.png)

After:

![picture 6](https://cloud.githubusercontent.com/assets/1515970/21224792/bf1e102e-c2c5-11e6-8b87-11ee7137e270.png)

cc @johnduffell @jacobwinch @pvighi @AWare 