### PR TITLE
pass in a list of rate plan for renewal instead of one

### DIFF
--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -282,7 +282,7 @@ class CheckoutService(identityService: IdentityService,
     val customerAcceptance = nextFridayFrom(contractEffective)
     def addPlan = {
       val newRatePlan = RatePlan(renewal.plan.id.get, None)
-      val renewCommand = Renew(subscription.id.get, subscription.startDate, newRatePlan, contractEffective, customerAcceptance)
+      val renewCommand = Renew(subscription.id.get, subscription.startDate, NonEmptyList(newRatePlan), contractEffective, customerAcceptance)
       zuoraService.renewSubscription(renewCommand)
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.330-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.331",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.329",
+    "com.gu" %% "membership-common" % "0.330-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
This just uses the non empty list renewal instead of the single item renewal call.

@pvighi @paulbrown1982 