### PR TITLE
Voucher book start date for weekends + 1 week

### DIFF
--- a/assets/javascripts/modules/checkout/voucherFields.jsx
+++ b/assets/javascripts/modules/checkout/voucherFields.jsx
@@ -27,12 +27,7 @@ function getFirstSelectableDate(filterFn) {
     var weeksToAdd = currentWeekday >= CUTOFF_WEEKDAY && currentHour >= CUTOFF_HOUR ? EXTRA_DELIVERY_DELAY : NORMAL_DELIVERY_DELAY;
     var firstSelectableDate = mostRecentMonday.add(weeksToAdd, 'weeks');
     while (filterFn && !filterFn(firstSelectableDate)) {
-        // Weekend / Sunday subs can have an earlier first voucher than weekday-starting books.
-        if (/Weekend|Sunday/i.test(ratePlanChoice.getSelectedRatePlanName())) {
-            firstSelectableDate.subtract(1, 'day');
-        } else {
-            firstSelectableDate.add(1, 'day');
-        }
+        firstSelectableDate.add(1, 'day');
     }
     return firstSelectableDate;
 }


### PR DESCRIPTION
Reverted an earlier requested change which let customers pick a Saturday/Sunday voucher start date a week early. Even though the voucher book is still likely to arrive on time, customers are reporting that there is not enough time to arrange deliveries via their local news agent.

Before:

![picture 296](https://cloud.githubusercontent.com/assets/1515970/20341352/d7038dc6-abdd-11e6-8462-3afe9b1abfb4.png)

After:

![picture 297](https://cloud.githubusercontent.com/assets/1515970/20341366/df62d396-abdd-11e6-8ef4-12c03d749a4c.png)

cc @AWare @johnduffell @jacobwinch @JuliaBellis @pvighi @jayceb1 