### PR TITLE
Format promotional prices in the right currency

### DIFF
--- a/app/controllers/Binders.scala
+++ b/app/controllers/Binders.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.i18n.{Country, CountryGroup}
+import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.memsub.{ProductFamily, SupplierCode, SupplierCodeBuilder}
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.promo.PromoCode
@@ -42,5 +42,9 @@ object Binders {
 
   implicit object bindableCountry extends QueryParsing[Country](
     CountryGroup.countryByCode(_).get, _.alpha2, (key: String, _: Exception) => s"URL parameter $key is not a valid Country"
+  )
+
+  implicit object bindableCurrency extends QueryParsing[Currency](
+    Currency.fromString(_).get, _.iso, (key: String, _: Exception) => s"URL parameter $key is not a valid Currency"
   )
 }

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -120,10 +120,7 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
         val trackingCodeSessionData = validatedPromoCode.right.toSeq.flatten
         val supplierCodeSessionData = resolvedSupplierCode.map(code => Seq(SupplierTrackingCode -> code.get)).getOrElse(Seq.empty)
         val productData = ProductPopulationData(user.map(_.address), planList)
-        val promoCodeExists = for {
-          code <- promoCode
-          promotion <- tpBackend.promoService.findPromotion(code)
-        } yield code
+        val promoCodeExists = promoCode.filter(tpBackend.promoService.findPromotion(_).isDefined)
 
         Ok(views.html.checkout.payment(
           personalData = personalData,

--- a/app/controllers/Promotion.scala
+++ b/app/controllers/Promotion.scala
@@ -20,20 +20,21 @@ import views.support.{BillingPeriod => _}
 
 object Promotion extends Controller with LazyLogging with CatalogProvider {
 
-  def getAdjustedRatePlans(promo: AnyPromotion, country:Country)(implicit tpBackend:TouchpointBackend): Option[Map[String, String]] = {
+  def getAdjustedRatePlans(promo: AnyPromotion, country:Country, requestedCurrency: Option[Currency])(implicit tpBackend:TouchpointBackend): Option[Map[String, String]] = {
+    def impliedCurrency = CountryGroup.byCountryCode(country.alpha2).getOrElse(CountryGroup.UK).currency
     case class RatePlanPrice(ratePlanId: ProductRatePlanId, chargeList: PaidChargeList)
     promo.asDiscount.map { discountPromo =>
       catalog.allSubs.flatten
         .filter(plan => promo.appliesTo.productRatePlanIds.contains(plan.id))
         .map(plan => RatePlanPrice(plan.id, plan.charges)).map { ratePlanPrice =>
-        val currency = CountryGroup.byCountryCode(country.alpha2).getOrElse(CountryGroup.UK).currency
+        val currency = requestedCurrency.getOrElse(impliedCurrency)
         ratePlanPrice.ratePlanId.get -> ratePlanPrice.chargeList.prettyPricingForDiscountedPeriod(discountPromo, currency)
       }.toMap
     }
   }
 
 
-  def validateForProductRatePlan(promoCode: PromoCode, prpId: ProductRatePlanId, country: Country) = NoCacheAction { implicit request =>
+  def validateForProductRatePlan(promoCode: PromoCode, prpId: ProductRatePlanId, country: Country, currency: Option[Currency]) = NoCacheAction { implicit request =>
     implicit val resolution: TouchpointBackend.Resolution = TouchpointBackend.forRequest(PreSigninTestCookie, request.cookies)
     implicit val tpBackend = resolution.backend
 
@@ -43,7 +44,7 @@ object Promotion extends Controller with LazyLogging with CatalogProvider {
       val result = promo.validateFor(prpId, country)
       val body = Json.obj(
         "promotion" -> Json.toJson(promo),
-        "adjustedRatePlans" -> Json.toJson(getAdjustedRatePlans(promo,country)),
+        "adjustedRatePlans" -> Json.toJson(getAdjustedRatePlans(promo, country, currency)),
         "isValid" -> result.isRight,
         "errorMessage" -> result.swap.toOption.map(_.msg)
       )
@@ -51,7 +52,7 @@ object Promotion extends Controller with LazyLogging with CatalogProvider {
     }
   }
 
-  def validate(promoCode: PromoCode, country: Country) = NoCacheAction { implicit request =>
+  def validate(promoCode: PromoCode, country: Country, currency: Option[Currency]) = NoCacheAction { implicit request =>
     implicit val resolution: TouchpointBackend.Resolution = TouchpointBackend.forRequest(PreSigninTestCookie, request.cookies)
     implicit val tpBackend = resolution.backend
 
@@ -61,7 +62,7 @@ object Promotion extends Controller with LazyLogging with CatalogProvider {
       val result = promo.validate(country)
       val body = Json.obj(
         "promotion" -> Json.toJson(promo),
-        "adjustedRatePlans" -> Json.toJson(getAdjustedRatePlans(promo,country)),
+        "adjustedRatePlans" -> Json.toJson(getAdjustedRatePlans(promo, country, currency)),
         "isValid" -> result.isRight,
         "errorMessage" -> result.swap.toOption.map(_.msg)
       )

--- a/app/views/fragments/checkout/promoCode.scala.html
+++ b/app/views/fragments/checkout/promoCode.scala.html
@@ -1,42 +1,22 @@
-@import com.gu.i18n.Country
-@import com.gu.memsub.Subscription.ProductRatePlanId
 @import com.gu.memsub.promo.PromoCode
-@import controllers.routes.Promotion.validateForProductRatePlan
-@(promoCode: Option[PromoCode])
-@if(false) {
-    <div class="promo-code-applied">✓&nbsp; Promotion applied</div>
-    <div class="promo-code-snippet">
-        <ul>
-            <li><strong>50% off for your first 3 months</strong></li>
-            <li><strong>14 day free trial before first payment</strong></li>
-            <li>Access to the daily edition</li>
-            <li>Ad free experience on the live news app</li>
-        </ul>
-    </div>
-    <input name="promoCode" type="hidden" value="@promoCode.map(_.get)"/>
-} else {
-    @defining(
-        // use Play reverse routing to get the action request path
-        validateForProductRatePlan(
-            PromoCode("_"),
-            ProductRatePlanId("_"),
-            Country.UK).path.replaceFirst("\\?.*", "")) { lookupUrl =>
-        <div class="checkout-promo-code js-promo-code">
-            <label class="label" for="promo-code">Promo code</label>
-            <div class="form-field field-group__item">
-                <div class="col-2">
-                    <input id="promo-code" name="promoCode" value="@promoCode.map(_.get)" class="input-text js-input" data-lookup-url="@lookupUrl"/>
-                    <a class="button button--primary button--large button--arrow-right js-promo-code-validate">Apply</a>
-                </div>
-                @fragments.forms.errorMessage("Please enter a valid promo code.")
-            </div>
-            <div class="js-promo-code-applied promo-code-applied" style="display: none">
-                <div><strong>✓&nbsp;&nbsp;Promotion applied</strong></div>
-                <div class="js-promo-code-snippet"></div>
-                <div class="u-note">
-                     <a class="u-link js-promo-code-tsandcs" href="#" target="_blank">See full terms and conditions</a>
-                </div>
-            </div>
+@(promoCode: Option[PromoCode])(implicit r: RequestHeader)
+@helper.javascriptRouter("jsRoutes")(
+    routes.javascript.Promotion.validateForProductRatePlan
+)
+<div class="checkout-promo-code js-promo-code">
+    <label class="label" for="promo-code">Promo code</label>
+    <div class="form-field field-group__item">
+        <div class="col-2">
+            <input id="promo-code" name="promoCode" value="@promoCode.map(_.get)" class="input-text js-input"/>
+            <a class="button button--primary button--large button--arrow-right js-promo-code-validate">Apply</a>
         </div>
-    }
-}
+        @fragments.forms.errorMessage("Please enter a valid promo code.")
+    </div>
+    <div class="js-promo-code-applied promo-code-applied" style="display: none">
+        <div><strong>✓&nbsp;&nbsp;Promotion applied</strong></div>
+        <div class="js-promo-code-snippet"></div>
+        <div class="u-note">
+             <a class="u-link js-promo-code-tsandcs" href="#" target="_blank">See full terms and conditions</a>
+        </div>
+    </div>
+</div>

--- a/assets/javascripts/modules/checkout/fieldSwitcher.js
+++ b/assets/javascripts/modules/checkout/fieldSwitcher.js
@@ -93,7 +93,7 @@ define([
 
     var update = function () {
         var currentState = getCurrentState();
-        updatePriceBanding(currentState)
+        updatePriceBanding(currentState);
     };
 
     var isCurrencyOverrideChecked = function() {

--- a/assets/javascripts/modules/promoCode.es6
+++ b/assets/javascripts/modules/promoCode.es6
@@ -1,9 +1,9 @@
 import ajax from 'ajax';
 import jsRoutes from './jsRoutes'
 
-export function check(promoCode, country){
+export function validatePromoCode(promoCode, country, currency){
     return new Promise((resolve,reject)=>{
-        let route = jsRoutes.controllers.Promotion.validate(promoCode,country);
+        let route = jsRoutes.controllers.Promotion.validate(promoCode, country, currency);
         ajax({
             type: 'json',
             method: route.method,
@@ -15,6 +15,18 @@ export function check(promoCode, country){
             console.log('f',f,a);
             reject(f);
         })
+    })
+}
+
+export function validatePromotionForPlans(promotion, plans) {
+    let newPlans = promotion.adjustedRatePlans;
+    return plans.map((plan) => {
+        if (plan.id in newPlans) {
+            return Object.assign({},plan, {promotionalPrice: newPlans[plan.id]})
+        }
+        else {
+            return plan;
+        }
     })
 }
 

--- a/assets/javascripts/modules/react/promoCode.jsx
+++ b/assets/javascripts/modules/react/promoCode.jsx
@@ -9,7 +9,7 @@ export const status = {
 
 export class PromoCode extends React.Component {
 render(){
-    let href = '/p/'+this.props.value+'/terms/';
+    let href = '/p/'+this.props.value+'/terms';
     return <div>
         <dt className="mma-section__list--title">
             <label className="label" for="promoCode">Promo code</label>

--- a/assets/javascripts/modules/react/weeklyRenew.jsx
+++ b/assets/javascripts/modules/react/weeklyRenew.jsx
@@ -2,10 +2,9 @@ import React from 'react'
 import ReactDOM from 'react-dom';
 import {DirectDebit} from 'modules/react/directDebit'
 import {PromoCode, status} from 'modules/react/promoCode'
+import {validatePromoCode, validatePromotionForPlans} from '../promoCode';
 import {
     SortCode,
-    validatePromo,
-    validatePromoForPlans,
     validAccount,
     validEmail,
     validState,
@@ -23,10 +22,10 @@ const empty = {
 };
 export function init(container) {
     stripeInit();
-    let showPaymentType = container.dataset.country === 'GB';
+    let showPaymentType = container.dataset.billingCountry === 'GB';
     let plans = window.guardian.plans;
-    ReactDOM.render(<WeeklyRenew showPaymentType={showPaymentType} email={container.dataset.email}
-                                 country={container.dataset.country} plans={plans} promoCode={container.dataset.promoCode}/>, container);
+    ReactDOM.render(<WeeklyRenew showPaymentType={showPaymentType} email={container.dataset.email} currency={container.dataset.currency}
+                                 country={container.dataset.deliveryCountry} plans={plans} promoCode={container.dataset.promoCode}/>, container);
 }
 
 class WeeklyRenew extends React.Component {
@@ -91,8 +90,8 @@ class WeeklyRenew extends React.Component {
             promosStatus: status.LOADING
         });
 
-        validatePromo(this.state.promoCode, this.props.country).then((a) => {
-            let newPlans = validatePromoForPlans(a, this.state.plans);
+        validatePromoCode(this.state.promoCode, this.props.country, this.props.currency).then((a) => {
+            let newPlans = validatePromotionForPlans(a, this.state.plans);
             let update = newPlans.map((plan) => {
                 return 'promotionalPrice' in plan
             }).reduce((a, b) => {

--- a/assets/javascripts/modules/renew/renew.es6
+++ b/assets/javascripts/modules/renew/renew.es6
@@ -102,19 +102,3 @@ export function init() {
     stripeHandler = window.StripeCheckout.configure(guardian.stripeCheckout);
 }
 
-export function validatePromo(code, country) {
-    return check(code, country);
-}
-
-
-export function validatePromoForPlans(promotion, plans) {
-    let newPlans = promotion.adjustedRatePlans;
-    return plans.map((plan) => {
-        if (plan.id in newPlans) {
-            return Object.assign({},plan, {promotionalPrice: newPlans[plan.id]})
-        }
-        else {
-            return plan;
-        }
-    })
-}

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ lazy val root = (project in file(".")).enablePlugins(
       "model.DigitalEdition",
       "com.gu.i18n.CountryGroup",
       "com.gu.i18n.Country",
+      "com.gu.i18n.Currency",
       "com.gu.memsub.promo.PromoCode",
       "com.gu.memsub.SupplierCode",
       "com.gu.memsub.Subscription.ProductRatePlanId"

--- a/conf/routes
+++ b/conf/routes
@@ -22,8 +22,8 @@ POST        /checkout                        controllers.Checkout.handleCheckout
 GET         /checkout/check-identity         controllers.Checkout.checkIdentity(email: String)
 POST        /checkout/check-account          controllers.Checkout.checkAccount
 POST        /checkout/register-guest-user    controllers.Checkout.convertGuestUser
-GET         /checkout/lookupPromotion        controllers.Promotion.validateForProductRatePlan(promoCode: PromoCode, productRatePlanId: ProductRatePlanId, country: Country)
-GET         /promotion/validate              controllers.Promotion.validate(promoCode: PromoCode, country: Country)
+GET         /checkout/lookupPromotion        controllers.Promotion.validateForProductRatePlan(promoCode: PromoCode, productRatePlanId: ProductRatePlanId, country: Country, currency: Option[Currency])
+GET         /promotion/validate              controllers.Promotion.validate(promoCode: PromoCode, country: Country, currency: Option[Currency])
 GET         /checkout/findAddress            controllers.Checkout.findAddress(postCode: String)
 
 # Checkout pages


### PR DESCRIPTION
- Added a requested currency hint to both promotion validation AJAX URLs in the checkout and renewal page. Builds upon https://github.com/guardian/subscriptions-frontend/pull/754 for the renewal page.
- Fixed a bug where the promo code was not passed to the checkout if there was no preselected country, because it wouldn't validate. Now we fall back to using the provided one iff the code exists in the DB.
- Altered how the AJAX URL for the promoCode form in the checkout is generated , using the Play javascriptRouter like renewal does (no longer via data-lookup-url=""). This is good because the promoCode.js module doesn't need to know the request parameter names.
- Made the promo code lookup on the checkout read the country from the delivery country, falling back to the billing country.
- Some refactoring of the validatePromo* JavaScript function names in the renewal section, moving them from renew.es6 to promoCode.es6.

cc @johnduffell @AWare 