### PR TITLE
Fire the 'Conversion' event on the thank you page.

### DIFF
--- a/assets/javascripts/modules/checkout/eventTracking.js
+++ b/assets/javascripts/modules/checkout/eventTracking.js
@@ -35,7 +35,7 @@ define(['modules/analytics/ga', 'modules/checkout/ratePlanChoice'], function (ga
 
             // Trigger the Converted metric if the product was already purchased upon page initialisation.
             if (guardian.pageInfo.productData.productPurchased) {
-                trackEvent('Converted');
+                trackEvent('Converted')();
             }
         }
     };


### PR DESCRIPTION
Actually fire the 'Conversion' event on the thank you page. Realised trackEvent was a function which returned a function.

cc @ajosephides @AWare @jacobwinch 