### PR TITLE
Fix bug with bill to country display

### DIFF
--- a/app/views/account/renew.scala.html
+++ b/app/views/account/renew.scala.html
@@ -45,7 +45,7 @@
                 <h3 class="mma-section__header">
                     Bill to country
                 </h3>
-                @billToCountry
+                @billToCountry.name
             </section>
 
             <section class="mma-section">


### PR DESCRIPTION
Noticed a small copy bug on the /manage page.

Before:
![oldcountry](https://cloud.githubusercontent.com/assets/19384074/21233102/e13d85fc-c2e5-11e6-8633-a94bcf0aecd6.png)

After:
![newcountry](https://cloud.githubusercontent.com/assets/19384074/21233108/e61032f0-c2e5-11e6-8715-30a3464e0620.png)

