### PR TITLE
Add credit card country, card type and expiry date to Zuora

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -162,8 +162,7 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
     val requestData = SubscriptionRequestData(
       ipAddress = ProxiedIP.getIP(request),
       ipCountry = request.getFastlyCountry,
-      supplierCode = sessionSupplierCode.map(SupplierCode),
-      cardCountry = None
+      supplierCode = sessionSupplierCode.map(SupplierCode)
     )
 
     val checkoutResult = checkoutService.processSubscription(subscribeRequest, idUserOpt, requestData)

--- a/app/model/SubscriptionRequestData.scala
+++ b/app/model/SubscriptionRequestData.scala
@@ -5,4 +5,4 @@ import java.net.InetAddress
 import com.gu.i18n.Country
 import com.gu.memsub.SupplierCode
 
-case class SubscriptionRequestData(ipAddress: Option[InetAddress], ipCountry: Option[Country], supplierCode: Option[SupplierCode], cardCountry: Option[Country])
+case class SubscriptionRequestData(ipAddress: Option[InetAddress], ipCountry: Option[Country], supplierCode: Option[SupplierCode])

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -203,8 +203,7 @@ class CheckoutService(identityService: IdentityService,
       paymentDelay = paymentDelay,
       ipAddress = requestData.ipAddress.map(_.getHostAddress),
       supplierCode = requestData.supplierCode,
-      ipCountry = requestData.ipCountry,
-      cardCountry = requestData.cardCountry
+      ipCountry = requestData.ipCountry
     )
 
   private def createSubscription(

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.313-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.313",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.312",
+    "com.gu" %% "membership-common" % "0.313-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
- Added the credit card country, card type and expiry date to the CreditCardReferenceTransaction so that it can be passed to Zuora along with the Stripe tokens. This builds upon https://github.com/guardian/membership-common/pull/366
- Also removed cardCountry from SubscriptionRequestData as it's not going to be passed through from the front end. Hence I've closed: https://github.com/guardian/subscriptions-frontend/pull/714

cc @AWare @ajosephides @johnduffell @pvighi @jacobwinch @jayceb1 