### PR TITLE
standalone registration needs display name

### DIFF
--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -47,6 +47,7 @@ class CheckoutSpec extends FeatureSpec with Browser
 
     // And they submit the form to create Identity account
     register.createAccount()
+    assert(register.hasCreated())
 
     testFun(testUser)
   }

--- a/test/acceptance/pages/Register.scala
+++ b/test/acceptance/pages/Register.scala
@@ -3,9 +3,13 @@ package acceptance.pages
 import acceptance.util.{TestUser, LoadablePage, Browser, Config}
 
 class Register(val testUser: TestUser) extends LoadablePage with Browser {
-  val url = s"${Config.identityFrontendUrl}/register?skipConfirmation=true"
+  val url = s"${Config.identityFrontendUrl}/register?skipConfirmation=true&returnUrl=${Config.baseUrl}/uk"
 
   def hasLoaded(): Boolean = pageHasElement(createAccountButton)
+
+  def hasCreated(): Boolean = pageHasElement(subscriptionsUKDigital)
+  // just anything we expect on config.baseurl page
+  private lazy val subscriptionsUKDigital = xpath("//*[@data-test-id='subscriptions-uk-digital']")
 
   def fillInPersonalDetails(): Unit = RegisterFields.fillIn()
 
@@ -16,6 +20,7 @@ class Register(val testUser: TestUser) extends LoadablePage with Browser {
     val lastName = id("register_field_lastname")
     val email = id("register_field_email")
     val password = id("register_field_password")
+    val displayName = id("register_field_displayName")
 
     def fillIn() = {
       clear()
@@ -23,6 +28,10 @@ class Register(val testUser: TestUser) extends LoadablePage with Browser {
       setValue(lastName, testUser.username)
       setValue(email, s"${testUser.username}@gu.com")
       setValue(password, testUser.username)
+      if (pageHasElement(displayName)) {
+        // must be the normal rather than membership signup
+        setValue(displayName, testUser.username)
+      }
     }
 
     def clear() = {
@@ -30,6 +39,9 @@ class Register(val testUser: TestUser) extends LoadablePage with Browser {
       clearValue(lastName)
       clearValue(email)
       clearValue(password)
+      if (pageHasElement(displayName)) {
+        clearValue(displayName)
+      }
     }
   }
 


### PR DESCRIPTION
This should fix the failing prout tests.

Added the code to enter the display name to the tests.  Turned out if there's a validation failure in identity, nothing checks that it actually registered, it just assumes it worked.  So I've added a redirect to subs frontend and a check it actually ended up there, so we know what went wrong next time it happens.

@jacobwinch @AWare 