### PR TITLE
Remove billing period from gw checkout title

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -33,7 +33,7 @@
             data-option-mirror-payment-default="@plan.charges.prettyPricing(currency)"
             data-option-mirror-payment="@plan.charges.prettyPricing(currency)"
             data-option-mirror-description="@for(s <- plan.subtitle) {(@s)}"
-            data-option-mirror-package="@plan.title"
+            data-option-mirror-package="@plan.packageName"
             data-amount="@plan.charges.unsafePrice(currency).prettyAmount"
             data-name="@plan.name"
             data-number-of-months="@plan.charges.billingPeriod.monthsInPeriod"
@@ -44,7 +44,7 @@
             @if(plan == productData.plans.default && currency == countryAndCurrencySettings.defaultCurrency){ checked="checked" }
             >
         </span>
-        <span class="option__label" id="label-for-@plan.id.get-@currency" title="@plan.title">@plan.prettyName(currency)</span>
+        <span class="option__label" id="label-for-@plan.id.get-@currency">@plan.prettyName(currency)</span>
     </label>
 }
 
@@ -67,8 +67,7 @@
     guardian.supplierCode = '@{supplierCode.mkString}';
     guardian.pageInfo.productData.initialProduct = '@{productData.plans.default.name}';
     guardian.pageInfo.productData.productPurchasing = '@{productData.plans.default.name}';
-    guardian.pageInfo.productData.productType = '@{productData.productType}';
-
+    guardian.pageInfo.productData.productType = '@{productData.plans.default.productType}';
 </script>
     @fragments.analytics.tagmanager()
 

--- a/app/views/fragments/checkout/basketPreview.scala.html
+++ b/app/views/fragments/checkout/basketPreview.scala.html
@@ -17,11 +17,11 @@
     </div>
     <div class="basket-preview__product">
         <span class="basket-preview__product__title js-option-mirror-package-display">
-            @plan.title
+            @plan.packageName
         </span>
-            <span class="basket-preview__product__caption js-option-mirror-description-display">
-                (@plan.subtitle)
-            </span>
+        <span class="basket-preview__product__caption js-option-mirror-description-display">
+            (@plan.subtitle)
+        </span>
         <span class="basket-preview__product__payment js-option-mirror-payment-display"></span>
     </div>
 </div>

--- a/app/views/fragments/checkout/basketPreview.scala.html
+++ b/app/views/fragments/checkout/basketPreview.scala.html
@@ -13,7 +13,7 @@
             src="@plan.packImage.defaultImage"
             srcset="@plan.packImage.srcset"
             sizes="(max-width: 980px) 150px, 300px"
-            alt="@plan.title">
+            alt="@plan.packImage.metadataAltText">
     </div>
     <div class="basket-preview__product">
         <span class="basket-preview__product__title js-option-mirror-package-display">

--- a/app/views/fragments/checkout/checkoutHeader.scala.html
+++ b/app/views/fragments/checkout/checkoutHeader.scala.html
@@ -1,4 +1,4 @@
 @(product: String)
 <div class="checkout-header">
-    <h1 class="checkout-header__title">Subscribe to the <span class="js-option-mirror-package-display">@product</span></h1>
+    <h1 class="checkout-header__title">Subscribe to the @product</h1>
 </div>

--- a/app/views/fragments/checkout/reviewPanel.scala.html
+++ b/app/views/fragments/checkout/reviewPanel.scala.html
@@ -17,11 +17,10 @@
     <div class="review-panel__item">
         <h4 class="review-panel__label">Your subscription:</h4>
         <div class="review-panel__details">
-            <div>@plan.title</div>
+            <div>@plan.packageName</div>
             @for(subtitle <- plan.subtitle) {
                 <em>(@subtitle)</em>
             }
-
         </div>
     </div>
     <div class="review-panel__item">

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -15,10 +15,7 @@ object PlanOps {
     def title: String = in.charges.benefits.list match {
       case Digipack :: Nil => "Guardian Digital Pack"
       case Weekly :: Nil => "Guardian Weekly"
-      case x =>
-        if (x.toSet == Set(Digipack, SundayPaper)) "Observer Newspaper"
-        else if (x.contains(SundayPaper)) "Guardian and Observer Newspapers"
-        else "Guardian Newspaper"
+      case x => "Guardian/Observer Newspapers"
     }
 
     def packageName: String = in.charges.benefits.list match {
@@ -34,11 +31,20 @@ object PlanOps {
 
     def packImage: ResponsiveImageGroup = in.charges.benefits.list match {
       case Digipack :: Nil =>
-        ResponsiveImageGroup(availableImages = Seq(ResponsiveImage(controllers.CachedAssets.hashedPathFor("images/digital-pack.png"), 300)))
+        ResponsiveImageGroup(
+          availableImages = Seq(ResponsiveImage(controllers.CachedAssets.hashedPathFor("images/digital-pack.png"), 300)),
+            altText = Some("Guardian apps demoed on Apple, Android and Kindle Fire devices")
+        )
       case Weekly :: Nil =>
-        ResponsiveImageGroup(availableImages = ResponsiveImageGenerator("1961260fc68598c31c0b882d8f4da8e8ec34e7d0/0_0_1000_1333", Seq(375, 750, 1000), "png"))
+        ResponsiveImageGroup(
+          availableImages = ResponsiveImageGenerator("1961260fc68598c31c0b882d8f4da8e8ec34e7d0/0_0_1000_1333", Seq(375, 750, 1000), "png"),
+          altText = Some("Stack of The Guardian Weekly editions")
+        )
       case _ =>
-        ResponsiveImageGroup(availableImages = ResponsiveImageGenerator("05129395fe0461071f176f526d7a4ae2b1d9b9bf/0_0_5863_5116", Seq(140, 500, 1000, 2000)))
+        ResponsiveImageGroup(
+          availableImages = ResponsiveImageGenerator("05129395fe0461071f176f526d7a4ae2b1d9b9bf/0_0_5863_5116", Seq(140, 500, 1000, 2000)),
+          altText = Some("Stack of The Guardian newspapers")
+        )
     }
 
     def changeRatePlanText: String = in.charges.benefits.list match {

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -14,6 +14,16 @@ object PlanOps {
 
     def title: String = in.charges.benefits.list match {
       case Digipack :: Nil => "Guardian Digital Pack"
+      case Weekly :: Nil => "Guardian Weekly"
+      case x =>
+        if (x.toSet == Set(Digipack, SundayPaper)) "Observer Newspaper"
+        else if (x.contains(SundayPaper)) "Guardian and Observer Newspapers"
+        else "Guardian Newspaper"
+    }
+
+    def packageName: String = in.charges.benefits.list match {
+      case Digipack :: Nil => "Guardian Digital Pack"
+      case Weekly :: Nil => "Guardian Weekly"
       case _ => s"${in.name} package"
     }
 
@@ -33,7 +43,6 @@ object PlanOps {
 
     def changeRatePlanText: String = in.charges.benefits.list match {
       case Digipack :: Nil | Weekly :: Nil=> "Change payment frequency"
-
       case _ => "Add more"
     }
 
@@ -70,21 +79,19 @@ object PlanOps {
         "Digital Pack"
       } else if (isGuardianWeekly) {
         "Guardian Weekly"
-      }
-      else {
+      } else {
         "Unknown"
       }
     }
   }
 
   implicit class ProductPopulationDataOps(in: ProductPopulationData) {
-    val products = in.plans.list.head
+    val products = in.plans.default
     def isHomeDelivery: Boolean = products.isHomeDelivery
     def isGuardianWeekly: Boolean = products.isGuardianWeekly
     def isPhysical: Boolean = products.hasPhysicalBenefits
     def isVoucher: Boolean = products.isVoucher
     def isDigitalPack: Boolean = products.isDigitalPack
-    def productType: String = products.productType
   }
 
 }

--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -64,7 +64,7 @@ object Pricing {
 
     def prefix = in.charges.benefits.list match {
       case Digipack :: Nil => ""
-      case _ => s"${in.title} - "
+      case _ => s"${in.packageName} - "
     }
 
     def prettyName(currency: Currency): String = in.charges.benefits.list match {


### PR DESCRIPTION
Tweaking the checkout page title for Guardian Weekly to reflect the type of product being bought not the exact package name. 

- Parts of the page still use the original rate plan names so I've created a packageName method on the view helper class and use that in all existing places except the page title. This makes things much more consistent across HTML templates and Scala now.
- I also stopped the title changing as the radios change (more mobile friendly). 
- Added appropriate alt text to the packshot images.

![picture 1](https://cloud.githubusercontent.com/assets/1515970/21638164/0d98d3e6-d262-11e6-9fcd-a5c26574df46.png)

cc @johnduffell @AWare 