### PR TITLE
Attempt to flush event queue when GA loads

### DIFF
--- a/assets/javascripts/modules/analytics/ga.js
+++ b/assets/javascripts/modules/analytics/ga.js
@@ -83,6 +83,8 @@ define(['modules/analytics/analyticsEnabled',
             'cookieDomain': 'auto'
         });
         ga('jellyfishGA.send', 'pageview');
+
+        flushEventQueue();
     }
 
     function flushEventQueue() {


### PR DESCRIPTION
_EVENT_QUEUE may have something in it before window.ga gets defined, therefore we need to fire flushEventQueue once we know ga has loaded.

cc @jacobwinch @AWare @ajosephides 