### PR TITLE
Handle removal of Ireland country group

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -47,9 +47,12 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
   def getBetterPlans[A <: CatalogPlan.Paid](plan: A, others: List[A]) =
     others.sortBy(_.charges.gbpPrice.amount).dropWhile(_.charges.gbpPrice.amount <= plan.charges.gbpPrice.amount)
 
-  def renderCheckout(countryGroup: CountryGroup, promoCode: Option[PromoCode], supplierCode: Option[SupplierCode], forThisPlan: String) = NoCacheAction.async { implicit request =>
+  def renderCheckout(countryGroup: String, promoCode: Option[PromoCode], supplierCode: Option[SupplierCode], forThisPlan: String) = NoCacheAction.async { implicit request =>
     implicit val resolution: TouchpointBackend.Resolution = TouchpointBackend.forRequest(PreSigninTestCookie, request.cookies)
     implicit val tpBackend = resolution.backend
+
+    // countryGroup String above basically means now 'countryOrCountryGroup' so we'll use the fromHint API on DetermineCountryGroup
+    val determinedCountryGroup = DetermineCountryGroup.fromHint(countryGroup) getOrElse CountryGroup.UK
 
     val matchingPlanList: Option[PlanList[CatalogPlan.ContentSubscription]] = {
 
@@ -94,10 +97,10 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
         }
 
         val countryAndCurrencySettings = planList.default.product match {
-          case Product.Digipack => getSettings(countryGroup.defaultCountry, GBP)
+          case Product.Digipack => getSettings(determinedCountryGroup.defaultCountry, GBP)
           case Product.Delivery => getSettings(Some(Country.UK), GBP)
           case Product.Voucher => getSettings(Some(Country.UK), GBP)
-          case Product.WeeklyZoneA => getSettings(countryGroup.defaultCountry, GBP)
+          case Product.WeeklyZoneA => getSettings(determinedCountryGroup.defaultCountry, GBP)
           case Product.WeeklyZoneB => getSettings(None, USD)
         }
 
@@ -119,7 +122,7 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
         Ok(views.html.checkout.payment(
           personalData = personalData,
           productData = productData,
-          countryGroup = countryGroup,
+          countryGroup = determinedCountryGroup,
           touchpointBackendResolution = resolution,
           promoCode = promo.left.toOption,
           supplierCode = resolvedSupplierCode,

--- a/app/controllers/Shipping.scala
+++ b/app/controllers/Shipping.scala
@@ -1,6 +1,6 @@
 package controllers
 import actions.CommonActions._
-import com.gu.i18n.CountryGroup
+import com.gu.i18n.CountryGroup.UK
 import com.gu.memsub.subsv2.CatalogPlan
 import model.Subscriptions._
 import play.api.mvc._
@@ -18,7 +18,7 @@ object Shipping extends Controller {
   def planToOptions(in: CatalogPlan.Paid): SubscriptionOption =
     SubscriptionOption(in.slug,
       in.name, in.charges.gbpPrice.amount * 12 / 52, in.saving.map(_.toString + "%"), in.charges.gbpPrice.amount, in.description,
-      routes.Checkout.renderCheckout(CountryGroup.UK, None, None, in.slug).url
+      routes.Checkout.renderCheckout(UK.id, None, None, in.slug).url
     )
 
   def viewCollectionPaperDigital() = CachedAction {

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -162,10 +162,10 @@
                             }
                             <div class="field-note field-note--offset prose">
                                 @if(personalData.isDefined) {
-                                    <a href="@idWebAppSignOutUrl(routes.Checkout.renderCheckout(countryGroup, promoCode, None, productData.plans.default.slug))">Sign out</a>
+                                    <a href="@idWebAppSignOutUrl(routes.Checkout.renderCheckout(countryGroup.id, promoCode, None, productData.plans.default.slug))">Sign out</a>
                                 } else {
                                     <span class="field-note__label">Already have a Guardian account?</span>
-                                    <a class="js-sign-in-link" href="@idWebAppSigninUrl(routes.Checkout.renderCheckout(countryGroup, promoCode, None, productData.plans.default.slug))">Sign in</a>
+                                    <a class="js-sign-in-link" href="@idWebAppSigninUrl(routes.Checkout.renderCheckout(countryGroup.id, promoCode, None, productData.plans.default.slug))">Sign in</a>
                                 }
                             </div>
                         </div>

--- a/app/views/promotion/termsPage.scala.html
+++ b/app/views/promotion/termsPage.scala.html
@@ -30,7 +30,7 @@
             <h4>Applies to products</h4>
             <ul class="promotion-applies-to">
                 @catalog.allSubs.flatten.filter(plan => promotion.appliesTo.productRatePlanIds.contains(plan.id)).map { plan =>
-                    <li><a class="u-link" href="@routes.Checkout.renderCheckout(UK, None, None, plan.slug).url">@{plan.product.toString.replace("Digipack", "")} @plan.name</a></li>
+                    <li><a class="u-link" href="@routes.Checkout.renderCheckout(UK.id, None, None, plan.slug).url">@{plan.product.toString.replace("Digipack", "")} @plan.name</a></li>
                 }
             </ul>
 

--- a/app/views/support/CountryWithCurrency.scala
+++ b/app/views/support/CountryWithCurrency.scala
@@ -23,3 +23,20 @@ object CountryWithCurrency {
 }
 
 case class CountryAndCurrencySettings(availableDeliveryCountries: Option[List[CountryWithCurrency]], availableBillingCountries: List[CountryWithCurrency], defaultCountry: Option[Country], defaultCurrency: Currency)
+
+object DetermineCountryGroup {
+
+  /***
+    * This method takes a hint String and returns a CountryGroup if it can map to it. If the hint also implies a Country
+    * which exists within the CountryGroup, then it sets the defaultCountry within that CountryGroup to that Country.
+    * @param hint a CountryCode ID or a Country.alpha2 value.
+    * @return a potentially modified CountryGroup
+    */
+  def fromHint(hint: String): Option[CountryGroup] = {
+    val possibleCountryGroup = CountryGroup.byId(hint) orElse CountryGroup.byCountryCode(hint.toUpperCase)
+    possibleCountryGroup.map { foundCountryGroup =>
+      val determinedCountry = CountryGroup.countryByCode(hint.toUpperCase) orElse foundCountryGroup.defaultCountry
+      foundCountryGroup.copy(defaultCountry = determinedCountry)
+    }
+  }
+}

--- a/app/views/support/LandingPageOps.scala
+++ b/app/views/support/LandingPageOps.scala
@@ -1,6 +1,6 @@
 package views.support
 
-import com.gu.i18n.CountryGroup
+import com.gu.i18n.CountryGroup.UK
 import com.gu.memsub.promo.Promotion._
 import com.gu.memsub.promo._
 import com.gu.memsub.subsv2.CatalogPlan
@@ -55,7 +55,7 @@ object LandingPageOps {
       saving.map(_.toString + "%"),
       planPrice.amount,
       in.description,
-      routes.Checkout.renderCheckout(CountryGroup.UK, Some(promoCode), None, in.slug).url,
+      routes.Checkout.renderCheckout(UK.id, Some(promoCode), None, in.slug).url,
       paymentDetails
     )
   }

--- a/app/views/testing/testUsers.scala.html
+++ b/app/views/testing/testUsers.scala.html
@@ -28,7 +28,7 @@
             @for(group <- products) {
                 <dl>
                 @for(plan <- group.sortBy(_.charges.gbpPrice.amount)) {
-                    <a href="@routes.Checkout.renderCheckout(UK, None, None, plan.slug)" style="margin-bottom: 10px" class="button button--primary button--large">@plan.name (@{(plan.charges.gbpPrice * 12 / 52).pretty}/w, @plan.charges.gbpPrice.pretty/m)</a>
+                    <a href="@routes.Checkout.renderCheckout(UK.id, None, None, plan.slug)" style="margin-bottom: 10px" class="button button--primary button--large">@plan.name (@{(plan.charges.gbpPrice * 12 / 52).pretty}/w, @plan.charges.gbpPrice.pretty/m)</a>
                 }
                 </dl>
             }
@@ -41,7 +41,7 @@
             @for(group <- products) {
                 <dl>
                     @for(plan <- group.sortBy(_.charges.gbpPrice.amount)) {
-                        <a href="@idWebAppRegisterUrl(routes.Checkout.renderCheckout(UK, None, None, plan.slug))" style="margin-bottom: 10px" class="button button--primary button--large">@plan.name (@{(plan.charges.gbpPrice * 12 / 52).pretty}/w, @plan.charges.gbpPrice.pretty/m)</a>
+                        <a href="@idWebAppRegisterUrl(routes.Checkout.renderCheckout(UK.id, None, None, plan.slug))" style="margin-bottom: 10px" class="button button--primary button--large">@plan.name (@{(plan.charges.gbpPrice * 12 / 52).pretty}/w, @plan.charges.gbpPrice.pretty/m)</a>
                     }
                 </dl>
             }

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.304",
+    "com.gu" %% "membership-common" % "0.306-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.306-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.306",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/conf/routes
+++ b/conf/routes
@@ -28,8 +28,8 @@ GET         /checkout/findAddress            controllers.Checkout.findAddress(po
 
 # Checkout pages
 GET         /checkout/thank-you              controllers.Checkout.thankYou()
-GET         /checkout                        controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], supplierCode: Option[SupplierCode], forThisPlan = "digitalpack-digitalpackmonthly")
-GET         /checkout/:forThisPlan           controllers.Checkout.renderCheckout(countryGroup: CountryGroup ?= CountryGroup.UK, promoCode: Option[PromoCode], supplierCode: Option[SupplierCode], forThisPlan: String)
+GET         /checkout                        controllers.Checkout.renderCheckout(countryGroup: String ?= CountryGroup.UK.id, promoCode: Option[PromoCode], supplierCode: Option[SupplierCode], forThisPlan = "digitalpack-digitalpackmonthly")
+GET         /checkout/:forThisPlan           controllers.Checkout.renderCheckout(countryGroup: String ?= CountryGroup.UK.id, promoCode: Option[PromoCode], supplierCode: Option[SupplierCode], forThisPlan: String)
 
 # collection and delivery
 GET         /collection/paper-digital        controllers.Shipping.viewCollectionPaperDigital

--- a/test/views/support/DetermineCountryGroupTest.scala
+++ b/test/views/support/DetermineCountryGroupTest.scala
@@ -1,0 +1,51 @@
+package views.support
+
+import com.gu.i18n.{Country, CountryGroup}
+import org.specs2.mutable.Specification
+
+class DetermineCountryGroupTest extends Specification {
+
+  "DetermineCountryGroup fromHint" should {
+
+    "return None when hint is nonsense" in {
+      val gottenCountryGroup = DetermineCountryGroup.fromHint("nonsense")
+      gottenCountryGroup must_=== None
+    }
+
+    "return a Europe countryGroup with Germany defaultCountry when 'de' is provided." in {
+      val gottenCountryGroup = DetermineCountryGroup.fromHint("de")
+
+      assert(gottenCountryGroup.isDefined)
+      gottenCountryGroup.get.id must_=== CountryGroup.Europe.id
+      assert(gottenCountryGroup.get.defaultCountry.isDefined)
+      gottenCountryGroup.get.defaultCountry.get must_=== Country("DE","Germany", Nil)
+    }
+
+    "return a Europe countryGroup with Germany defaultCountry when 'DE' is provided." in {
+      val gottenCountryGroup = DetermineCountryGroup.fromHint("DE")
+
+      assert(gottenCountryGroup.isDefined)
+      gottenCountryGroup.get.id must_=== CountryGroup.Europe.id
+      assert(gottenCountryGroup.get.defaultCountry.isDefined)
+      gottenCountryGroup.get.defaultCountry.get must_=== Country("DE","Germany", Nil)
+    }
+
+    "return a Europe countryGroup with Ireland defaultCountry when 'ie' is provided." in {
+      val gottenCountryGroup = DetermineCountryGroup.fromHint("ie")
+
+      assert(gottenCountryGroup.isDefined)
+      gottenCountryGroup.get.id must_=== CountryGroup.Europe.id
+      assert(gottenCountryGroup.get.defaultCountry.isDefined)
+      gottenCountryGroup.get.defaultCountry.get must_=== Country.Ireland
+    }
+
+    "return a Europe countryGroup with Ireland defaultCountry when 'IE' is provided." in {
+      val gottenCountryGroup = DetermineCountryGroup.fromHint("IE")
+
+      assert(gottenCountryGroup.isDefined)
+      gottenCountryGroup.get.id must_=== CountryGroup.Europe.id
+      assert(gottenCountryGroup.get.defaultCountry.isDefined)
+      gottenCountryGroup.get.defaultCountry.get must_=== Country.Ireland
+    }
+  }
+}


### PR DESCRIPTION
- Updated how the countryGroup is handled on the checkout page. It now accepts upper or lower case country ISO codes as well as country group IDs.
- Providing a country code will find the enclosing country-group AND set the default country within that group to the provided code. Falling back to UK as normal if an enclosing country group cannot be found.
- This change has been made because the Ireland country group has been removed from membership-common and the /checkout?countryGroup=ie is still a heavily linked-to URL (primarily at JellyFish).

cc @rtyley 