### PR TITLE
write plans into the html safely

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -155,6 +155,19 @@ object ManageWeekly extends LazyLogging {
 
   case class WeeklyPlanInfo(id: ProductRatePlanId, price: String)
 
+  object WeeklyPlanInfo {
+
+    import play.api.libs.json._
+    import play.api.libs.functional.syntax._
+
+    implicit def writer: Writes[WeeklyPlanInfo] =
+      (
+        (JsPath \ "id").write[String].contramap[ProductRatePlanId](_.get) and
+          (JsPath \ "price").write[String]
+        )(unlift(WeeklyPlanInfo.unapply))
+
+  }
+
   def apply(billingSchedule: BillingSchedule, weeklySubscription: Subscription[WeeklyPlan], promoCode: Option[PromoCode])(implicit request: Request[AnyContent], resolution: TouchpointBackend.Resolution): Future[Result] = {
     implicit val tpBackend = resolution.backend
     implicit val flash = request.flash

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -8,6 +8,7 @@
 @import controllers.ManageWeekly.WeeklyPlanInfo
 @import model.SubscriptionOps._
 @import org.joda.time.LocalDate
+@import play.api.libs.json.Json
 
 @import com.gu.i18n.Currency
 @import com.gu.memsub.promo.PromoCode
@@ -21,14 +22,7 @@
     )
     <script>
 
-        guardian.plans = [
-            @plans.map { plan =>
-                {
-                    id: '@plan.id.get',
-                    price: '@plan.price'
-                },
-            }
-        ];
+        guardian.plans = @Html(Json.stringify(Json.toJson(plans)))
 
     </script>
     <main class="page-container gs-container">


### PR DESCRIPTION
We used to roll our own data format for putting things into the page.
This ended up with us trying to write strings inside json inside html inside scala inside templates.
This would have had trouble with at least single quotes in the description, and possibly other things.

At least this sorts out the strings and the json properly, if nothing else!

```html
    <script>

        guardian.plans = [{"id":"2c92c0f8574b2b8101574c4a957706be","price":"£30 every 3 months"},{"id":"2c92c0f8574b2b8101574c4a9480068d","price":"£120 every 12 months"}]

    </script>
```

@paulbrown1982 @AWare 