### PR TITLE
Suspend and resume for quarterly and annual subscribers

### DIFF
--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -24,8 +24,8 @@
                 </p>
                 <p>
                     If you do not have your Subscriber ID to hand, or you have any other customer service enquir​ies,
-                    please contact us on: <a href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
-                    or email <a href="mailto:homedelivery@@theguardian.com">homedelivery@@theguardian.com</a>.
+                    please contact us on: <a class="u-link" href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
+                    or email <a class="u-link" href="mailto:homedelivery@@theguardian.com">homedelivery@@theguardian.com</a>.
                 </p>
             </div>
 

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -6,6 +6,7 @@
 @import model.DigitalEdition.UK
 @import views.support.Dates.prettyDate
 @import views.support.AccountManagementOps._
+@import org.joda.time.Days
 @import com.gu.memsub.BillingPeriod
 @import com.gu.memsub.subsv2.SubscriptionPlan.DailyPaper
 @import com.gu.memsub.PaperDay
@@ -18,7 +19,10 @@
     suspendedDays: Int,
     errorCodes: Set[String]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
-
+@avgPeriodBetweenInvoices = @{
+    val dates = billingSchedule.invoices.list.filter(_.amount > 0).map(_.date)
+    Math.floor(Days.daysBetween(dates.head, dates.last).getDays / dates.size)
+}
 @main("Cancel your papers while you're away | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
     <main class="page-container gs-container">
@@ -42,12 +46,13 @@
                 }
             </section>
 
-            @if(subscription.plan.charges.billingPeriod == BillingPeriod.month && (suspendableDays - suspendedDays) > 0) {
+            @if((suspendableDays - suspendedDays) > 0) {
                 <section class="mma-section">
+                @if(subscription.plan.charges.billingPeriod == BillingPeriod.month && avgPeriodBetweenInvoices <= 31) {
                     <form class="form js-suspend-form" action="@routes.AccountManagement.processSuspension().url" method="POST" novalidate>
                         <fieldset>
                             <legend class="mma-section__header">
-                                Create a suspension
+                                Book a delivery holiday
                             </legend>
                             @helper.CSRF.formField
 
@@ -71,13 +76,19 @@
                         </fieldset>
                     </form>
                     <span class="mma-dates__request">
-                        Please give us at least 5 days notice to process the suspension. You can suspend up to @suspendableWeeks weeks. <strong>
-                        All dates are inclusive</strong>.</span>
+                        Please give us at least 5 days notice to process the delivery holiday. You can line up to @suspendableWeeks weeks of holidays.<strong>
+                        All dates are inclusive</strong>.
+                    </span>
+                } else {
+                    <h3 class="mma-section__header">Book a delivery holiday</h3>
+                    <p>Unfortunately you cannot set up a delivery holiday online at the moment. Please call Customer Services on <a class="u-link" href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
+                        or email <a class="u-link" href="mailto:homedelivery@@theguardian.com">homedelivery@@theguardian.com</a>.</p>
+                }
                 </section>
             }
 
             <section class="mma-section">
-                <h3 class="mma-section__header">Scheduled suspensions</h3>
+                <h3 class="mma-section__header">Upcoming delivery holidays</h3>
                 @account.fragments.suspensions(holidayRefunds, suspendableDays, suspendedDays)
             </section>
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.301",
+    "com.gu" %% "membership-common" % "0.302",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
- Now shows a message to phone customer services if the billing period is not 1 month.

https://trello.com/c/l7exA31F/40-suspend-and-resume-calculations-are-wrong-for-quarterly-and-annual-subscribers-copy-workaround

- Upgraded to latest membership-common to take now properly working billing schedule API.
- Updated the copy on the page to say "Book a delivery holiday" and "Upcoming delivery holidays" rather than "Create suspension" and "Scheduled suspensions"

cc @johnduffell @pvighi @AWare @jacobwinch @JuliaBellis 