### PR TITLE
Adding a new mail group to those who can access CAS

### DIFF
--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -37,7 +37,8 @@ object CommonActions {
     "directteam@guardian.co.uk",
     "userhelp@guardian.co.uk",
     "dig.qa@guardian.co.uk",
-    "subscriptions.dev@guardian.co.uk"
+    "subscriptions.dev@guardian.co.uk",
+    "subscriptions.cas@guardian.co.uk"
   ))
 
   val CachedAction = resultModifier(Cached(_))


### PR DESCRIPTION
Adding a new mail group to those who can access CAS. This gives me and Hamza a group which we can control to add ad-hoc people which is not subject to loads of other mails.

cc @JuliaBellis @mario-galic @jacobwinch 