### PR TITLE
Salesforce scheduled downtime

### DIFF
--- a/app/views/downForMaintanance.scala.html
+++ b/app/views/downForMaintanance.scala.html
@@ -1,0 +1,24 @@
+@import com.gu.memsub.subsv2.CatalogPlan
+@import views.support.PlanOps._
+@import model.DigitalEdition
+@(digitalEdition: DigitalEdition, plan: Option[CatalogPlan.Paid] = None)
+
+@main(
+    title = "Down for maintenance",
+    plan = plan,
+    edition = digitalEdition
+) {
+    <main class="page-container gs-container">
+        @fragments.page.header("Down for maintenance")
+        <div class="prose">
+            <p>
+                Sorry, we are currently down for scheduled maintenance.
+            </p>
+            <p>
+                Please come back again in a few hours, or email
+                    <a href="mailto:@plan.fold("subscriptions@theguardian.com")(_.email)">@plan.fold("subscriptions@theguardian.com")(_.email)</a>.
+            </p>
+        </div>
+    </main>
+}
+

--- a/app/views/downForMaintanance.scala.html
+++ b/app/views/downForMaintanance.scala.html
@@ -16,7 +16,7 @@
             </p>
             <p>
                 Please come back again in a few hours, or email
-                    <a href="mailto:@plan.fold("subscriptions@theguardian.com")(_.email)">@plan.fold("subscriptions@theguardian.com")(_.email)</a>.
+                    <a href="mailto:@plan.map(_.email).getOrElse("subscriptions@theguardian.com")">@plan.map(_.email).getOrElse("subscriptions@theguardian.com")</a>.
             </p>
         </div>
     </main>


### PR DESCRIPTION
Added a 'Down for maintenance' page. I've scheduled some downtime to match the Salesforce maintenance window this Sunday at 2am-5am.

![picture 260](https://cloud.githubusercontent.com/assets/1515970/19970748/debc97be-a1d4-11e6-80f9-985747410158.png)

cc @johnduffell @jacobwinch @pvighi @AWare @JuliaBellis @jayceb1 