### PR TITLE
Guardian Weekly - moving Canada to Zone B

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -3,7 +3,6 @@ package controllers
 import actions.CommonActions._
 import com.gu.i18n._
 import com.gu.identity.play.ProxiedIP
-import com.gu.memsub.Product.WeeklyZoneB
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.promo.Formatters.PromotionFormatters._
 import com.gu.memsub.promo.Promotion.{AnyPromotion, _}
@@ -49,7 +48,7 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
       Country("JE", "Jersey")
     ))
 
-  val weeklyZoneAGroups = List(weeklyUkCountries, CountryGroup.US, CountryGroup.Canada)
+  val weeklyZoneAGroups = List(weeklyUkCountries, CountryGroup.US)
   val weeklyZoneBGroups = {
     val rowUk = CountryGroup("Row Uk", "uk", None, CountryGroup.UK.countries.filterNot(weeklyUkCountries.countries.contains(_)), GBP, PostCode)
     rowUk :: CountryGroup.allGroups.filterNot(group => (CountryGroup.UK :: weeklyZoneAGroups) contains group)

--- a/app/model/WeeklyRegions.scala
+++ b/app/model/WeeklyRegions.scala
@@ -16,13 +16,13 @@ object WeeklyRegion {
 
 object UnitedKingdom extends WeeklyRegion {
   override val title = "United Kingdom"
-  override val description = "Including Isle of Man and Channel Islands"
+  override val description = "Includes Isle of Man and Channel Islands"
   override val url = Uri.parse("checkout/weeklyzonea-guardianweeklyquarterly?countryGroup=uk")
 }
 
 object UnitedStates extends WeeklyRegion {
   override val title = "United States"
-  override val description = "Mainland US including Alaska and Hawaii"
+  override val description = "Includes Alaska and Hawaii"
   override val url = Uri.parse("checkout/weeklyzonea-guardianweeklyquarterly?countryGroup=us")
 }
 

--- a/app/model/WeeklyRegions.scala
+++ b/app/model/WeeklyRegions.scala
@@ -11,18 +11,18 @@ trait WeeklyRegion {
 }
 
 object WeeklyRegion {
-  val all = List(Uk, NorthAmerica, Row)
+  val all = List(UnitedKingdom, UnitedStates, Row)
 }
 
-object Uk extends WeeklyRegion {
+object UnitedKingdom extends WeeklyRegion {
   override val title = "United Kingdom"
-  override val description = "Includes Isle of Man and Channel Islands"
+  override val description = "Including Isle of Man and Channel Islands"
   override val url = Uri.parse("checkout/weeklyzonea-guardianweeklyquarterly?countryGroup=uk")
 }
 
-object NorthAmerica extends WeeklyRegion {
-  override val title = "North America"
-  override val description = "Canada and USA"
+object UnitedStates extends WeeklyRegion {
+  override val title = "United States"
+  override val description = "Mainland US including Alaska and Hawaii"
   override val url = Uri.parse("checkout/weeklyzonea-guardianweeklyquarterly?countryGroup=us")
 }
 

--- a/app/views/weekly/weekly_landing.scala.html
+++ b/app/views/weekly/weekly_landing.scala.html
@@ -10,7 +10,7 @@
 
         <section class="section-slice">
 
-            <h2 class="page-heading">Where do you want the Guardian Weekly delivered?</h2>
+            <h2 class="page-heading">Where should we send your Guardian Weekly?</h2>
 
             @for(option <- options) {
                 <a href="@option.url.toString" class="package">


### PR DESCRIPTION
 - Moved Canada to Zone B Rest of the world. 
- Also updated the UI links and some copy on the /weekly page.

E.g.

<img width="1002" alt="picture 280" src="https://cloud.githubusercontent.com/assets/1515970/20103089/7793eb1a-a5c0-11e6-8bf7-df16002d11a4.png">

cc @pvighi @johnduffell @JuliaBellis @jacobwinch @AWare 