### PR TITLE
Move renew/view details logic into controller

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -164,7 +164,6 @@ object ManageWeekly extends LazyLogging {
         val futureZuoraBillToContact = tpBackend.zuoraService.getContact(account.billToId)
         futureSfContact.flatMap { contact =>
           futureZuoraBillToContact.map { zuoraContact =>
-            logger.info(zuoraContact.toString())
             zuoraContact.country.map { billToCountry =>
               val catalog = tpBackend.catalogService.unsafeCatalog
                   val weeklyPlans = weeklySubscription.plan.product match {

--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -164,6 +164,7 @@ object ManageWeekly extends LazyLogging {
         val futureZuoraBillToContact = tpBackend.zuoraService.getContact(account.billToId)
         futureSfContact.flatMap { contact =>
           futureZuoraBillToContact.map { zuoraContact =>
+            logger.info(zuoraContact.toString())
             zuoraContact.country.map { billToCountry =>
               val catalog = tpBackend.catalogService.unsafeCatalog
                   val weeklyPlans = weeklySubscription.plan.product match {
@@ -181,7 +182,10 @@ object ManageWeekly extends LazyLogging {
                 Ok(views.html.account.details(None))
               },
                 {
-                weeklyPlans => Ok(views.html.account.renew(weeklySubscription, billingSchedule, contact, billToCountry, plans = weeklyPlans))
+                weeklyPlans => {
+                  if (weeklySubscription.renewable) Ok(views.html.account.weeklyRenew(weeklySubscription, billingSchedule, contact, billToCountry, plans = weeklyPlans))
+                  else Ok(views.html.account.weeklyDetails(weeklySubscription, billingSchedule, contact, billToCountry, plans = weeklyPlans))
+                }
               })
             }.getOrElse {
               logger.info(s"no valid bill to country for ${weeklySubscription.id}")

--- a/app/views/account/renew.scala.html
+++ b/app/views/account/renew.scala.html
@@ -51,7 +51,7 @@
                 <h3 class="mma-section__header">
                     Bill to country
                 </h3>
-                @billToCountry
+                @billToCountry.name
             </section>
 
             <section class="mma-section">

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -15,19 +15,6 @@
     @helper.javascriptRouter("jsRoutes")(
         routes.javascript.Promotion.validate
     )
-    <script>
-
-        guardian.plans = [
-            @plans.map { plan =>
-            {
-                id: '@plan.id.get',
-                price: '@plan.price'
-            },
-            }
-        ]
-
-    </script>
-
     <main class="page-container gs-container">
         <section class="suspend-container">
 

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -1,0 +1,60 @@
+@import com.gu.memsub.BillingSchedule
+@import com.gu.memsub.subsv2.SubscriptionPlan
+@import com.gu.memsub.subsv2.Subscription
+@import model.DigitalEdition.UK
+@import com.gu.salesforce.Contact
+@import com.gu.i18n.Country
+@import controllers.ManageWeekly.WeeklyPlanInfo
+@import model.SubscriptionOps._
+@import org.joda.time.LocalDate
+@(
+    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: BillingSchedule, contact: Contact, billToCountry: Country, plans: List[WeeklyPlanInfo]
+)(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
+
+@main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
+    @helper.javascriptRouter("jsRoutes")(
+        routes.javascript.Promotion.validate
+    )
+    <script>
+
+        guardian.plans = [
+            @plans.map { plan =>
+            {
+                id: '@plan.id.get',
+                price: '@plan.price'
+            },
+            }
+        ]
+
+    </script>
+
+    <main class="page-container gs-container">
+        <section class="suspend-container">
+
+            <div class="suspend-header">
+                <h1 class="suspend-header__title">Your Guardian Weekly subscription</h1>
+            </div>
+
+            <section class="mma-section">
+                <h3 class="mma-section__header">
+                    Your details
+                </h3>
+                @views.html.account.fragments.yourDetails(
+                    subscriptionName = subscription.name.get,
+                    plan = subscription.latestPlan,
+                    maybeStartDate = Some(subscription.firstPaymentDate).filter(d => d.isAfter(LocalDate.now.minusMonths(1))),
+                    maybeContact = Some(contact))()
+            </section>
+
+            <section class="mma-section">
+                <h3 class="mma-section__header">
+                    Your billing schedule
+                </h3>
+                @views.html.account.fragments.billingSchedule(billingSchedule, subscription.plan.charges.price.currencies.head)
+            </section>
+            <section class="mma-section">
+                <a class="button button--primary button--large" href="@routes.AccountManagement.logout">Sign Out</a>
+            </section>
+        </section>
+    </main>
+}

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -56,7 +56,7 @@
                 } else {
                     Your subscription expired on @prettyDate(subscription.termEndDate).
                 }
-                Please complete the form below to renew your subscription. You can find your Promo Code on any correspondence from us.
+                Please complete the form below to renew your subscription.
                 </p>
 
                 <div class="js-weekly-renew" data-email="@contact.email" data-country="@billToCountry.alpha2" />

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -33,7 +33,7 @@
         <section class="suspend-container">
 
             <div class="suspend-header">
-                <h1 class="suspend-header__title">Your Guardian Weekly subscription --- TEST PAGE</h1>
+                <h1 class="suspend-header__title">Your Guardian Weekly subscription</h1>
             </div>
 
             <section class="mma-section">
@@ -48,47 +48,20 @@
             </section>
 
             <section class="mma-section">
-                <h3 class="mma-section__header">
-                    Bill to country
-                </h3>
-                @billToCountry.name
-            </section>
+                <h3 class="mma-section__header">Renew your subscription</h3>
 
+                <p>
+                @if(subscription.termEndDate.isAfter(LocalDate.now)) {
+                    Your current subscription is due to expire on @prettyDate(subscription.termEndDate).
+                } else {
+                    Your subscription expired on @prettyDate(subscription.termEndDate).
+                }
+                Please complete the form below to renew your subscription. You can find your Promo Code on any correspondence from us.
+                </p>
+
+                <div class="js-weekly-renew" data-email="@contact.email" data-country="@billToCountry.alpha2" />
+            </section>
             <section class="mma-section">
-                <h3 class="mma-section__header">
-                    Email address
-                </h3>
-                @contact.email
-                @helper.CSRF.formField
-            </section>
-
-                @if(subscription.renewable){
-
-                    <section class="mma-section">
-                        <h3 class="mma-section__header">
-                            Subscription end date
-                        </h3>
-                        @prettyDate(subscription.termEndDate)
-
-                    </section>
-
-                        <section class="mma-section">
-                        <h3 class="mma-section__header">Renew</h3>
-
-                        <p>
-                        Here is some copy about renewing your subscription, which is a very fulfilling thing to do and should probably fill one to two lines of text telling the user what renewing their subscription entails.
-                        </p>
-                            <div class="js-weekly-renew" data-email="@contact.email" data-country="@billToCountry.alpha2" />
-                        </section>
-                    }
-
-                <section class="mma-section">
-                    <h3 class="mma-section__header">
-                        Your billing schedule
-                    </h3>
-                    @views.html.account.fragments.billingSchedule(billingSchedule, subscription.plan.charges.price.currencies.head)
-                </section>
-                <section class="mma-section">
                     <a class="button button--primary button--large" href="@routes.AccountManagement.logout">Sign Out</a>
                 </section>
             </section>


### PR DESCRIPTION
This PR moves the logic which decides whether or not we show the Renew section out of the view and into the controller.

It also tidies up the views a bit (although I'm sure there are still improvements which can be made to this!):

Details page (i.e. auto-renewing subs):

<img width="1304" alt="weeklydetails" src="https://cloud.githubusercontent.com/assets/19384074/21267219/56fed96a-c3a1-11e6-9fc0-8e4c1051d226.png">

Renew page:

<img width="1299" alt="weeklyrenew" src="https://cloud.githubusercontent.com/assets/19384074/21267226/5f84fae2-c3a1-11e6-92ec-d3070d2528da.png">

@paulbrown1982 @pvighi @johnduffell @AWare 