### PR TITLE
Pass zuora currency to client side for renewals

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -171,8 +171,8 @@ object ManageWeekly extends LazyLogging {
                     case Product.WeeklyZoneB => catalog.weeklyZoneB.toList
                     case Product.WeeklyZoneC => catalog.weeklyZoneC.toList
                   }
-              val curr = account.currency.toRight(s"could not deserialise currency for account ${account.id}")
-              val weeklyPlanInfo = curr.right.flatMap { existingCurrency =>
+              val currency = account.currency.toRight(s"could not deserialise currency for account ${account.id}")
+              val weeklyPlanInfo = currency.right.flatMap { existingCurrency =>
                 sequence(weeklyPlans.map { plan =>
                   val price = plan.charges.price.getPrice(existingCurrency).toRight(s"could not find price in $existingCurrency for plan ${plan.id} ${plan.name}").right
                   price.map(price => WeeklyPlanInfo(plan.id, plan.charges.prettyPricing(price.currency)))

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -3,12 +3,10 @@
 @import com.gu.memsub.subsv2.Subscription
 @import model.DigitalEdition.UK
 @import com.gu.salesforce.Contact
-@import com.gu.i18n.Country
-@import controllers.ManageWeekly.WeeklyPlanInfo
 @import model.SubscriptionOps._
 @import org.joda.time.LocalDate
 @(
-    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: BillingSchedule, contact: Contact, billToCountry: Country, plans: List[WeeklyPlanInfo]
+    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: BillingSchedule, contact: Contact
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -9,8 +9,9 @@
 @import model.SubscriptionOps._
 @import org.joda.time.LocalDate
 
+@import com.gu.i18n.Currency
 @(
-    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: BillingSchedule, contact: Contact, billToCountry: Country, plans: List[WeeklyPlanInfo]
+    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: BillingSchedule, contact: Contact, billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
@@ -19,6 +20,8 @@
     )
     <script>
 
+        guardian.currency = '@currency.iso';
+
         guardian.plans = [
             @plans.map { plan =>
                 {
@@ -26,7 +29,7 @@
                     price: '@plan.price'
                 },
             }
-        ]
+        ];
 
     </script>
     <main class="page-container gs-container">


### PR DESCRIPTION
This means the promo code validator can use the delivery country to validate the code, and then the zuora currency to decide which currency to pretty print the resulting prices in.

![image](https://cloud.githubusercontent.com/assets/7304387/21688137/995063a2-d363-11e6-835e-4649af622bde.png)


Paul is doing the changes the to promo validate endpoint and will make it actually pass the param through the es6 code.
@AWare @paulbrown1982 