### PR TITLE
Remove the savings % as these will change v soon, and also remove Le …

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -66,9 +66,9 @@
                 <h2 class="block__title">Guardian Weekly</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">A selection of international editorial from the Guardian, Observer, Washington Post and Le Monde</li>
+                        <li class="block__list-item">A selection of international editorial from the Guardian, Observer, and Washington Post</li>
                         <li class="block__list-item">A unique blend of international news, politics, culture and comment</li>
-                        <li class="block__list-item"><strong>Save up to 9%</strong> on the retail price</li>
+                        <li class="block__list-item"><strong>Save on the retail price</strong></li>
                         <li class="block__list-item">Free delivery to your door, wherever you are in the world</li>
                     </ul>
                 </div>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -66,7 +66,7 @@
                 <h2 class="block__title">Guardian Weekly</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">A selection of international editorial from the Guardian, Observer, and Washington Post</li>
+                        <li class="block__list-item">A selection of international editorial from the Guardian, Observer and Washington Post</li>
                         <li class="block__list-item">A unique blend of international news, politics, culture and comment</li>
                         <li class="block__list-item"><strong>Save on the retail price</strong></li>
                         <li class="block__list-item">Free delivery to your door, wherever you are in the world</li>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -68,7 +68,7 @@
                     <ul class="block__list">
                         <li class="block__list-item">A selection of international editorial from the Guardian, Observer and Washington Post</li>
                         <li class="block__list-item">A unique blend of international news, politics, culture and comment</li>
-                        <li class="block__list-item"><strong>Save on the retail price</strong></li>
+                        <li class="block__list-item">Save on the retail price</li>
                         <li class="block__list-item">Free delivery to your door, wherever you are in the world</li>
                     </ul>
                 </div>

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -29,9 +29,9 @@
             <h2 class="block__title">Subscribe to the Guardian Weekly</h2>
             <div class="block__info">
                 <ul class="block__list">
-                    <li class="block__list-item">A selection of international editorial from the Guardian, Observer, Washington Post and Le Monde</li>
+                    <li class="block__list-item">A selection of international editorial from the Guardian, Observer and Washington Post</li>
                     <li class="block__list-item">A unique blend of international news, politics, culture and comment</li>
-                    @edition.guardianWeeklySaving.map {saving => <li class="block__list-item"><strong>Save up to @{saving}%</strong> on the retail price</li>}
+                    <li class="block__list-item"><strong>Save on the retail price</strong></li>
                     <li class="block__list-item">Free delivery to your door, wherever you are in the world</li>
                 </ul>
             </div>

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -31,7 +31,7 @@
                 <ul class="block__list">
                     <li class="block__list-item">A selection of international editorial from the Guardian, Observer and Washington Post</li>
                     <li class="block__list-item">A unique blend of international news, politics, culture and comment</li>
-                    <li class="block__list-item"><strong>Save on the retail price</strong></li>
+                    <li class="block__list-item">Save on the retail price</li>
                     <li class="block__list-item">Free delivery to your door, wherever you are in the world</li>
                 </ul>
             </div>

--- a/app/views/support/DigitalEdition.scala
+++ b/app/views/support/DigitalEdition.scala
@@ -32,11 +32,6 @@ object DigitalEdition {
       case INT => None
     }
 
-    def guardianWeeklySaving = edition match {
-      case INT | UK => None
-      case US => Some(23)
-      case AU => Some(9)
-    }
   }
 
 }


### PR DESCRIPTION
Remove the Guardian Weekly homepage savings % as these will change v soon, and also removed Le Monde as they are no longer a publishing partner for Guardian Weekly.

Before:
![picture 10](https://cloud.githubusercontent.com/assets/1515970/21722952/944ac65e-d426-11e6-87f7-a4ee4ec3aac2.png)
![picture 13](https://cloud.githubusercontent.com/assets/1515970/21722973/b28de1dc-d426-11e6-8d0c-75949f94db59.png)

After:

![picture 14](https://cloud.githubusercontent.com/assets/1515970/21723022/db1c60e2-d426-11e6-89a5-4d17568ef617.png)
![picture 11](https://cloud.githubusercontent.com/assets/1515970/21722941/880fe6ee-d426-11e6-8e4e-694a39ddef7c.png)

cc @johnduffell @AWare