### PR TITLE
Rationalise checkout.js module loading

### DIFF
--- a/assets/javascripts/modules/checkout.js
+++ b/assets/javascripts/modules/checkout.js
@@ -44,7 +44,6 @@ define([
             deliveryAsBilling.init();
             billingAddress.init();
             ratePlanChoice.init();
-            eventTracking.init();
             if (formElements.$DELIVERY_FIELDS.length) {
                 require(['modules/checkout/deliveryFields', 'modules/checkout/addressFinder'], function(deliveryFields, addressFinder) {
                     deliveryFields.default.init();
@@ -63,8 +62,9 @@ define([
                     event.stopPropagation();
                 }
             });
+            curl('js!stripeCheckout');
         }
-        curl('js!stripeCheckout');
+        eventTracking.init();
     }
 
     return {


### PR DESCRIPTION
- stripeCheckout JavaScript is only curled on the Checkout page. 
- eventTracking is now initialised on other non-checkout pages too, so that it initialises on the thank you page too.

cc @AWare @ajosephides 