### PR TITLE
get bill-to contact for manage weekly, and display the country

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -2,6 +2,7 @@ package controllers
 
 import actions.CommonActions._
 import com.gu.i18n._
+import Currency._
 import com.gu.identity.play.ProxiedIP
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.promo.Formatters.PromotionFormatters._

--- a/app/model/ContentSubscriptionPlanOps.scala
+++ b/app/model/ContentSubscriptionPlanOps.scala
@@ -1,6 +1,7 @@
 package model
 
 import com.gu.i18n._
+import Currency._
 import com.gu.memsub.Product
 import com.gu.memsub.subsv2.CatalogPlan
 import views.support.CountryWithCurrency

--- a/app/model/JsVars.scala
+++ b/app/model/JsVars.scala
@@ -1,6 +1,7 @@
 package model
 
-import com.gu.i18n.{GBP, Currency, Country, CountryGroup}
+import com.gu.i18n.{Currency, Country}
+import Currency.GBP
 import play.api.libs.json._
 
 object JsVars {

--- a/app/model/PaymentValidation.scala
+++ b/app/model/PaymentValidation.scala
@@ -1,6 +1,7 @@
 package model
 
-import com.gu.i18n.{Country, Currency, GBP, USD}
+import com.gu.i18n.Currency._
+import com.gu.i18n.{Country, Currency}
 import com.gu.memsub.Product
 import com.gu.memsub.subsv2.CatalogPlan
 import views.support.CountryWithCurrency

--- a/app/services/PaymentService.scala
+++ b/app/services/PaymentService.scala
@@ -1,6 +1,7 @@
 package services
 import com.gu.i18n.Country.UK
-import com.gu.i18n.{Currency, GBP}
+import com.gu.i18n.Currency
+import com.gu.i18n.Currency.GBP
 import com.gu.memsub.subsv2.CatalogPlan
 import com.gu.salesforce.ContactId
 import com.gu.stripe.StripeService

--- a/app/views/account/fragments/suspensions.scala.html
+++ b/app/views/account/fragments/suspensions.scala.html
@@ -1,4 +1,4 @@
-@import com.gu.i18n.GBP
+@import com.gu.i18n.Currency.GBP
 @import com.gu.memsub.Price
 @import com.gu.subscriptions.suspendresume.SuspensionService.HolidayRefund
 @import views.support.Dates.formattedDateRange

--- a/app/views/account/renew.scala.html
+++ b/app/views/account/renew.scala.html
@@ -4,9 +4,10 @@
 @import model.DigitalEdition.UK
 @import com.gu.salesforce.Contact
 @import views.support.Dates.prettyDate
+@import com.gu.i18n.Country
 
 @(
-    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: BillingSchedule, contact: Contact
+    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: BillingSchedule, contact: Contact, billToCountry: Country
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
@@ -23,6 +24,13 @@
                     Your details
                 </h3>
                 @views.html.account.fragments.yourDetails(subscription, maybeContact = Some(contact))()
+            </section>
+
+            <section class="mma-section">
+                <h3 class="mma-section__header">
+                    Bill to country
+                </h3>
+                @billToCountry
             </section>
 
             <section class="mma-section">

--- a/app/views/account/success.scala.html
+++ b/app/views/account/success.scala.html
@@ -1,5 +1,4 @@
 @import com.gu.i18n.Currency
-@import com.gu.i18n.GBP
 @import com.gu.memsub.{BillingSchedule, Price}
 @import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan => Plan}
 @import com.gu.subscriptions.suspendresume.SuspensionService.HolidayRefund

--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -1,6 +1,7 @@
 package views.support
 
-import com.gu.i18n.{Currency, GBP}
+import com.gu.i18n.Currency
+import com.gu.i18n.Currency.GBP
 import com.gu.memsub.promo.PercentDiscount.getDiscountScaledToPeriod
 import com.gu.memsub.promo.{LandingPage, PercentDiscount, Promotion}
 import com.gu.memsub.{BillingPeriod => BP, _}

--- a/app/views/testing/testUsers.scala.html
+++ b/app/views/testing/testUsers.scala.html
@@ -1,9 +1,5 @@
-@import com.gu.i18n.CountryGroup
-@import com.gu.i18n.GBP
-@import com.gu.memsub.Subscriptions
 @import com.gu.i18n.CountryGroup.UK
 @import com.gu.memsub.subsv2._
-@import views.support.Pricing._
 
 @(userString: String, products: List[List[CatalogPlan.Paid]])(implicit request: RequestHeader)
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.307-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.307",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.304",
+    "com.gu" %% "membership-common" % "0.307-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
Pulls in https://github.com/guardian/membership-common/pull/359

Then we can display the bill to country in the weekly renewal.  This lets us decide whether direct debit is allowed.

@AWare @pvighi @paulbrown1982 @jacobwinch