### PR TITLE
See full terms and conditions link under promo

### DIFF
--- a/app/views/fragments/checkout/promoCode.scala.html
+++ b/app/views/fragments/checkout/promoCode.scala.html
@@ -30,9 +30,13 @@
                 </div>
                 @fragments.forms.errorMessage("Please enter a valid promo code.")
             </div>
-            <div class="js-promo-code-applied promo-code-applied" style="display: none"><strong>✓&nbsp;</strong>
-                Promotion applied</div>
-            <div class="promo-code-snippet js-promo-code-snippet"></div>
+            <div class="js-promo-code-applied promo-code-applied" style="display: none">
+                <div><strong>✓&nbsp;&nbsp;Promotion applied</strong></div>
+                <div class="js-promo-code-snippet"></div>
+                <div class="js-promo-code-applied u-note">
+                     <a class="u-link js-promo-code-tsandcs" href="#" target="_blank">See full terms and conditions</a>
+                </div>
+            </div>
         </div>
     }
 }

--- a/app/views/fragments/checkout/promoCode.scala.html
+++ b/app/views/fragments/checkout/promoCode.scala.html
@@ -33,7 +33,7 @@
             <div class="js-promo-code-applied promo-code-applied" style="display: none">
                 <div><strong>✓&nbsp;&nbsp;Promotion applied</strong></div>
                 <div class="js-promo-code-snippet"></div>
-                <div class="js-promo-code-applied u-note">
+                <div class="u-note">
                      <a class="u-link js-promo-code-tsandcs" href="#" target="_blank">See full terms and conditions</a>
                 </div>
             </div>

--- a/app/views/fragments/promotion/incentiveLegalTerms.scala.html
+++ b/app/views/fragments/promotion/incentiveLegalTerms.scala.html
@@ -3,4 +3,4 @@
 @import views.support.LandingPageOps._
 
 @(promotion: AnyPromotion, md: MarkdownRenderer)
-@Html(md.render(promotion.getIncentiveLegalTerms))
+<p>@Html(md.render(promotion.getIncentiveLegalTerms))</p>

--- a/app/views/promotion/termsPage.scala.html
+++ b/app/views/promotion/termsPage.scala.html
@@ -30,7 +30,7 @@
             <h4>Applies to products</h4>
             <ul class="promotion-applies-to">
                 @catalog.allSubs.flatten.filter(plan => promotion.appliesTo.productRatePlanIds.contains(plan.id)).map { plan =>
-                    <li><a href="@routes.Checkout.renderCheckout(UK, None, None, plan.slug).url">@{plan.product.toString.replace("Digipack", "")} @plan.name</a></li>
+                    <li><a class="u-link" href="@routes.Checkout.renderCheckout(UK, None, None, plan.slug).url">@{plan.product.toString.replace("Digipack", "")} @plan.name</a></li>
                 }
             </ul>
 

--- a/assets/javascripts/modules/checkout/promoCode.js
+++ b/assets/javascripts/modules/checkout/promoCode.js
@@ -11,6 +11,7 @@ define([
     var $inputBox           = formElements.$PROMO_CODE,
         $ratePlanFields     = $('input[name="ratePlanId"]'),
         $promoCodeSnippet   = $('.js-promo-code-snippet'),
+        $promoCodeTsAndCs   = $('.js-promo-code-tsandcs'),
         $promoCodeError     = $('.js-promo-code .js-error-message'),
         $promoCodeApplied   = $('.js-promo-code-applied'),
         lookupUrl           = $inputBox.data('lookup-url');
@@ -64,6 +65,7 @@ define([
     function clearDown() {
         $promoCodeError.text('');
         $promoCodeSnippet.html('');
+        $promoCodeTsAndCs.attr('href', '#');
         $promoCodeApplied.hide();
         toggleError($promoCodeError.parent(), false);
         removePromotionFromRatePlans();
@@ -77,10 +79,11 @@ define([
 
     }
 
-    function displayPromotion(response) {
+    function displayPromotion(response, promoCode) {
         clearDown();
         $promoCodeApplied.show();
         $promoCodeSnippet.html(response.promotion.description);
+        $promoCodeTsAndCs.attr('href', '/p/' + promoCode + '/terms');
         applyPromotionToRatePlans(response.adjustedRatePlans);
     }
 
@@ -104,7 +107,7 @@ define([
             }
         }).then(function (a) {
             if (a.isValid) {
-                displayPromotion(a);
+                displayPromotion(a, promoCode);
                 bindExtraKeyListener();
             } else {
                 displayError(a.errorMessage);

--- a/assets/stylesheets/modules/_checkout-promocode.scss
+++ b/assets/stylesheets/modules/_checkout-promocode.scss
@@ -27,13 +27,6 @@
     }
 }
 .promo-code-applied {
-    font-weight: guss-font-weight(bold);
-
-    @include mq($until: desktop) {
-        @include fs-textSans(3);
-    }
-}
-.promo-code-snippet {
     margin-bottom: ($gs-baseline);
 
     @include mq($until: desktop) {

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,7 @@ resolvers ++= Seq(
     "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
     Resolver.sonatypeRepo("releases"))
 
-addCommandAlias("devrun", "run -Dconfig.resource=DEV.conf 9200")
+addCommandAlias("devrun", "run -Dconfig.resource=PROD.conf 9200")
 addCommandAlias("fast-test", "testOnly -- -l Acceptance")
 addCommandAlias("acceptance-test", "testOnly acceptance.CheckoutSpec")
 

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,7 @@ resolvers ++= Seq(
     "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
     Resolver.sonatypeRepo("releases"))
 
-addCommandAlias("devrun", "run -Dconfig.resource=PROD.conf 9200")
+addCommandAlias("devrun", "run -Dconfig.resource=DEV.conf 9200")
 addCommandAlias("fast-test", "testOnly -- -l Acceptance")
 addCommandAlias("acceptance-test", "testOnly acceptance.CheckoutSpec")
 


### PR DESCRIPTION
- Add a 'See full terms and conditions' link under the promotion applied description.

![picture 274](https://cloud.githubusercontent.com/assets/1515970/20058164/7ff1917e-a4e7-11e6-97cf-f07c1d37f8fd.png)

- Tidy up padding and products link styling on terms and conditions page template.

![picture 275](https://cloud.githubusercontent.com/assets/1515970/20058170/850a3170-a4e7-11e6-9cbd-06291bfa1c0a.png)

cc @JuliaBellis @johnduffell @pvighi @AWare @jacobwinch 