### PR TITLE
bug with "pay in £GBP" checkbox 

### DIFF
--- a/assets/javascripts/modules/checkout/fieldSwitcher.js
+++ b/assets/javascripts/modules/checkout/fieldSwitcher.js
@@ -106,8 +106,6 @@ define([
     };
 
     var redrawCurrencyOverride = function (currentState) {
-        $('.js-currency-override-checkbox').attr('checked', false);
-
         var currencySelector = $('.js-checkout-currency-override');
 
         if (currentState.priceBanding.currency == 'USD') {
@@ -177,6 +175,10 @@ define([
         };
 
         var refresh = function () {
+            if (determinesPriceBanding) {
+                $('.js-currency-override-checkbox').attr('checked', false);
+            }
+            
             var currentState = getCurrentState();
 
              if (determinesPriceBanding) {


### PR DESCRIPTION
fixed bug introduced in latest js refactor:
 If the "Pay in £GBP" checkbox was selected then the first time the country was changed the currency remained as £ and the checkbox would hide.

It should now reset the checkbox state when changing countries and the appropriate currency should be selected.
