### PR TITLE
don't let people log in to a gifted weekly sub

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -110,10 +110,10 @@ object AccountManagement extends Controller with LazyLogging {
           Ok(views.html.account.voucher(voucherSubscription, billingSchedule))
         }
         case _: Product.Weekly => sub.asWeekly.map { weeklySubscription =>
-          if (weeklySubscription.gift)
-            Ok(views.html.account.details(None))// don't support gifts (yet) as they have related contacts in salesforce of unknown structure
-          else
+          if (weeklySubscription.readerType == ReaderType.Direct)
             Ok(views.html.account.renew(weeklySubscription, billingSchedule))
+          else
+            Ok(views.html.account.details(None))// don't support gifts (yet) as they have related contacts in salesforce of unknown structure
         }
       }).getOrElse {
         // the product type didn't have the right charges

--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -110,7 +110,10 @@ object AccountManagement extends Controller with LazyLogging {
           Ok(views.html.account.voucher(voucherSubscription, billingSchedule))
         }
         case _: Product.Weekly => sub.asWeekly.map { weeklySubscription =>
-          Ok(views.html.account.renew(weeklySubscription, billingSchedule))
+          if (weeklySubscription.gift)
+            Ok(views.html.account.details(None))// don't support gifts (yet) as they have related contacts in salesforce of unknown structure
+          else
+            Ok(views.html.account.renew(weeklySubscription, billingSchedule))
         }
       }).getOrElse {
         // the product type didn't have the right charges

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.298",
+    "com.gu" %% "membership-common" % "0.299-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.299-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.300",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
We don't support renewing a gifted sub yet, so we need to remove this check once we've worked out how it will look in salesforce.

At the moment (non gifting) there is one salesforce contact which has all the information about the buyer and the recipient.  When gifting is imported, there will be a related contact.  The structure is not set in stone yet, but the email field in the contact will probably be the delivery email so we would have to read the right email address to prepopulate the field in the checkout.

In the mean time, this PR just disables login for gifted subs so that forces us to address these issues.

@paulbrown1982 @pvighi 