### PR TITLE
Set the InitialPromotionCode__c too when creating a subscription

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.333",
+    "com.gu" %% "membership-common" % "0.334",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
Take on the latest [membership common](https://github.com/guardian/membership-common/pull/389) which will set the InitialPromotionCode__c too when creating a subscription.

cc @johnduffell @AWare @jayceb1 