### PR TITLE
Added a promotion to the homepage

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -31,13 +31,14 @@
                     <ul class="block__list">
                         <li class="block__list-item"><strong>Save up to 36%</strong>
                             on the Guardian and Observer newspapers and digital daily edition</li>
-                        <li class="block__list-item">Pick the package you want: Everyday+, Sixday+, Weekend+ and Sunday+</li>
+                        <li class="block__list-item"><strong>M&S e-gift card worth up to £50</strong></li>
+                        <li class="block__list-item">Pick the package you want: Everyday+, Sixday+ and Weekend+</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
                         <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/collection/paper-digital?INTCMP=GU_SUBSCRIPTIONS_PACKAGES" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="/p/GAA99G?INTCMP=GU_SUBSCRIPTIONS_PACKAGES" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper">
@@ -46,13 +47,14 @@
                     <ul class="block__list">
                         <li class="block__list-item"><strong>Save up to 31%</strong>
                             on the Guardian and Observer newspapers</li>
+                        <li class="block__list-item"><strong>M&S e-gift card worth up to £50</strong></li>
                         <li class="block__list-item">Pick the package you want: Everyday, Sixday and Weekend</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
-                        <li class="block__list-item">Receive vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
+                        <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/collection/paper?INTCMP=GU_SUBSCRIPTIONS_PACKAGES" data-test-id="subscriptions-uk-paper">Subscribe now</a>
+                    <a class="button button--large button--primary" href="/p/GAA99F?INTCMP=GU_SUBSCRIPTIONS_PACKAGES" data-test-id="subscriptions-uk-paper">Subscribe now</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Added an 'M&S e-gift card worth up to £50' benefit to the Paper and Paper + digital offers on the home page, and changed the CTA link to be the relevant promotion landing page.

This needs to be taken down on 4th January - I've added something to my calendar, and will prepare the pull request once this is merged.

cc @johnduffell @pvighi @AWare 