### PR TITLE
Promo renew

### DIFF
--- a/app/controllers/Promotion.scala
+++ b/app/controllers/Promotion.scala
@@ -65,7 +65,7 @@ object Promotion extends Controller with LazyLogging with CatalogProvider {
         "isValid" -> result.isRight,
         "errorMessage" -> result.swap.toOption.map(_.msg)
       )
-      result.fold(_ => NotAcceptable(body), _ => Ok(body))
+      result.fold(_ => NotAcceptable/*FIXME prob 404*/(body), _ => Ok(body))
     }
   }
 

--- a/app/controllers/Promotion.scala
+++ b/app/controllers/Promotion.scala
@@ -65,7 +65,7 @@ object Promotion extends Controller with LazyLogging with CatalogProvider {
         "isValid" -> result.isRight,
         "errorMessage" -> result.swap.toOption.map(_.msg)
       )
-      result.fold(_ => NotAcceptable/*FIXME prob 404*/(body), _ => Ok(body))
+      result.fold(_ => NotAcceptable/*should be 404*/(body), _ => Ok(body))
     }
   }
 

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -61,7 +61,7 @@ class CheckoutService(identityService: IdentityService,
   def processSubscription(subscriptionData: SubscribeRequest,
                           authenticatedUserOpt: Option[AuthenticatedIdUser],
                           requestData: SubscriptionRequestData
-                         )(implicit p: PromotionApplicator[PromoContext.Renewal, Subscribe]): Future[NonEmptyList[SubsError] \/ CheckoutSuccess] = {
+                         )(implicit p: PromotionApplicator[NewUsers, Subscribe]): Future[NonEmptyList[SubsError] \/ CheckoutSuccess] = {
 
     import subscriptionData.genericData._
     val plan = RatePlan(subscriptionData.productRatePlanId.get, None)
@@ -80,7 +80,7 @@ class CheckoutService(identityService: IdentityService,
       defaultPaymentDelay = CheckoutService.paymentDelay(subscriptionData.productData, zuoraProperties)
       paymentMethod <- EitherT(attachPaymentMethodToStripeCustomer(payment, purchaserIds))
       subscribe = createSubscribeRequest(personalData, soldToContact, requestData, plan, purchaserIds, paymentMethod, payment.makeAccount, Some(defaultPaymentDelay))
-      validPromotion = promoCode.flatMap(promoService.validate[PromoContext.Renewal](_, personalData.address.country.getOrElse(Country.UK), subscriptionData.productRatePlanId).toOption)
+      validPromotion = promoCode.flatMap(promoService.validate[NewUsers](_, personalData.address.country.getOrElse(Country.UK), subscriptionData.productRatePlanId).toOption)
       withPromo = validPromotion.map(v => p.apply(v, prpId => catalog.paid.find(_.id == prpId).map(_.charges.billingPeriod).get, promoPlans)(subscribe)).getOrElse(subscribe)
       result <- EitherT(createSubscription(withPromo, purchaserIds))
       out <- postSubscribeSteps(authenticatedUserOpt, memberId, result, subscriptionData, validPromotion)
@@ -288,7 +288,7 @@ class CheckoutService(identityService: IdentityService,
         code <- renewal.promoCode
         deliveryCountryString <- contact.mailingCountry
         deliveryCountry <- CountryGroup.countryByName(deliveryCountryString)
-        validPromotion <- promoService.validate[NewUsers](code, deliveryCountry, renewal.plan.id).toOption // FIXME this line to have 3 states
+        validPromotion <- promoService.validate[NewUsers](code, deliveryCountry, renewal.plan.id).toOption // would be better to have valid/invalid/tracking
       } yield validPromotion
       val withPromo = validPromotion.map(v => p.apply(v, prpId => catalog.paid.find(_.id == prpId).map(_.charges.billingPeriod).get, promoPlans)(renewCommand)).getOrElse(renewCommand)
       zuoraService.renewSubscription(withPromo)

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -1,7 +1,7 @@
 package services
 
 import com.gu.config.DiscountRatePlanIds
-import com.gu.i18n.Country
+import com.gu.i18n.{Country, CountryGroup}
 import com.gu.i18n.Currency.GBP
 import com.gu.identity.play.{AuthenticatedIdUser, IdMinimalUser}
 import com.gu.memsub.promo._
@@ -261,7 +261,8 @@ class CheckoutService(identityService: IdentityService,
     }
   }
 
-  def renewSubscription(subscription: Subscription[SubscriptionPlan.WeeklyPlan], renewal: Renewal, subscriptionDetails: String ) = {
+  def renewSubscription(subscription: Subscription[SubscriptionPlan.WeeklyPlan], renewal: Renewal, subscriptionDetails: String )
+    (implicit p: PromotionApplicator[NewUsers, Renew])= {
     import model.SubscriptionOps._
 
     def getPayment(contact: Contact, billto: Queries.Contact): PaymentService#Payment = {
@@ -280,10 +281,17 @@ class CheckoutService(identityService: IdentityService,
 
     val contractEffective = subscription.termEndDate
     val customerAcceptance = nextFridayFrom(contractEffective)
-    def addPlan = {
+    def addPlan(contact: Contact) = {
       val newRatePlan = RatePlan(renewal.plan.id.get, None)
       val renewCommand = Renew(subscription.id.get, subscription.startDate, newRatePlan, contractEffective, customerAcceptance)
-      zuoraService.renewSubscription(renewCommand)
+      val validPromotion = for {
+        code <- renewal.promoCode
+        deliveryCountryString <- contact.mailingCountry
+        deliveryCountry <- CountryGroup.countryByName(deliveryCountryString)
+        validPromotion <- promoService.validate[NewUsers](code, deliveryCountry, renewal.plan.id).toOption // FIXME this line to have 3 states
+      } yield validPromotion
+      val withPromo = validPromotion.map(v => p.apply(v, prpId => catalog.paid.find(_.id == prpId).map(_.charges.billingPeriod).get, promoPlans)(renewCommand)).getOrElse(renewCommand)
+      zuoraService.renewSubscription(withPromo)
     }
 
     def ensureEmail(contact: Contact) = if (contact.email.isDefined) Future.successful(\/.right(()))
@@ -299,7 +307,7 @@ class CheckoutService(identityService: IdentityService,
       paymentMethod <- payment.makePaymentMethod
       createPaymentMethod = CreatePaymentMethod(subscription.accountId, paymentMethod, payment.makeAccount.paymentGateway, billto)
       updateResult <- zuoraService.createPaymentMethod(createPaymentMethod)
-      amendResult <- addPlan
+      amendResult <- addPlan(contact)
       _ <- ensureEmail(contact)
       _ <- exactTargetService.enqueueRenewalEmail(subscription, renewal, subscriptionDetails, contact, renewal.email, customerAcceptance, contractEffective)
     }

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.331",
+    "com.gu" %% "membership-common" % "0.332-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.332-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.333",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
This allows promos on renew.  So far it works with discounts, but I'm struggling to test with custom created promotions.  I will carry on trying to test with free trials and tracking

bugs to be fixed are:
- promo code isn't getting written to the subscription - need to find the right kind of Amend call in Commands.scala as it's not TermsAndConditions
- the client side code assumes your zuora account is using the default currency of your billing country, which means promotions are displayed in dollars if you are paying in pounds with a US billing address

@pvighi @paulbrown1982 @AWare 