### PR TITLE
countries and currency validation

### DIFF
--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -1,6 +1,6 @@
 package forms
 
-import com.gu.i18n.{CountryGroup, Currency, Title}
+import com.gu.i18n._
 import com.gu.memsub.Address
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.promo.PromoCode
@@ -8,12 +8,14 @@ import com.gu.memsub.subsv2.CatalogPlan
 import com.gu.memsub.subsv2.Catalog
 import com.gu.memsub.BillingPeriod
 import forms.SubscriptionsForm._
-import model._
+import model.{SubscribeRequest, _}
 import play.api.data.Forms._
 import play.api.data.format.Formats._
 import play.api.data.format.Formatter
 import play.api.data.{Form, _}
 import play.api.mvc.{AnyContent, Request}
+import model.ContentSubscriptionPlanOps._
+import views.support.CountryWithCurrency
 
 import scalaz.\/
 
@@ -49,10 +51,50 @@ class SubscriptionsForm(catalog: Catalog) {
     def asEither: Either[Seq[FormError], A] = in.fold(e => Left(e.errors), Right(_))
   }
 
+  private def validationError(key:String, msg:String) = \/.left(Seq(FormError(key, msg)))
+
+  private def validCurrency(selectedCurrency: Currency, settings: CountryWithCurrency) = settings.currency == selectedCurrency || selectedCurrency == GBP && settings.currency == USD && settings.country != Country.US
+
+  private def invalidCurrencyError = validationError("currency", "invalid plan, currency and country combination")
+
+  def toSubscribeRequest(subscriptionData: SubscriptionData, digipackData: DigipackData): Seq[FormError] \/ SubscribeRequest = {
+    val selectedCountrySettings = for {
+      country <- subscriptionData.personalData.address.country
+      validBillingCountries = digipackData.plan.localizationSettings.availableBillingCountriesWithCurrency
+      countrySettings <- validBillingCountries.find(_.country == country)
+    } yield (countrySettings)
+
+    selectedCountrySettings match {
+      case None => validationError("country", "invalid Country")
+      case Some(settings) => if (validCurrency(subscriptionData.currency, settings)) \/.right(SubscribeRequest(subscriptionData, Right(digipackData))) else invalidCurrencyError
+    }
+  }
+
+  def toSubscribeRequest (subscriptionData: SubscriptionData, paperData: PaperData): Seq[FormError] \/ SubscribeRequest = {
+    val localizationSettings = paperData.plan.localizationSettings
+    val billingCountrySettings = for {
+      country <- subscriptionData.personalData.address.country
+      validBillingCountries = localizationSettings.availableBillingCountriesWithCurrency
+      countrySettings <- validBillingCountries.find(_.country == country)
+    } yield (countrySettings)
+
+    val deliveryCountrySettings = for {
+      country <- paperData.deliveryAddress.country
+      validDeliveryCountries <- localizationSettings.availableDeliveryCountriesWithCurrency
+      countrySettings <- validDeliveryCountries.find(_.country == country)
+    } yield (countrySettings)
+
+    (billingCountrySettings, deliveryCountrySettings) match {
+      case (None, _) => validationError("billing address", "invalid billing country")
+      case (_, None) => validationError("delivery address", "invalid delivery country")
+      case (Some(billingSettings), Some(deliverySEttings)) => if (validCurrency(subscriptionData.currency, deliverySEttings)) \/.right(SubscribeRequest(subscriptionData, Left(paperData))) else invalidCurrencyError
+    }
+  }
+
   def bindFromRequest(implicit r: Request[AnyContent]): Seq[FormError] \/ SubscribeRequest = {
     (subsForm.bindFromRequest().asEither, digipackForm.bindFromRequest().asEither, paperForm.bindFromRequest().asEither) match {
-      case(Right(a), Right(d), Left(_)) => \/.right(SubscribeRequest(a, Right(d)))
-      case(Right(a), Left(_), Right(p)) => \/.right(SubscribeRequest(a, Left(p)))
+      case(Right(a), Right(d), Left(_)) => toSubscribeRequest(a,d)
+      case(Right(a), Left(_), Right(p)) => toSubscribeRequest(a,p)
       case(a, b, c) => \/.left(a.left.toOption.toSeq.flatten ++ b.left.toOption.toSeq.flatten ++ c.left.toOption.toSeq.flatten)
     }
   }

--- a/app/model/ContentSubscriptionPlanOps.scala
+++ b/app/model/ContentSubscriptionPlanOps.scala
@@ -1,0 +1,49 @@
+package model
+
+import com.gu.i18n._
+import com.gu.memsub.Product
+import com.gu.memsub.subsv2.CatalogPlan
+import views.support.CountryWithCurrency
+
+
+object ContentSubscriptionPlanOps {
+  val weeklyUkCountries = CountryGroup.UK.copy(
+    countries = List(
+      Country.UK,
+      Country("GG", "Guernsey"),
+      Country("IM", "Isle of Man"),
+      Country("JE", "Jersey")
+    ))
+  val weeklyZoneAGroups = List(weeklyUkCountries, CountryGroup.US)
+  val weeklyZoneBGroups = {
+    val rowUk = CountryGroup("Row Uk", "uk", None, CountryGroup.UK.countries.filterNot(weeklyUkCountries.countries.contains(_)), GBP, PostCode)
+    rowUk :: CountryGroup.allGroups.filterNot(group => (CountryGroup.UK :: weeklyZoneAGroups) contains group)
+  }
+  val ukAndIsleOfMan = CountryGroup.UK.copy(countries = List(Country.UK, Country("IM", "Isle of Man")))
+
+  implicit class EnrichedContentSubscriptionPlan[+A <: CatalogPlan.ContentSubscription](in: A) {
+
+    case class LocalizationSettings(availableDeliveryCountriesWithCurrency: Option[List[CountryWithCurrency]], availableBillingCountriesWithCurrency: List[CountryWithCurrency])
+
+    def localizationSettings: LocalizationSettings = {
+      val supportedCurrencies = in.charges.currencies
+      def allCountriesWithCurrencyOrGBP = CountryWithCurrency.whitelisted(supportedCurrencies, GBP)
+      in.product match {
+        case Product.Digipack => LocalizationSettings(None, allCountriesWithCurrencyOrGBP)
+
+        case Product.Delivery =>
+          val deliveryCountries = List(CountryWithCurrency(Country.UK, GBP))
+          LocalizationSettings(Some(deliveryCountries), deliveryCountries)
+
+        case Product.Voucher =>
+          val voucherCountries = CountryWithCurrency.fromCountryGroup(ukAndIsleOfMan)
+          LocalizationSettings(Some(voucherCountries), voucherCountries)
+
+        case Product.WeeklyZoneA => LocalizationSettings(Some(CountryWithCurrency.whitelisted(supportedCurrencies, GBP, weeklyZoneAGroups)), allCountriesWithCurrencyOrGBP)
+
+        case Product.WeeklyZoneB => LocalizationSettings(Some(CountryWithCurrency.whitelisted(supportedCurrencies, USD, weeklyZoneBGroups)), allCountriesWithCurrencyOrGBP)
+      }
+    }
+  }
+
+}

--- a/app/model/PaymentValidation.scala
+++ b/app/model/PaymentValidation.scala
@@ -1,6 +1,9 @@
 package model
 
-import com.gu.i18n.{Country, Currency, GBP}
+import com.gu.i18n.{Country, Currency, GBP, USD}
+import com.gu.memsub.Product
+import com.gu.memsub.subsv2.CatalogPlan
+import views.support.CountryWithCurrency
 
 object PaymentValidation {
   def validateDirectDebit(subscriptionData: SubscriptionData): Boolean = {
@@ -9,5 +12,15 @@ object PaymentValidation {
         subscriptionData.personalData.address.country.contains(Country.UK) && subscriptionData.currency == GBP
       case _ => true
     }
+  }
+
+  def validateCurrency(currency: Currency, settings: CountryWithCurrency, plan: CatalogPlan.ContentSubscription): Boolean = {
+
+    def isValidCurrencyOverride = plan.product match {
+      case Product.WeeklyZoneB => currency == GBP && settings.currency == USD && settings.country != Country.US
+      case _ => false
+    }
+
+    settings.currency == currency || isValidCurrencyOverride
   }
 }


### PR DESCRIPTION
On different parts of the renewal flow we're going to need to be aware of which currencies and country combinations are valid for each plan. This is currently hard coded in the checkout controller method that renders the subscription flow.

This PR :

- Removes the code to a common location in order to use it for the renewal flow

- Reuses it to provide server side currency and countries validation to the subscription flow 