### PR TITLE
upgrade of library broke renew

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-datepicker": "^0.27.0",
     "react-dom": "^15.1.0",
     "react-redux": "^4.4.5",
-    "react-switch-button": "^2.0.1",
+    "react-switch-button": "2.0.1",
     "redux": "^3.5.2",
     "reqwest": "^2.0.5",
     "style-loader": "^0.13.1",


### PR DESCRIPTION
A change to react-switch-button broke the renew js. 
Probably worth switching to yarn.