### PR TITLE
Change to roll back the M&S e-gift card promotion when it expires

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -32,13 +32,13 @@
                         <li class="block__list-item"><strong>Save up to 36%</strong>
                             on the Guardian and Observer newspapers and digital daily edition</li>
                         <li class="block__list-item"><strong>M&S e-gift card worth up to £50</strong></li>
-                        <li class="block__list-item">Pick the package you want: Everyday+, Sixday+ and Weekend+</li>
+                        <li class="block__list-item">Pick the package you want: Everyday+, Sixday+, Weekend+ and Sunday+</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
                         <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/p/GAA99G?INTCMP=GU_SUBSCRIPTIONS_PACKAGES" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="/collection/paper-digital?INTCMP=GU_SUBSCRIPTIONS_PACKAGES" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper">
@@ -47,14 +47,13 @@
                     <ul class="block__list">
                         <li class="block__list-item"><strong>Save up to 31%</strong>
                             on the Guardian and Observer newspapers</li>
-                        <li class="block__list-item"><strong>M&S e-gift card worth up to £50</strong></li>
                         <li class="block__list-item">Pick the package you want: Everyday, Sixday and Weekend</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
                         <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/p/GAA99F?INTCMP=GU_SUBSCRIPTIONS_PACKAGES" data-test-id="subscriptions-uk-paper">Subscribe now</a>
+                    <a class="button button--large button--primary" href="/collection/paper?INTCMP=GU_SUBSCRIPTIONS_PACKAGES" data-test-id="subscriptions-uk-paper">Subscribe now</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Change to roll back https://github.com/guardian/subscriptions-frontend/pull/734 on 4 January 2017 when the promotion expires.

cc @johnduffell @AWare @pvighi @jacobwinch 