### PR TITLE
don't need to input username into identity in the tests now

### DIFF
--- a/test/acceptance/pages/Register.scala
+++ b/test/acceptance/pages/Register.scala
@@ -15,7 +15,6 @@ class Register(val testUser: TestUser) extends LoadablePage with Browser {
     val firstName = id("register_field_firstname")
     val lastName = id("register_field_lastname")
     val email = id("register_field_email")
-    val username = id("register_field_username")
     val password = id("register_field_password")
 
     def fillIn() = {
@@ -23,7 +22,6 @@ class Register(val testUser: TestUser) extends LoadablePage with Browser {
       setValue(firstName, testUser.username)
       setValue(lastName, testUser.username)
       setValue(email, s"${testUser.username}@gu.com")
-      setValue(username, testUser.username)
       setValue(password, testUser.username)
     }
 
@@ -31,7 +29,6 @@ class Register(val testUser: TestUser) extends LoadablePage with Browser {
       clearValue(firstName)
       clearValue(lastName)
       clearValue(email)
-      clearValue(username)
       clearValue(password)
     }
   }


### PR DESCRIPTION
same fix as https://github.com/guardian/identity-frontend/pull/187 

Basically identity doesn't have a username field that needs inputting any more, so we shouldn't try to use it in the tests.

@guardian/membership-and-subscriptions 