### PR TITLE
Adding Guardian Weekly Zone C rate plans

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -167,6 +167,7 @@ object ManageWeekly extends LazyLogging {
                   val weeklyPlans = weeklySubscription.plan.product match {
                     case Product.WeeklyZoneA => catalog.weeklyZoneA.toList
                     case Product.WeeklyZoneB => catalog.weeklyZoneB.toList
+                    case Product.WeeklyZoneC => catalog.weeklyZoneC.toList
                   }
               sequence(weeklyPlans.map { plan =>
                 account.currency.toRight(s"could not deserialise currency for account ${account.id}").right.flatMap { existingCurrency =>

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -102,6 +102,7 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
           case Product.Voucher => getSettings(Some(Country.UK), GBP)
           case Product.WeeklyZoneA => getSettings(determinedCountryGroup.defaultCountry, GBP)
           case Product.WeeklyZoneB => getSettings(None, USD)
+          case Product.WeeklyZoneC => getSettings(None, USD)
         }
 
         val digitalEdition = model.DigitalEdition.getForCountry(countryAndCurrencySettings.defaultCountry)

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -56,12 +56,14 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
 
     val matchingPlanList: Option[PlanList[CatalogPlan.ContentSubscription]] = {
 
+      val testOnlyPlans = if (tpBackend == TouchpointBackend.Test) List(catalog.weeklyZoneB.toList) else List.empty
+
       val contentSubscriptionPlans = List(
         catalog.delivery.list,
         catalog.voucher.list,
         catalog.weeklyZoneA.toList,
-        catalog.weeklyZoneB.toList,
-        catalog.digipack.toList)
+        catalog.weeklyZoneC.toList,
+        catalog.digipack.toList) ++ testOnlyPlans
 
       def matchPlan(planCandidates: List[CatalogPlan.ContentSubscription]) = planCandidates.find(_.slug == forThisPlan).map(p => PlanList(p, getBetterPlans(p, planCandidates): _*))
 

--- a/app/controllers/WeeklyLandingPage.scala
+++ b/app/controllers/WeeklyLandingPage.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import actions.CommonActions._
-import model.{DigitalEdition, WeeklyRegion}
+import model.WeeklyRegion
 import play.api.mvc._
 import services.TouchpointBackend
 
@@ -9,8 +9,7 @@ object WeeklyLandingPage extends Controller {
 
   val tpBackend = TouchpointBackend.Normal
   val catalog = tpBackend.catalogService.unsafeCatalog
-  val edition = DigitalEdition.UK
 
   def index = CachedAction { implicit request =>
-    Ok(views.html.weekly.weekly_landing(WeeklyRegion.all))
+    Ok(views.html.weekly.weekly_landing(WeeklyRegion.all(catalog)))
 }}

--- a/app/model/ContentSubscriptionPlanOps.scala
+++ b/app/model/ContentSubscriptionPlanOps.scala
@@ -20,6 +20,7 @@ object ContentSubscriptionPlanOps {
     val rowUk = CountryGroup("Row Uk", "uk", None, CountryGroup.UK.countries.filterNot(weeklyUkCountries.countries.contains(_)), GBP, PostCode)
     rowUk :: CountryGroup.allGroups.filterNot(group => (CountryGroup.UK :: weeklyZoneAGroups) contains group)
   }
+  val weeklyZoneCGroups = weeklyZoneBGroups
   val ukAndIsleOfMan = CountryGroup.UK.copy(countries = List(Country.UK, Country("IM", "Isle of Man")))
 
   implicit class EnrichedContentSubscriptionPlan[+A <: CatalogPlan.ContentSubscription](in: A) {
@@ -43,6 +44,8 @@ object ContentSubscriptionPlanOps {
         case Product.WeeklyZoneA => LocalizationSettings(Some(CountryWithCurrency.whitelisted(supportedCurrencies, GBP, weeklyZoneAGroups)), allCountriesWithCurrencyOrGBP)
 
         case Product.WeeklyZoneB => LocalizationSettings(Some(CountryWithCurrency.whitelisted(supportedCurrencies, USD, weeklyZoneBGroups)), allCountriesWithCurrencyOrGBP)
+
+        case Product.WeeklyZoneC => LocalizationSettings(Some(CountryWithCurrency.whitelisted(supportedCurrencies, USD, weeklyZoneCGroups)), allCountriesWithCurrencyOrGBP)
       }
     }
   }

--- a/app/model/WeeklyRegions.scala
+++ b/app/model/WeeklyRegions.scala
@@ -1,5 +1,6 @@
 package model
 
+import com.gu.memsub.subsv2.Catalog
 import com.netaporter.uri.Uri
 
 trait WeeklyRegion {
@@ -11,24 +12,23 @@ trait WeeklyRegion {
 }
 
 object WeeklyRegion {
-  val all = List(UnitedKingdom, UnitedStates, Row)
+  def all(catalog: Catalog): List[WeeklyRegion] = List(UnitedKingdom(catalog), UnitedStates(catalog), Row(catalog))
 }
 
-object UnitedKingdom extends WeeklyRegion {
+case class UnitedKingdom(catalog: Catalog) extends WeeklyRegion {
   override val title = "United Kingdom"
   override val description = "Includes Isle of Man and Channel Islands"
-  override val url = Uri.parse("checkout/weeklyzonea-guardianweeklyquarterly?countryGroup=uk")
+  override val url = Uri.parse(catalog.weeklyZoneA.quarter.slug).addParam("countryGroup", "uk")
 }
 
-object UnitedStates extends WeeklyRegion {
+case class UnitedStates(catalog: Catalog) extends WeeklyRegion {
   override val title = "United States"
   override val description = "Includes Alaska and Hawaii"
-  override val url = Uri.parse("checkout/weeklyzonea-guardianweeklyquarterly?countryGroup=us")
+  override val url = Uri.parse(catalog.weeklyZoneA.quarter.slug).addParam("countryGroup", "us")
 }
 
-object Row extends WeeklyRegion {
+case class Row(catalog: Catalog) extends WeeklyRegion {
   override val title = "Rest of the world"
-  override val description = "Posted to you by Air Mail"
-  override val url = Uri.parse("checkout/weeklyzoneb-guardianweeklyquarterly")
+  override val description = "Posted to you by air mail"
+  override val url = Uri.parse(catalog.weeklyZoneB.quarter.slug)
 }
-

--- a/app/model/WeeklyRegions.scala
+++ b/app/model/WeeklyRegions.scala
@@ -18,17 +18,17 @@ object WeeklyRegion {
 case class UnitedKingdom(catalog: Catalog) extends WeeklyRegion {
   override val title = "United Kingdom"
   override val description = "Includes Isle of Man and Channel Islands"
-  override val url = Uri.parse(catalog.weeklyZoneA.quarter.slug).addParam("countryGroup", "uk")
+  override val url = Uri.parse(s"checkout/${catalog.weeklyZoneA.quarter.slug}").addParam("countryGroup", "uk")
 }
 
 case class UnitedStates(catalog: Catalog) extends WeeklyRegion {
   override val title = "United States"
   override val description = "Includes Alaska and Hawaii"
-  override val url = Uri.parse(catalog.weeklyZoneA.quarter.slug).addParam("countryGroup", "us")
+  override val url = Uri.parse(s"checkout/${catalog.weeklyZoneA.quarter.slug}").addParam("countryGroup", "us")
 }
 
 case class Row(catalog: Catalog) extends WeeklyRegion {
   override val title = "Rest of the world"
   override val description = "Posted to you by air mail"
-  override val url = Uri.parse(catalog.weeklyZoneB.quarter.slug)
+  override val url = Uri.parse(s"checkout/${catalog.weeklyZoneC.quarter.slug}")
 }

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -52,9 +52,7 @@ class CheckoutService(identityService: IdentityService,
   type SubNel[A] = EitherT[Future, NonEmptyList[SubsError], A]
   type FatalErrors = NonEmptyList[SubsError]
 
-  private def isGuardianWeekly(paperData: PaperData): Boolean = {
-    paperData.plan.product == Product.WeeklyZoneA || paperData.plan.product == Product.WeeklyZoneB
-  }
+  private def isGuardianWeekly(paperData: PaperData): Boolean = paperData.plan.product.isInstanceOf[Product.Weekly]
 
   def processSubscription(subscriptionData: SubscribeRequest,
                           authenticatedUserOpt: Option[AuthenticatedIdUser],

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -52,7 +52,10 @@ class CheckoutService(identityService: IdentityService,
   type SubNel[A] = EitherT[Future, NonEmptyList[SubsError], A]
   type FatalErrors = NonEmptyList[SubsError]
 
-  private def isGuardianWeekly(paperData: PaperData): Boolean = paperData.plan.product.isInstanceOf[Product.Weekly]
+  private def isGuardianWeekly(paperData: PaperData): Boolean = paperData.plan.product match {
+    case _:Product.Weekly => true
+    case _ => false
+  }
 
   def processSubscription(subscriptionData: SubscribeRequest,
                           authenticatedUserOpt: Option[AuthenticatedIdUser],

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -50,7 +50,10 @@ object PlanOps {
 
     def isDigitalPack: Boolean = in.product == com.gu.memsub.Product.Digipack
 
-    def isGuardianWeekly: Boolean = in.product.isInstanceOf[Product.Weekly]
+    def isGuardianWeekly: Boolean = in.product match {
+      case _:Product.Weekly => true
+      case _ => false
+    }
 
     def hasPhysicalBenefits: Boolean = in.charges.benefits.list.exists(_.isPhysical)
 

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -50,7 +50,7 @@ object PlanOps {
 
     def isDigitalPack: Boolean = in.product == com.gu.memsub.Product.Digipack
 
-    def isGuardianWeekly: Boolean = in.product == Product.WeeklyZoneA || in.product == Product.WeeklyZoneB // TODO is this right to include both?
+    def isGuardianWeekly: Boolean = in.product.isInstanceOf[Product.Weekly]
 
     def hasPhysicalBenefits: Boolean = in.charges.benefits.list.exists(_.isPhysical)
 

--- a/app/views/testing/testUsers.scala.html
+++ b/app/views/testing/testUsers.scala.html
@@ -22,6 +22,9 @@
         <div class="actions">
             <h2>Subscribe as a <em>guest</em> user to:</h2>
             @for(group <- products) {
+                @group.headOption.map { plan =>
+                    <h4>@plan.product.name.capitalize:</h4>
+                }
                 <dl>
                 @for(plan <- group.sortBy(_.charges.gbpPrice.amount)) {
                     <a href="@routes.Checkout.renderCheckout(UK.id, None, None, plan.slug)" style="margin-bottom: 10px" class="button button--primary button--large">@plan.name (@{(plan.charges.gbpPrice * 12 / 52).pretty}/w, @plan.charges.gbpPrice.pretty/m)</a>
@@ -35,6 +38,9 @@
         <div class="actions">
             <h2>Register as an Identity user, redirecting to checkout for:</h2>
             @for(group <- products) {
+                @group.headOption.map { plan =>
+                    <h4>@plan.product.name.capitalize:</h4>
+                }
                 <dl>
                     @for(plan <- group.sortBy(_.charges.gbpPrice.amount)) {
                         <a href="@idWebAppRegisterUrl(routes.Checkout.renderCheckout(UK.id, None, None, plan.slug))" style="margin-bottom: 10px" class="button button--primary button--large">@plan.name (@{(plan.charges.gbpPrice * 12 / 52).pretty}/w, @plan.charges.gbpPrice.pretty/m)</a>

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.320",
+    "com.gu" %% "membership-common" % "0.321",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/conf/touchpoint.DEV.conf
+++ b/conf/touchpoint.DEV.conf
@@ -20,7 +20,6 @@ touchpoint.backend.environments {
                 username = ""
                 password = ""
             }
-            digital = "2c92c0f84b786da2014b91d3629b4298"
         }
         stripe {
             api.key {

--- a/conf/touchpoint.PROD.conf
+++ b/conf/touchpoint.PROD.conf
@@ -20,7 +20,6 @@ touchpoint.backend.environments {
                 username = ""
                 password = ""
             }
-            digital = "2c92a0fb4edd70c8014edeaa4ddb21e7"
         }
         stripe {
             api.key {

--- a/conf/touchpoint.UAT.conf
+++ b/conf/touchpoint.UAT.conf
@@ -20,7 +20,6 @@ touchpoint.backend.environments {
                 username = ""
                 password = ""
             }
-            digital = "2c92c0f84f2ac59d014f2c8f0f853d09"
         }
         stripe {
             api.key {


### PR DESCRIPTION
- Adding Guardian Weekly Zone C rate plans, and updating those as what we are going to sell.
- Guardian Weekly Zone B will be what the migrated customers are set as, and the renewal options will be also be within that set.

See: https://github.com/guardian/membership-common/pull/374

cc @johnduffell @pvighi @AWare @jacobwinch 