### PR TITLE
fixed promo code serialisation for renewals

### DIFF
--- a/app/model/Renewal.scala
+++ b/app/model/Renewal.scala
@@ -37,7 +37,14 @@ class RenewalReads(catalog: Catalog) {
         case None => JsError("invalid payment data type")
       }
   }
-  implicit val promoReads = Json.reads[PromoCode]
+
+  implicit val promoReads = new Reads[PromoCode] {
+    override def reads(json: JsValue): JsResult[PromoCode] = json match {
+      case JsString(s) => JsSuccess(PromoCode(s))
+      case _ => JsError("invalid value for promo code")
+    }
+  }
+
   implicit val renewalReads = Json.reads[Renewal]
 }
 


### PR DESCRIPTION
The current deserialisation code expects to deserialise promo codes in the format : {"get":"promoCodeValue"}
instead the frontend is posting them as plain strings in the Renewal JSON, so this change alters the reader to construct a PromoCode case class from just a String.

@johnduffell @AWare @paulbrown1982 