### PR TITLE
Fix sundayplus on sundays

### DIFF
--- a/assets/javascripts/modules/checkout/voucherFields.jsx
+++ b/assets/javascripts/modules/checkout/voucherFields.jsx
@@ -11,8 +11,8 @@ require('react-datepicker/dist/react-datepicker.css');
 
 const MAX_WEEKS_AVAILABLE = 4;
 
-// The cut off for getting vouchers in two weeks is Wednesday at 6 AM GMT
-const CUTOFF_WEEKDAY = 3;
+// The cut off for getting vouchers in two weeks is Wednesday (day #2 in ISO format) at 6 AM GMT
+const CUTOFF_WEEKDAY = 2;
 const CUTOFF_HOUR = 6;
 
 const NORMAL_DELIVERY_DELAY = 2;
@@ -21,7 +21,7 @@ const EXTRA_DELIVERY_DELAY  = 3;
 
 function getFirstSelectableDate(filterFn) {
     var now = moment.utc();
-    var currentWeekday = now.weekday();
+    var currentWeekday = now.isoWeekday();
     var currentHour = now.hour();
     var mostRecentMonday = moment().startOf('isoWeek');
     var weeksToAdd = currentWeekday >= CUTOFF_WEEKDAY && currentHour >= CUTOFF_HOUR ? EXTRA_DELIVERY_DELAY : NORMAL_DELIVERY_DELAY;

--- a/assets/javascripts/modules/checkout/voucherFields.jsx
+++ b/assets/javascripts/modules/checkout/voucherFields.jsx
@@ -11,8 +11,8 @@ require('react-datepicker/dist/react-datepicker.css');
 
 const MAX_WEEKS_AVAILABLE = 4;
 
-// The cut off for getting vouchers in two weeks is Wednesday (day #2 in ISO format) at 6 AM GMT
-const CUTOFF_WEEKDAY = 2;
+// The cut off for getting vouchers in two weeks is Wednesday (day #3 in ISO format) at 6 AM GMT
+const CUTOFF_WEEKDAY = 3;
 const CUTOFF_HOUR = 6;
 
 const NORMAL_DELIVERY_DELAY = 2;


### PR DESCRIPTION
Fixed bug where we were reading Sunday as being the start of the week in one half of the algorithm and Monday in the other. This meant that anyone buying a paper on a Sunday had an earlier start date presented to them as 0 (Sunday in non-ISO) was before 1 (Monday in ISO).

In these examples, I changed my clock so that 'today' was Sunday 4 December.

Before:

![picture 315](https://cloud.githubusercontent.com/assets/1515970/20795540/999839e4-b7c9-11e6-9b6c-f0357d9a8a93.png)

After:

![picture 316](https://cloud.githubusercontent.com/assets/1515970/20795592/dd41996a-b7c9-11e6-9948-f4cf66244af2.png)

The calendar on-screen starts with Monday so I've adjusted the algorithm to match, and use the ISO format throughout.

cc @jayceb1 @jacobwinch 