### PR TITLE
Use the latest membership-common for extra field in NewpaperLandingPage 

### DIFF
--- a/app/views/promotion/newspaperLandingPage.scala.html
+++ b/app/views/promotion/newspaperLandingPage.scala.html
@@ -48,7 +48,12 @@
         @fragments.page.header(title)
 
         <section class="promotion-description">
-            <p>@promotion.landingPage.description.filter(_.isEmpty).getOrElse(promotion.description)</p>
+            @promotion.landingPage.description.fold {
+                <p>@promotion.description</p>
+            } { d =>
+                <div>@Html(md.render(d))</div>
+                <br/>
+            }
 
             @promotion.asIncentive.map { p =>
                 <h4>Redemption instructions</h4>

--- a/app/views/promotion/newspaperLandingPage.scala.html
+++ b/app/views/promotion/newspaperLandingPage.scala.html
@@ -48,7 +48,7 @@
         @fragments.page.header(title)
 
         <section class="promotion-description">
-            <p>@promotion.description</p>
+            <p>@promotion.landingPage.description.filter(_.isEmpty).getOrElse(promotion.description)</p>
 
             @promotion.asIncentive.map { p =>
                 <h4>Redemption instructions</h4>

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.337",
+    "com.gu" %% "membership-common" % "0.338",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
Use the latest membership-common which has an extra Markdown field in the NewpaperLandingPage model that can be used to override the promotion description on the Newspaper promo landing page. See https://github.com/guardian/memsub-promotions/pull/90 for where the field will be edited.

![picture 6](https://cloud.githubusercontent.com/assets/1515970/21716732/37abbcb8-d404-11e6-9022-058096ef7114.png)

cc @johnduffell @AWare 
