### PR TITLE
show email field if user hasn't got an email set

### DIFF
--- a/assets/javascripts/modules/react/weeklyRenew.jsx
+++ b/assets/javascripts/modules/react/weeklyRenew.jsx
@@ -49,7 +49,7 @@ class WeeklyRenew extends React.Component {
             promo: null
 
         };
-        this.showEmail = !("email" in this.props);
+        this.showEmail = !this.state.email.isValid;
         this.handlePromo = this.handlePromo.bind(this);
         this.handleError = this.handleError.bind(this);
         this.handleEmail = this.handleEmail.bind(this);


### PR DESCRIPTION
Logic to show email wasn't correctly determining absence of email address. @paulbrown1982 @johnduffell 