### PR TITLE
when renewing Weekly, output salesforce email if available

### DIFF
--- a/app/model/exactTarget/DataExtensionRow.scala
+++ b/app/model/exactTarget/DataExtensionRow.scala
@@ -219,7 +219,7 @@ object HolidaySuspensionBillingScheduleDataExtensionRow {
 
   def apply(
            email: Option[String],
-           saltuation: String,
+           saluation: String,
            subscriptionName: String,
            subscriptionCurrency: Currency,
            packageName: String,
@@ -247,7 +247,7 @@ object HolidaySuspensionBillingScheduleDataExtensionRow {
         "EmailAddress" -> emailAddress,
         "uuid" -> UUID.randomUUID().toString,
         "subscriber_id" -> subscriptionName,
-        "customer_salutation" -> saltuation,
+        "customer_salutation" -> saluation,
         "package_name" -> packageName,
         "days_allowed" -> daysAllowed.toString,
         "days_used" -> daysUsed.toString,

--- a/app/views/account/renew.scala.html
+++ b/app/views/account/renew.scala.html
@@ -25,6 +25,13 @@
 
             <section class="mma-section">
                 <h3 class="mma-section__header">
+                    Email address
+                </h3>
+                @contact.email
+            </section>
+
+            <section class="mma-section">
+                <h3 class="mma-section__header">
                     Your billing schedule
                 </h3>
                 @views.html.account.fragments.billingSchedule(billingSchedule, subscription.plan.charges.price.currencies.head)

--- a/app/views/account/renew.scala.html
+++ b/app/views/account/renew.scala.html
@@ -3,6 +3,8 @@
 @import com.gu.memsub.subsv2.Subscription
 @import model.DigitalEdition.UK
 @import com.gu.salesforce.Contact
+@import views.support.Dates.prettyDate
+
 @(
     subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: BillingSchedule, contact: Contact
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
@@ -28,6 +30,13 @@
                     Email address
                 </h3>
                 @contact.email
+            </section>
+
+            <section class="mma-section">
+                <h3 class="mma-section__header">
+                    Subscription end date
+                </h3>
+                @prettyDate(subscription.termEndDate)
             </section>
 
             <section class="mma-section">

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.302",
+    "com.gu" %% "membership-common" % "0.303-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.303",
+    "com.gu" %% "membership-common" % "0.304-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.303-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.303",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.304-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.304",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
Further to https://github.com/guardian/membership-common/pull/354
This uses the above PR to get migrated weekly subscribers from salesforce, and only send their email address to the logged in page if they have one so that we can update it only if it's not present.

@pvighi @paulbrown1982 @AWare 