### PR TITLE
Add default terms and conditions to the /p/<promo_code>/terms page

### DIFF
--- a/app/views/fragments/promotion/copyrightNotice.scala.html
+++ b/app/views/fragments/promotion/copyrightNotice.scala.html
@@ -1,2 +1,2 @@
 @()
-<p>Guardian News and Media Limited – a member of Guardian Media Group plc. Registered office: Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396</p>
+<p>&copy; Guardian News and Media Limited – a member of Guardian Media Group plc. Registered office: Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396</p>

--- a/app/views/fragments/promotion/digitalpackLegalTerms.scala.html
+++ b/app/views/fragments/promotion/digitalpackLegalTerms.scala.html
@@ -1,0 +1,25 @@
+@import com.gu.memsub.promo.Promotion.AnyPromotion
+@import views.support.MarkdownRenderer
+@import com.gu.memsub.promo.PromoCode
+@import views.support.Dates.prettyLegalDate
+@(promoCode: PromoCode, promotion: AnyPromotion, md: MarkdownRenderer)
+@Html(md.render(
+s"""
+1. The promotion (the “Promotion”) is open to new Digital Pack subscribers aged 18 and over ("you") subject to paragraph 2 below.
+2. Employees or agencies of Guardian News & Media Limited ("GNM", "We") and/or their group companies or their family members, or anyone else connected with the promotion may not enter the Promotion.
+3. By entering the promotion you are accepting these terms and conditions.
+4. To enter the promotion, you must: (i) either go to [subscribe.theguardian.com](https://subscribe.theguardian.com/) or call 0330 333 6767 and quote promotion code ${promoCode.get} (ii) purchase a Digital Pack subscription and maintain that subscription for at least three months.
+5. Entry to this promotion is available only to new subscribers: this means that you must not already have a subscription to the Digital Pack to be eligible to participate in this Promotion.
+6. Please note that purchasing a subscription as referred to in paragraph 4 above will also be subject to the terms and conditions for Guardian and Observer Subscriptions available at [theguardian.com/subscriber-direct/subscription-terms-and-conditions](https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions)
+7. The opening date and time of the Promotion is ${prettyLegalDate(promotion.starts)}. ${promotion.expires.map(expires => s"The closing date and time of the promotion is ${prettyLegalDate(expires)}. Purchases after that date and time will not be eligible for the promotion.").mkString}
+8. If you opt to use the SMS response service to place your order you will be charged your standard network rate.
+9. Only one entry to this Promotion per person. Entries on behalf of another person will not be accepted.
+10. We take no responsibility for entries that are lost, delayed, misdirected or incomplete or cannot be delivered or entered for any technical or other reason. Proof of delivery of the entry is not proof of receipt.
+11. The Promoter of the Promotion is Guardian News & Media Limited whose address is Kings Place, 90 York Way, London N1 9GU. Any complaints regarding the Promotion should be sent to this address.
+12. Nothing in these terms and conditions shall exclude the liability of GNM for death, personal injury, fraud or fraudulent misrepresentation as a result of its negligence.
+13. GNM accepts no responsibility for any damage, loss, liabilities, injury or disappointment incurred or suffered by you as a result of entering the Promotion. GNM further disclaims liability for any injury or damage to you or any other person’s computer relating to or resulting from participation in the Promotion.
+14. GNM reserves the right at any time and from time to time to modify or discontinue, temporarily or permanently, this Promotion with or without prior notice due to reasons outside its control (including, without limitation, in the case of anticipated, suspected or actual fraud). The decision of GNM in all matters under its control is final and binding.
+15. GNM shall not be liable for any failure to comply with its obligations where the failure is caused by something outside its reasonable control. Such circumstances shall include, but not be limited to, weather conditions, fire, flood, hurricane, strike, industrial dispute, war, hostilities, political unrest, riots, civil commotion, inevitable accidents, supervening legislation or any other circumstances amounting to force majeure.
+16. The Promotion will be governed by English law.
+"""
+))

--- a/app/views/fragments/promotion/fullTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/fullTermsAndConditions.scala.html
@@ -1,0 +1,17 @@
+@import com.gu.memsub.promo.Promotion.AnyPromotion
+@import views.support.MarkdownRenderer
+@import views.support.LandingPageOps._
+@import com.gu.memsub.subsv2.Catalog
+@import com.gu.memsub.promo.PromoCode
+
+@(promoCode: PromoCode, catalog: Catalog, promotion: AnyPromotion, md: MarkdownRenderer)
+@isDigipack = @{catalog.digipack.toList.exists(plan => promotion.appliesTo.productRatePlanIds.contains(plan.id))}
+@if(promotion.asIncentive.isDefined) {
+    <p>@Html(md.render(promotion.getIncentiveLegalTerms))</p>
+} else {
+    @if(isDigipack) {
+        <p>@fragments.promotion.digitalpackLegalTerms(promoCode, promotion, md)</p>
+    } else {
+        <p>@fragments.promotion.newspaperLegalTerms(promoCode, promotion, md)</p>
+    }
+}

--- a/app/views/fragments/promotion/incentiveLegalTerms.scala.html
+++ b/app/views/fragments/promotion/incentiveLegalTerms.scala.html
@@ -1,6 +1,0 @@
-@import com.gu.memsub.promo.Promotion.AnyPromotion
-@import views.support.MarkdownRenderer
-@import views.support.LandingPageOps._
-
-@(promotion: AnyPromotion, md: MarkdownRenderer)
-<p>@Html(md.render(promotion.getIncentiveLegalTerms))</p>

--- a/app/views/fragments/promotion/newspaperLegalTerms.scala.html
+++ b/app/views/fragments/promotion/newspaperLegalTerms.scala.html
@@ -1,0 +1,26 @@
+@import com.gu.memsub.promo.Promotion.AnyPromotion
+@import views.support.MarkdownRenderer
+@import com.gu.memsub.promo.PromoCode
+@import views.support.Dates.prettyLegalDate
+@(promoCode: PromoCode, promotion: AnyPromotion, md: MarkdownRenderer)
+@Html(md.render(
+s"""
+1. The promotion (the “Promotion”) is open to UK residents aged 18 and over ("you") subject to paragraph 2 below.
+2. Employees or agencies of Guardian News & Media Limited ("GNM", "We") and/or their group companies or their family members, or anyone else connected with the promotion may not enter the Promotion.
+3. By entering the promotion you are accepting these terms and conditions.
+4. To enter the promotion, you must: (i) either go to [subscribe.theguardian.com](https://subscribe.theguardian.com/) or call 0330 333 6767 and quote promotion code ${promoCode.get} (ii) purchase a print or print + digital editions subscription package to either the Guardian and Observer (excludes digital-only subscriptions) and maintain that subscription for at least three months.
+5. Entry to this promotion is available only to new subscribers: this means that you must not already have a subscription to the Guardian and/or Observer to be eligible to participate in this Promotion.
+6. Please note that purchasing a subscription as referred to in paragraph 4 above will also be subject to the terms and conditions for Guardian and Observer Subscriptions available at [theguardian.com/subscriber-direct/subscription-terms-and-conditions](https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions)
+7. The opening date and time of the Promotion is ${prettyLegalDate(promotion.starts)}. ${promotion.expires.map(expires => s"The closing date and time of the promotion is ${prettyLegalDate(expires)}. Purchases after that date and time will not be eligible for the promotion.").mkString}
+8. If you opt to use the SMS response service to place your order you will be charged your standard network rate.
+9. Only one entry to this Promotion per person. Entries on behalf of another person will not be accepted.
+10. We take no responsibility for entries that are lost, delayed, misdirected or incomplete or cannot be delivered or entered for any technical or other reason. Proof of delivery of the entry is not proof of receipt.
+11. The Promoter of the Promotion is Guardian News & Media Limited whose address is Kings Place, 90 York Way, London N1 9GU. Any complaints regarding the Promotion should be sent to this address.
+12. Nothing in these terms and conditions shall exclude the liability of GNM for death, personal injury, fraud or fraudulent misrepresentation as a result of its negligence.
+13. GNM accepts no responsibility for any damage, loss, liabilities, injury or disappointment incurred or suffered by you as a result of entering the Promotion. GNM further disclaims liability for any injury or damage to you or any other person’s computer relating to or resulting from participation in the Promotion.
+14. GNM reserves the right at any time and from time to time to modify or discontinue, temporarily or permanently, this Promotion with or without prior notice due to reasons outside its control (including, without limitation, in the case of anticipated, suspected or actual fraud). The decision of GNM in all matters under its control is final and binding.
+15. GNM shall not be liable for any failure to comply with its obligations where the failure is caused by something outside its reasonable control. Such circumstances shall include, but not be limited to, weather conditions, fire, flood, hurricane, strike, industrial dispute, war, hostilities, political unrest, riots, civil commotion, inevitable accidents, supervening legislation or any other circumstances amounting to force majeure.
+16. The Promotion will be governed by English law.
+
+"""
+))

--- a/app/views/fragments/promotion/promotionTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/promotionTermsAndConditions.scala.html
@@ -1,12 +1,9 @@
-@import com.gu.memsub.promo.PromoCode
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import views.support.MarkdownRenderer
 @import views.support.LandingPageOps._
-
 @(promotion: AnyPromotion, md: MarkdownRenderer)
 <h4>Promotion terms and conditions</h4>
 <p>Offer subject to availability. Guardian News and Media Limited ("GNM") reserves the right to withdraw this promotion at any time.</p>
-
 @promotion.asIncentive.map { p =>
     @if(p.promotionType.termsAndConditions.isDefined) {
         @Html(md.render(p.getIncentiveTermsAndConditions))

--- a/app/views/promotion/termsPage.scala.html
+++ b/app/views/promotion/termsPage.scala.html
@@ -2,7 +2,6 @@
 @import com.gu.memsub.promo.PromoCode
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import com.gu.memsub.subsv2.Catalog
-@import org.joda.time.Days
 @import views.support.Dates.prettyDate
 @import views.support.MarkdownRenderer
 @(promoCode: PromoCode, promotion: AnyPromotion, md: MarkdownRenderer, catalog: Catalog)
@@ -30,7 +29,7 @@
             <h4>Applies to products</h4>
             <ul class="promotion-applies-to">
                 @catalog.allSubs.flatten.filter(plan => promotion.appliesTo.productRatePlanIds.contains(plan.id)).map { plan =>
-                    <li><a class="u-link" href="@routes.Checkout.renderCheckout(UK.id, None, None, plan.slug).url">@{plan.product.toString.replace("Digipack", "")} @plan.name</a></li>
+                    <li>@{plan.product.toString.replace("Digipack", "")} @plan.name</li>
                 }
             </ul>
 
@@ -53,9 +52,8 @@
             }
         </section>
         <section class="section-slice promotion-terms">
-            @fragments.promotion.subscriptionTermsAndConditions(catalog, promotion)
             @fragments.promotion.promotionTermsAndConditions(promotion, md)
-            @fragments.promotion.incentiveLegalTerms(promotion, md)
+            @fragments.promotion.fullTermsAndConditions(promoCode, catalog, promotion, md)
             @fragments.promotion.copyrightNotice()
         </section>
     </main>

--- a/app/views/support/Dates.scala
+++ b/app/views/support/Dates.scala
@@ -1,32 +1,27 @@
 package views.support
 
 import com.github.nscala_time.time.Imports._
-import org.joda.time.{PeriodType, Instant, Interval}
+import configuration.Config.timezone
+import org.joda.time.{Instant, Interval, PeriodType}
 import org.joda.time.format.PeriodFormat
 import play.twirl.api.Html
 
 object Dates {
 
-  val humanPeriodFormat = PeriodFormat.getDefault()
+  val humanPeriodFormat = PeriodFormat.getDefault
 
   val YearMonthDayHours = PeriodType.yearMonthDayTime.withMinutesRemoved.withSecondsRemoved.withMillisRemoved
 
-  implicit
-
-  class RichPeriod(period: Period) {
+  implicit class RichPeriod(period: Period) {
     lazy val pretty = period.withMillis(0).toString(humanPeriodFormat)
   }
 
-  implicit
-
-  class RichDateTime(dt: DateTime) {
+  implicit class RichDateTime(dt: DateTime) {
     lazy val pretty = prettyDate(dt)
     lazy val prettyWithTime = prettyDateWithTime(dt)
   }
 
-  implicit
-
-  class RichLocalDate(ld: LocalDate) {
+  implicit class RichLocalDate(ld: LocalDate) {
     val dt = ld.toDateTimeAtCurrentTime()
     lazy val pretty = prettyDate(dt)
     lazy val prettyWithTime = prettyDateWithTime(dt)
@@ -35,9 +30,7 @@ object Dates {
 
   }
 
-  implicit
-
-  class RichInstant(dt: Instant) {
+  implicit class RichInstant(dt: Instant) {
     lazy val pretty = prettyDate(new DateTime(dt))
     lazy val prettyWithoutYear = prettyDateNoYear(new DateTime(dt))
     lazy val prettyWithTime = prettyDateWithTime(new DateTime(dt))
@@ -50,9 +43,7 @@ object Dates {
     def isContemporary(threshold: Duration = 24.hours) = new Interval(dt - threshold, dt + threshold).contains(DateTime.now)
   }
 
-  implicit
-
-  class RichInterval(interval: Interval) {
+  implicit class RichInterval(interval: Interval) {
     lazy val isSameDay = interval.start.withTimeAtStartOfDay() == interval.end.withTimeAtStartOfDay()
   }
 
@@ -62,9 +53,8 @@ object Dates {
 
   def prettyDateNoYear(dt: DateTime): String = dt.toString("d MMMMM")
 
-  def prettyTime(dt: DateTime): String = dt.toString(if (dt.getMinuteOfHour == 0) "h"
-
-  else "h.mm") +dt.toString("a").toLowerCase
+  def prettyTime(dt: DateTime): String =
+    dt.toString(if (dt.getMinuteOfHour == 0) "h" else "h.mm") +dt.toString("a").toLowerCase
 
   def prettyDateWithTime(dt: DateTime): String = prettyDate(dt) + ", " + prettyTime(dt)
 
@@ -78,6 +68,9 @@ object Dates {
 
   def prettyDateAndDayName(dt: DateTime): String =
     dt.toString("EE ") + prettyDate(dt)
+
+  def prettyLegalDate(dt: DateTime): String =
+    dt.withZone(timezone).toString("HH:mm z 'on' d MMMM YYYY") // e.g. 00:00 GMT on 25 December 2016
 
   def dayInMonthWithSuffix(date: DateTime = DateTime.now): Html = addSuffix(date.toString("dd").toInt)
 
@@ -101,12 +94,11 @@ object Dates {
     }
   }
 
-  case
-
-  class Range(start: String, end: String)
+  case class Range(start: String, end: String)
 
   private def multiDateRangeFormatter(interval: Interval, fmt: String): Range = {
     def dateToks(dt: DateTime) = dt.toString(fmt).split(" ").reverse
+
     val startToks = dateToks(interval.start)
     val endToks = dateToks(interval.end)
     val newStartToks = (startToks zip endToks).dropWhile { case (a, b) => a == b }.map { case (a, b) => a }
@@ -135,6 +127,6 @@ object Dates {
     val formatStart = "d" + (if (start.monthOfYear != finish.monthOfYear) " MMMM" + (if (start.year != finish.year) " YYYY" else "") else "")
     val formatFinish = "d MMMM" + (if (finish.year != LocalDate.now.year) " YYYY" else "")
     val formattedFinish = finish.toString(formatFinish)
-    if(finish.isAfter(start)) s"${start.toString(formatStart)} - $formattedFinish" else formattedFinish
+    if (finish.isAfter(start)) s"${start.toString(formatStart)} - $formattedFinish" else formattedFinish
   }
 }


### PR DESCRIPTION
Added some default full [legal] terms and conditions to the /p/<promo_code>/terms page for non-incentive type promotions. Incentive promotions already show on this page and they include specialised copies of the full T&Cs in the promotion tool.

I used a markdown triple-quote-string in the templates so that its easy to update the T&Cs at any point without someone needing to know HTML.
There will need to be a third set of terms in the new year for Guardian Weekly renewal and acquisition promotions.

cc @johnduffell @pvighi @AWare 