### PR TITLE
Promotion nomenclature fixes and field ordering

### DIFF
--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -61,7 +61,7 @@
                 </p>
 
                 <div class="js-weekly-renew" data-email="@contact.email"
-                data-country="@billToCountry.alpha2" data-promotion="test" />
+                data-country="@billToCountry.alpha2" data-promo-code="" />
             </section>
             <section class="mma-section">
                     <a class="button button--primary button--large" href="@routes.AccountManagement.logout">Sign Out</a>

--- a/assets/javascripts/modules/react/promoCode.jsx
+++ b/assets/javascripts/modules/react/promoCode.jsx
@@ -19,7 +19,7 @@ render(){
         <PromoButton status={this.props.status} onClick={this.props.send} />
             {this.props.status == status.VALID && <div className="u-note">
             {this.props.copy}<br />
-                <a className="u-link" href={href}>Terms and conditions</a></div>}
+                <a className="u-link" href={href} target="_blank">See full terms and conditions</a></div>}
         </dd>
     </div>
 }

--- a/assets/javascripts/modules/react/promoCode.jsx
+++ b/assets/javascripts/modules/react/promoCode.jsx
@@ -12,7 +12,7 @@ render(){
     let href = '/p/'+this.props.value+'/terms/';
     return <div>
         <dt className="mma-section__list--title">
-            <label className="label" for="promo">Promo Code</label>
+            <label className="label" for="promoCode">Promo code</label>
         </dt>
         <dd className="mma-section__list--content">
         <PromoField value={this.props.value} handler={this.props.handler}/>
@@ -52,7 +52,7 @@ class PromoButton extends React.Component {
 }
 class PromoField extends React.Component {
     render(){
-        return <input className="input-text input-text--promo grid__item" value={this.props.value} onChange={this.props.handler}/>
+        return <input name="promoCode" className="input-text input-text--promo grid__item" value={this.props.value} onChange={this.props.handler}/>
     }
 
 }

--- a/assets/javascripts/modules/renew/renew.es6
+++ b/assets/javascripts/modules/renew/renew.es6
@@ -103,16 +103,15 @@ export function init() {
 }
 
 export function validatePromo(code, country) {
-    console.log('validating promo');
     return check(code, country);
 }
 
 
-export function validatePromoForPlans(promo, plans) {
-    let newPlans = promo.adjustedRatePlans;
+export function validatePromoForPlans(promotion, plans) {
+    let newPlans = promotion.adjustedRatePlans;
     return plans.map((plan) => {
         if (plan.id in newPlans) {
-            return Object.assign({},plan, {promo: newPlans[plan.id]})
+            return Object.assign({},plan, {promotionalPrice: newPlans[plan.id]})
         }
         else {
             return plan;


### PR DESCRIPTION
- Refactored the 'promo' field names nomenclature into their respective 'promotion', 'promoCode' or 'promotionalPrice'. 'promo' should not be used on its own.
- Re-ordered the form so that the Promo code field comes first above the list of plans.
- Changed copy of terms and conditions link and make it open in a new page.

cc @AWare @johnduffell 