### PR TITLE
Fix renewal date starts

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -180,7 +180,7 @@ object ManageWeekly extends LazyLogging {
           futureZuoraBillToContact.map { zuoraContact =>
             zuoraContact.country.map { billToCountry =>
               val catalog = tpBackend.catalogService.unsafeCatalog
-              val weeklyPlans = weeklySubscription.currentOrExpiredPlan.product match {
+              val weeklyPlans = weeklySubscription.planToManage.product match {
                 case Product.WeeklyZoneA => catalog.weeklyZoneA.toList
                 case Product.WeeklyZoneB => catalog.weeklyZoneB.toList
                 case Product.WeeklyZoneC => catalog.weeklyZoneC.toList
@@ -258,7 +258,7 @@ object AccountManagement extends Controller with LazyLogging with CatalogProvide
       allHolidays <- OptionT(tpBackend.suspensionService.getHolidays(subscription.name).map(_.toOption))
       billingSchedule <- OptionT(tpBackend.commonPaymentService.billingSchedule(subscription.id, numberOfBills = 13))
     } yield {
-      val maybeFutureManagePage = subscription.currentOrExpiredPlan.product match {
+      val maybeFutureManagePage = subscription.planToManage.product match {
         case Product.Delivery => subscription.asDelivery.map { deliverySubscription =>
           Future.successful(ManageDelivery(errorCodes, allHolidays, billingSchedule, deliverySubscription))
         }
@@ -353,7 +353,7 @@ object AccountManagement extends Controller with LazyLogging with CatalogProvide
     subscription <- OptionT( SessionSubscription.subscriptionFromRequest)
     billingSchedule <- OptionT(tpBackend.commonPaymentService.billingSchedule(subscription.id, numberOfBills = 13))
     }yield {
-      Ok(thankYouRenew(subscription.latestPlan,billingSchedule, resolution))
+      Ok(thankYouRenew(subscription.nextPlan,billingSchedule, resolution))
     }
     res.run.map(_.getOrElse(Redirect(routes.Homepage.index()).withNewSession))
   }

--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -115,7 +115,7 @@ object ManageDelivery extends LazyLogging{
         billingSchedule = newBS,
         suspendableDays = suspendableDays,
         suspendedDays = suspendedDays,
-        currency = sub.plan.charges.price.currencies.head
+        currency = sub.currency
       ))
     }).valueOr(errorCode => Redirect(routes.AccountManagement.manage(None, Some(errorCode),None).url))
   }

--- a/app/model/SubscriptionOps.scala
+++ b/app/model/SubscriptionOps.scala
@@ -4,20 +4,44 @@ import com.gu.memsub.{OneOffPeriod, Product, Weekly}
 import com.gu.memsub.subsv2.{PaidCharge, PaidSubscriptionPlan, Subscription}
 import com.gu.memsub.subsv2.SubscriptionPlan.{Paid, PaperPlan, WeeklyPlan}
 import com.github.nscala_time.time.OrderingImplicits._
+import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.LocalDate.now
 
-object SubscriptionOps {
+object SubscriptionOps extends LazyLogging {
 
   type WeeklyPlanOneOff = PaidSubscriptionPlan[Product.Weekly, PaidCharge[Weekly.type, OneOffPeriod]]
 
   implicit class EnrichedPaidSubscription[P <: Paid](subscription: Subscription[P]) {
     val currency = subscription.plans.head.charges.currencies.head
-    val currentOrExpiredPlan = subscription.plans.list.filterNot(_.start.isAfter(now)).maxBy(_.end)
-    val latestPlan = subscription.plans.list.maxBy(_.end)
+    val nextPlan = subscription.plans.list.maxBy(_.end)
+    val planToManage = {
+      lazy val coveringPlans = subscription.plans.list.filter(p => (p.start.isEqual(now) || p.start.isBefore(now)) && p.end.isAfter(now))
+      lazy val expiredPlans = subscription.plans.list.filter(p => p.end.isBefore(now) || p.end.isEqual(now))
+
+      // The user's sub might be in many situations:
+
+      if (coveringPlans.nonEmpty) {
+        // Has a plan which is currently active (i.e today sits within the plan's start and end dates)
+        coveringPlans.maxBy(_.end)
+      } else if (expiredPlans.nonEmpty) {
+        // Has a plan which has recently expired
+        expiredPlans.maxBy(_.end)
+      } else {
+        // Has a plan(s) starting soon
+        if (subscription.plans.size > 1) {
+          logger.warn("User has multiple future plans, we are showing them their last ending plan")
+        }
+        nextPlan
+      }
+    }
   }
 
   implicit class EnrichedPaperSubscription[P <: PaperPlan](subscription: Subscription[P]) {
-    val renewable = subscription.latestPlan.charges.billingPeriod.isInstanceOf[OneOffPeriod]
+    val renewable = !subscription.autoRenew &&
+      // A sub it not renewable if the customer is waiting to start, or has not yet started their earlier-renewed term
+      subscription.termStartDate.isAfter(now) &&
+      // Currently, only subscriptions containing a OneOffPeriod plan are currently renewable
+      subscription.planToManage.charges.billingPeriod.isInstanceOf[OneOffPeriod]
   }
 
   implicit class EnrichedWeeklySubscription[P <: WeeklyPlan](subscription: Subscription[P]) {

--- a/app/model/SubscriptionOps.scala
+++ b/app/model/SubscriptionOps.scala
@@ -4,13 +4,14 @@ import com.gu.memsub.{OneOffPeriod, Product, Weekly}
 import com.gu.memsub.subsv2.{PaidCharge, PaidSubscriptionPlan, Subscription}
 import com.gu.memsub.subsv2.SubscriptionPlan.PaperPlan
 import com.github.nscala_time.time.OrderingImplicits._
-import org.joda.time.LocalDate
+import org.joda.time.LocalDate.now
 
 object SubscriptionOps {
 
   type WeeklyPlanOneOff = PaidSubscriptionPlan[Product.Weekly, PaidCharge[Weekly.type, OneOffPeriod]]
 
   implicit class EnrichedSubscription[P <: PaperPlan](subscription: Subscription[P]) {
+    val currentPlan = subscription.plans.list.filter(_.start.isBefore(now.plusDays(1))).maxBy(_.start)
     val latestPlan = {
       def getLatest(p1: P, p2: P) = if (p1.end.isAfter(p2.end)) p1 else p2
       subscription.plans.list.reduceLeft(getLatest)
@@ -18,13 +19,4 @@ object SubscriptionOps {
     val renewable = latestPlan.charges.billingPeriod.isInstanceOf[OneOffPeriod]
     val asRenewable = if (renewable) Some(subscription.asInstanceOf[Subscription[WeeklyPlanOneOff]]) else None
   }
-
-  implicit class EnrichedRenewableSubscription[P <: WeeklyPlanOneOff](subscription: Subscription[P]) {
-    val renewalDate: LocalDate = {
-      // Is the latest of: the term end date, or the fixed period plus the number of months in the period (usually just 12)
-      val fixedPeriodEnds = subscription.plan.start.plusMonths(subscription.plan.charges.billingPeriod.monthsInPeriod)
-      Seq(fixedPeriodEnds, subscription.termEndDate).max
-    }
-  }
-
 }

--- a/app/model/SubscriptionOps.scala
+++ b/app/model/SubscriptionOps.scala
@@ -1,10 +1,14 @@
 package model
 
-import com.gu.memsub.OneOffPeriod
-import com.gu.memsub.subsv2.Subscription
+import com.gu.memsub.{OneOffPeriod, Product, Weekly}
+import com.gu.memsub.subsv2.{PaidCharge, PaidSubscriptionPlan, Subscription}
 import com.gu.memsub.subsv2.SubscriptionPlan.PaperPlan
+import com.github.nscala_time.time.OrderingImplicits._
+import org.joda.time.LocalDate
 
 object SubscriptionOps {
+
+  type WeeklyPlanOneOff = PaidSubscriptionPlan[Product.Weekly, PaidCharge[Weekly.type, OneOffPeriod]]
 
   implicit class EnrichedSubscription[P <: PaperPlan](subscription: Subscription[P]) {
     val latestPlan = {
@@ -12,5 +16,15 @@ object SubscriptionOps {
       subscription.plans.list.reduceLeft(getLatest)
     }
     val renewable = latestPlan.charges.billingPeriod.isInstanceOf[OneOffPeriod]
+    val asRenewable = if (renewable) Some(subscription.asInstanceOf[Subscription[WeeklyPlanOneOff]]) else None
   }
+
+  implicit class EnrichedRenewableSubscription[P <: WeeklyPlanOneOff](subscription: Subscription[P]) {
+    val renewalDate: LocalDate = {
+      // Is the latest of: the term end date, or the fixed period plus the number of months in the period (usually just 12)
+      val fixedPeriodEnds = subscription.plan.start.plusMonths(subscription.plan.charges.billingPeriod.monthsInPeriod)
+      Seq(fixedPeriodEnds, subscription.termEndDate).max
+    }
+  }
+
 }

--- a/app/model/SubscriptionOps.scala
+++ b/app/model/SubscriptionOps.scala
@@ -2,7 +2,7 @@ package model
 
 import com.gu.memsub.{OneOffPeriod, Product, Weekly}
 import com.gu.memsub.subsv2.{PaidCharge, PaidSubscriptionPlan, Subscription}
-import com.gu.memsub.subsv2.SubscriptionPlan.PaperPlan
+import com.gu.memsub.subsv2.SubscriptionPlan.{PaperPlan, WeeklyPlan}
 import com.github.nscala_time.time.OrderingImplicits._
 import org.joda.time.LocalDate.now
 
@@ -11,12 +11,13 @@ object SubscriptionOps {
   type WeeklyPlanOneOff = PaidSubscriptionPlan[Product.Weekly, PaidCharge[Weekly.type, OneOffPeriod]]
 
   implicit class EnrichedSubscription[P <: PaperPlan](subscription: Subscription[P]) {
-    val currentPlan = subscription.plans.list.filter(_.start.isBefore(now.plusDays(1))).maxBy(_.start)
-    val latestPlan = {
-      def getLatest(p1: P, p2: P) = if (p1.end.isAfter(p2.end)) p1 else p2
-      subscription.plans.list.reduceLeft(getLatest)
-    }
+    val currentOrExpiredPlan = subscription.plans.list.filterNot(_.start.isAfter(now)).maxBy(_.end)
+    val latestPlan = subscription.plans.list.maxBy(_.end)
     val renewable = latestPlan.charges.billingPeriod.isInstanceOf[OneOffPeriod]
-    val asRenewable = if (renewable) Some(subscription.asInstanceOf[Subscription[WeeklyPlanOneOff]]) else None
+    val currency = subscription.plans.head.charges.currencies.head
+  }
+
+  implicit class EnrichedWeeklySubscription[P <: WeeklyPlan](subscription: Subscription[P]) {
+    val asRenewable = if (subscription.renewable) Some(subscription.asInstanceOf[Subscription[WeeklyPlanOneOff]]) else None
   }
 }

--- a/app/model/SubscriptionOps.scala
+++ b/app/model/SubscriptionOps.scala
@@ -2,7 +2,7 @@ package model
 
 import com.gu.memsub.{OneOffPeriod, Product, Weekly}
 import com.gu.memsub.subsv2.{PaidCharge, PaidSubscriptionPlan, Subscription}
-import com.gu.memsub.subsv2.SubscriptionPlan.{PaperPlan, WeeklyPlan}
+import com.gu.memsub.subsv2.SubscriptionPlan.{Paid, PaperPlan, WeeklyPlan}
 import com.github.nscala_time.time.OrderingImplicits._
 import org.joda.time.LocalDate.now
 
@@ -10,11 +10,14 @@ object SubscriptionOps {
 
   type WeeklyPlanOneOff = PaidSubscriptionPlan[Product.Weekly, PaidCharge[Weekly.type, OneOffPeriod]]
 
-  implicit class EnrichedSubscription[P <: PaperPlan](subscription: Subscription[P]) {
+  implicit class EnrichedPaidSubscription[P <: Paid](subscription: Subscription[P]) {
+    val currency = subscription.plans.head.charges.currencies.head
     val currentOrExpiredPlan = subscription.plans.list.filterNot(_.start.isAfter(now)).maxBy(_.end)
     val latestPlan = subscription.plans.list.maxBy(_.end)
-    val renewable = latestPlan.charges.billingPeriod.isInstanceOf[OneOffPeriod]
-    val currency = subscription.plans.head.charges.currencies.head
+  }
+
+  implicit class EnrichedPaperSubscription[P <: PaperPlan](subscription: Subscription[P]) {
+    val renewable = subscription.latestPlan.charges.billingPeriod.isInstanceOf[OneOffPeriod]
   }
 
   implicit class EnrichedWeeklySubscription[P <: WeeklyPlan](subscription: Subscription[P]) {

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -1,5 +1,6 @@
 package services
 
+import com.github.nscala_time.time.OrderingImplicits._
 import com.gu.config.DiscountRatePlanIds
 import com.gu.i18n.{Country, CountryGroup}
 import com.gu.i18n.Currency.GBP
@@ -16,11 +17,12 @@ import com.gu.zuora.soap.models.Queries
 import com.gu.zuora.soap.models.Results.SubscribeResult
 import com.gu.zuora.soap.models.errors._
 import com.typesafe.scalalogging.LazyLogging
-import model.SubscriptionOps.WeeklyPlanOneOff
+import model.SubscriptionOps._
 import model.{Renewal, _}
 import model.error.CheckoutService._
 import model.error.IdentityService._
 import model.error.SubsError
+import org.joda.time.LocalDate.now
 import org.joda.time.{DateTimeConstants, Days, LocalDate}
 import touchpoint.ZuoraProperties
 
@@ -70,7 +72,7 @@ class CheckoutService(identityService: IdentityService,
     val idMinimalUser = authenticatedUserOpt.map(_.user)
     val soldToContact = subscriptionData.productData.left.toOption.filter(isGuardianWeekly).map(_.deliveryAddress)
 
-    implicit val today = LocalDate.now()
+    implicit val today = now()
 
     (for {
       userExists <- EitherT(IdentityService.doesUserExist(personalData.email).map(\/.right[FatalErrors, Boolean]))
@@ -255,14 +257,12 @@ class CheckoutService(identityService: IdentityService,
   def renewSubscription(subscription: Subscription[WeeklyPlanOneOff], renewal: Renewal, subscriptionDetails: String )
     (implicit p: PromotionApplicator[NewUsers, Renew])= {
 
-    import model.SubscriptionOps.EnrichedRenewableSubscription
-
     def getPayment(contact: Contact, billto: Queries.Contact): PaymentService#Payment = {
       val idMinimalUser = IdMinimalUser(contact.identityId, None)
       val pid = PurchaserIdentifiers(contact, Some(idMinimalUser))
       renewal.paymentData match {
         case cd: CreditCardData =>
-          val currency = subscription.plan.charges.currencies.head
+          val currency = subscription.currentPlan.charges.currencies.head
           paymentService.makeCreditCardPayment(cd, currency, pid)
         case dd: DirectDebitData => paymentService.makeDirectDebitPayment(dd, billto.firstName, billto.lastName, contact)
       }
@@ -271,12 +271,12 @@ class CheckoutService(identityService: IdentityService,
     val ratePlan = RatePlan(renewal.plan.id.get, None, Nil)
     val amend =   Amend(subscriptionId = subscription.id.get, plansToRemove = Nil, newRatePlans = NonEmptyList(ratePlan))
 
-    val contractEffective = subscription.renewalDate
+    val contractEffective = Seq(subscription.termEndDate, now).max // The sub may have 'expired' before the customer gets round to renewing it.
     val customerAcceptance = contractEffective
 
     def addPlan(contact: Contact) = {
       val newRatePlan = RatePlan(renewal.plan.id.get, None)
-      val renewCommand = Renew(subscription.id.get, subscription.startDate, NonEmptyList(newRatePlan), contractEffective, customerAcceptance)
+      val renewCommand = Renew(subscription.id.get, subscription.termStartDate, subscription.termEndDate, NonEmptyList(newRatePlan), contractEffective, customerAcceptance)
       val validPromotion = for {
         code <- renewal.promoCode
         deliveryCountryString <- contact.mailingCountry

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -261,9 +261,7 @@ class CheckoutService(identityService: IdentityService,
       val idMinimalUser = IdMinimalUser(contact.identityId, None)
       val pid = PurchaserIdentifiers(contact, Some(idMinimalUser))
       renewal.paymentData match {
-        case cd: CreditCardData =>
-          val currency = subscription.currentPlan.charges.currencies.head
-          paymentService.makeCreditCardPayment(cd, currency, pid)
+        case cd: CreditCardData => paymentService.makeCreditCardPayment(cd, subscription.currency, pid)
         case dd: DirectDebitData => paymentService.makeDirectDebitPayment(dd, billto.firstName, billto.lastName, contact)
       }
     }

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -20,7 +20,8 @@ import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import model.exactTarget.HolidaySuspensionBillingScheduleDataExtensionRow.constructSalutation
 import model.exactTarget._
-import model.{PaperData, PurchaserIdentifiers, Renewal, SubscribeRequest}
+import model.{PaperData, PurchaserIdentifiers, Renewal, SubscribeRequest, SubscriptionOps}
+import model.SubscriptionOps._
 import org.joda.time.{Days, LocalDate}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
@@ -157,7 +158,7 @@ class ExactTargetService(
           email = salesforceContact.email,
           saluation = constructSalutation(salesforceContact.title, salesforceContact.firstName, Some(salesforceContact.lastName)),
           subscriptionName = subscription.name.get,
-          subscriptionCurrency = subscription.plan.charges.price.currencies.head,
+          subscriptionCurrency = subscription.currency,
           packageName = packageName,
           billingSchedule = billingSchedule,
           numberOfSuspensionsLinedUp = numberOfSuspensionsLinedUp,

--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -13,11 +13,14 @@ import scala.concurrent.Future
 trait SalesforceService extends LazyLogging {
   def repo: SimpleContactRepository
   def createOrUpdateUser(personalData: PersonalData, paperData: Option[PaperData], userId: Option[IdMinimalUser]): Future[ContactId]
+  def isAuthenticated: Boolean
 }
 
 class SalesforceServiceImp(val repo: SimpleContactRepository) extends SalesforceService {
   override def createOrUpdateUser(personalData: PersonalData, paperData: Option[PaperData], userId: Option[IdMinimalUser]): Future[ContactId] =
     repo.upsert(userId.map(_.id), SalesforceService.createSalesforceUserData(personalData, paperData))
+
+  override def isAuthenticated = repo.salesforce.isAuthenticated
 }
 
 object SalesforceService {

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -8,6 +8,7 @@
 @import model.SubscriptionOps._
 @import org.joda.time.LocalDate
 
+@import org.joda.time.LocalDate.now
 @(subscriptionName: String, plan: SubscriptionPlan.PaperPlan, maybeStartDate: Option[LocalDate], chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[Contact] = None)(extra: Html = Html(""))
 <dl class="mma-section__list">
     <dt class="mma-section__list--title">Subscriber ID</dt>
@@ -15,35 +16,38 @@
 
     <dt class="mma-section__list--title">Current plan</dt>
     <dd class="mma-section__list--content">
-            <div>
-            @if(plan.name == "Echo-Legacy") {
-                Multi-day (@{
-                chosenPaperDays.map(_.id.replace("Print ", "")).mkString(", ")
-            })
-            } else {
-                @plan.name
-            }
-            </div>
-            <div>@plan.charges.prettyPricing(plan.charges.price.currencies.head)</div>
-        </dd>
+        <div>
+        @if(plan.name == "Echo-Legacy") {
+            Multi-day (@{
+            chosenPaperDays.map(_.id.replace("Print ", "")).mkString(", ")
+        })
+        } else {
+            @plan.name
+        }
+        </div>
+        <div>@plan.charges.prettyPricing(plan.charges.price.currencies.head)</div>
+    </dd>
 
     @maybeStartDate.map { startDate =>
         <dt class="mma-section__list--title">Start date</dt>
-        <dd class="mma-section__list--content">
-            @prettyDate(startDate)
-        </dd>
+        <dd class="mma-section__list--content">@prettyDate(startDate)</dd>
+
+        @if(plan.start.isAfter(startDate)) {
+            <dt class="mma-section__list--title">@if(plan.start.isAfter(now)) { Renews } else { Renewed }</dt>
+            <dd class="mma-section__list--content">@prettyDate(plan.start)</dd>
         }
-    
-@maybeContact.map { contact =>
-    <dt class="mma-section__list--title">Delivery details</dt>
-    <dd class="mma-section__list--content">
-        <div>@contact.firstName @contact.lastName</div>
-        <div>@contact.mailingStreet
-        @contact.mailingCity
-        @contact.mailingState
-        @contact.mailingPostcode
-        @contact.mailingCountry</div>
-    </dd>
-}
+    }
+
+    @maybeContact.map { contact =>
+        <dt class="mma-section__list--title">Delivery details</dt>
+        <dd class="mma-section__list--content">
+            <div>@contact.firstName @contact.lastName</div>
+            <div>@contact.mailingStreet
+            @contact.mailingCity
+            @contact.mailingState
+            @contact.mailingPostcode
+            @contact.mailingCountry</div>
+        </dd>
+    }
     @extra
 </dl>

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -1,15 +1,13 @@
 @import com.gu.memsub.subsv2.SubscriptionPlan
-@import com.gu.memsub.subsv2.Subscription
 @import views.support.Dates._
 @import views.support.Pricing._
 @import com.gu.memsub.PaperDay
 @import scala.collection.immutable.List.empty
 @import com.gu.salesforce.Contact
-@import model.SubscriptionOps._
 @import org.joda.time.LocalDate
 
 @import org.joda.time.LocalDate.now
-@(subscriptionName: String, plan: SubscriptionPlan.PaperPlan, maybeStartDate: Option[LocalDate], chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[Contact] = None)(extra: Html = Html(""))
+@(subscriptionName: String, plan: SubscriptionPlan.PaperPlan, maybeStartDate: Option[LocalDate], chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[Contact] = None, maybeFuturePlan: Option[SubscriptionPlan.PaperPlan] = None)(extra: Html = Html(""))
 <dl class="mma-section__list">
     <dt class="mma-section__list--title">Subscriber ID</dt>
     <dd class="mma-section__list--content">@subscriptionName</dd>
@@ -26,26 +24,28 @@
         }
         </div>
         <div>@plan.charges.prettyPricing(plan.charges.price.currencies.head)</div>
+        @maybeStartDate.map { startDate =>
+            <div>@if(startDate.isAfter(now)) { Starts: } else { Started: } @prettyDate(startDate)</div>
+        }
     </dd>
 
-    @maybeStartDate.map { startDate =>
-        <dt class="mma-section__list--title">Start date</dt>
-        <dd class="mma-section__list--content">@prettyDate(startDate)</dd>
-
-        @if(plan.start.isAfter(startDate)) {
-            <dt class="mma-section__list--title">@if(plan.start.isAfter(now)) { Renews } else { Renewed }</dt>
-            <dd class="mma-section__list--content">@prettyDate(plan.start)</dd>
-        }
+    @maybeFuturePlan.map { futurePlan =>
+        <dt class="mma-section__list--title">Renewal plan</dt>
+        <dd class="mma-section__list--content">
+            <div>@futurePlan.name</div>
+            <div>@futurePlan.charges.prettyPricing(futurePlan.charges.price.currencies.head)</div>
+            <div>Starts: @prettyDate(futurePlan.start)</div>
+        </dd>
     }
 
     @maybeContact.map { contact =>
         <dt class="mma-section__list--title">Delivery details</dt>
         <dd class="mma-section__list--content">
             <div>@contact.firstName @contact.lastName</div>
-            <div>@contact.mailingStreet
-            @contact.mailingCity
-            @contact.mailingState
-            @contact.mailingPostcode
+            <div>@contact.mailingStreet,
+            @contact.mailingCity,
+            @contact.mailingState,
+            @contact.mailingPostcode,
             @contact.mailingCountry</div>
         </dd>
     }

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -4,6 +4,7 @@
 @import configuration.Config.suspendableWeeks
 @import com.gu.subscriptions.suspendresume.SuspensionService.holidayToDays
 @import model.DigitalEdition.UK
+@import model.SubscriptionOps._
 @import views.support.Dates.prettyDate
 @import views.support.AccountManagementOps._
 @import org.joda.time.Days
@@ -115,7 +116,7 @@
 
             <section class="mma-section">
                 <h3 class="mma-section__header">Your billing schedule</h3>
-                @account.fragments.billingSchedule(billingSchedule, subscription.plan.charges.price.currencies.head)
+                @account.fragments.billingSchedule(billingSchedule, subscription.currency)
             </section>
 
             <section class="mma-section">

--- a/app/views/account/thankYouRenew.scala.html
+++ b/app/views/account/thankYouRenew.scala.html
@@ -21,9 +21,9 @@
             @views.html.account.fragments.billingSchedule(billingSchedule, plan.charges.price.currencies.head)
 
         </section>
-        <section class="mma-section">
+        <section class="section-slice--bleed mma-section">
             <a class="button button--primary button--large" href="@routes.AccountManagement.processLogin">
-                back to subscription details</a>
+                Back to subscription details</a>
         </section>
 
     </main>

--- a/app/views/account/thankYouRenew.scala.html
+++ b/app/views/account/thankYouRenew.scala.html
@@ -1,18 +1,19 @@
 @import com.gu.memsub.subsv2.SubscriptionPlan
-@import views.support.PlanOps._
 @import com.gu.memsub.BillingSchedule
 @import views.support.Pricing._
+@import views.support.Dates._
+@import org.joda.time.LocalDate.now
 
-@(plan : SubscriptionPlan.PaperPlan,
-    billingSchedule: BillingSchedule,
-    touchpointBackendResolution: services.TouchpointBackend.Resolution
+@(plan: SubscriptionPlan.PaperPlan,
+  billingSchedule: BillingSchedule,
+  touchpointBackendResolution: services.TouchpointBackend.Resolution
 )(implicit request: RequestHeader)
 
 @main(s"Confirmation | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution), plan = None) {
     <main class="page-container gs-container gs-container--slim">
         @fragments.page.header("Thank you", None, List("l-padded"))
         <section class="section-slice section-slice--bleed section-slice--limited">
-            <p>Your Guardian Weekly subscription has been renewed. We will take @plan.charges.prettyPricing(plan.charges.currencies.head) from your account.</p>
+            <p>Your Guardian Weekly subscription has been renewed. We will take @plan.charges.prettyPricing(plan.charges.currencies.head) from your account, starting @if(plan.start.isAfter(now)) { @prettyDate(plan.start). } else { today. }</p>
         </section>
         <section class="section-slice--bleed section-slice--limited">
             <h3 class="mma-section__header">

--- a/app/views/account/voucher.scala.html
+++ b/app/views/account/voucher.scala.html
@@ -2,6 +2,7 @@
 @import com.gu.memsub.subsv2.SubscriptionPlan
 @import com.gu.memsub.subsv2.Subscription
 @import model.DigitalEdition.UK
+@import model.SubscriptionOps._
 @(
     subscription: Subscription[SubscriptionPlan.DailyPaper], billingSchedule: BillingSchedule
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
@@ -30,7 +31,7 @@
                 <h3 class="mma-section__header">
                     Your billing schedule
                 </h3>
-                @views.html.account.fragments.billingSchedule(billingSchedule, subscription.plan.charges.price.currencies.head)
+                @views.html.account.fragments.billingSchedule(billingSchedule, subscription.currency)
             </section>
             <section class="mma-section">
                 <a class="button button--primary button--large" href="@routes.AccountManagement.logout">Sign Out</a>

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -37,7 +37,7 @@
                 <h3 class="mma-section__header">
                     Your billing schedule
                 </h3>
-                @views.html.account.fragments.billingSchedule(billingSchedule, subscription.latestPlan.charges.price.currencies.head)
+                @views.html.account.fragments.billingSchedule(billingSchedule, subscription.currency)
             </section>
             <section class="mma-section">
                 <a class="button button--primary button--large" href="@routes.AccountManagement.logout">Sign Out</a>

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -26,10 +26,10 @@
                 </h3>
                 @views.html.account.fragments.yourDetails(
                     subscriptionName = subscription.name.get,
-                    plan = subscription.currentOrExpiredPlan,
-                    maybeStartDate = Some(subscription.currentOrExpiredPlan.start),
+                    plan = subscription.planToManage,
+                    maybeStartDate = Some(subscription.planToManage.start),
                     maybeContact = Some(contact),
-                    maybeFuturePlan = Some(subscription.latestPlan).filter(_.start.isAfter(now))
+                    maybeFuturePlan = Some(subscription.nextPlan).filter(_.start.isAfter(now))
                 )()
             </section>
 

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -4,7 +4,7 @@
 @import model.DigitalEdition.UK
 @import com.gu.salesforce.Contact
 @import model.SubscriptionOps._
-@import org.joda.time.LocalDate
+@import org.joda.time.LocalDate.now
 @(
     subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: BillingSchedule, contact: Contact
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
@@ -26,16 +26,18 @@
                 </h3>
                 @views.html.account.fragments.yourDetails(
                     subscriptionName = subscription.name.get,
-                    plan = subscription.latestPlan,
-                    maybeStartDate = Some(subscription.firstPaymentDate).filter(d => d.isAfter(LocalDate.now.minusMonths(1))),
-                    maybeContact = Some(contact))()
+                    plan = subscription.currentPlan,
+                    maybeStartDate = Some(subscription.currentPlan.start),
+                    maybeContact = Some(contact),
+                    maybeFuturePlan = if (subscription.latestPlan.start.isAfter(now)) Some(subscription.latestPlan) else None
+                )()
             </section>
 
             <section class="mma-section">
                 <h3 class="mma-section__header">
                     Your billing schedule
                 </h3>
-                @views.html.account.fragments.billingSchedule(billingSchedule, subscription.plan.charges.price.currencies.head)
+                @views.html.account.fragments.billingSchedule(billingSchedule, subscription.latestPlan.charges.price.currencies.head)
             </section>
             <section class="mma-section">
                 <a class="button button--primary button--large" href="@routes.AccountManagement.logout">Sign Out</a>

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -29,7 +29,7 @@
                     plan = subscription.currentOrExpiredPlan,
                     maybeStartDate = Some(subscription.currentOrExpiredPlan.start),
                     maybeContact = Some(contact),
-                    maybeFuturePlan = if (subscription.latestPlan.start.isAfter(now)) Some(subscription.latestPlan) else None
+                    maybeFuturePlan = Some(subscription.latestPlan).filter(_.start.isAfter(now))
                 )()
             </section>
 

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -26,8 +26,8 @@
                 </h3>
                 @views.html.account.fragments.yourDetails(
                     subscriptionName = subscription.name.get,
-                    plan = subscription.currentPlan,
-                    maybeStartDate = Some(subscription.currentPlan.start),
+                    plan = subscription.currentOrExpiredPlan,
+                    maybeStartDate = Some(subscription.currentOrExpiredPlan.start),
                     maybeContact = Some(contact),
                     maybeFuturePlan = if (subscription.latestPlan.start.isAfter(now)) Some(subscription.latestPlan) else None
                 )()

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -39,8 +39,8 @@
                 @helper.CSRF.formField
                 @views.html.account.fragments.yourDetails(
                     subscriptionName = subscription.name.get,
-                    plan = subscription.latestPlan,
-                    maybeStartDate = Some(subscription.latestPlan.start),
+                    plan = subscription.nextPlan,
+                    maybeStartDate = Some(subscription.nextPlan.start),
                     maybeContact = Some(contact))()
             </section>
 

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -14,7 +14,7 @@
 @import com.gu.i18n.Currency
 @import com.gu.memsub.promo.PromoCode
 @(
-    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: BillingSchedule, contact: Contact, billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
+    subscription: Subscription[WeeklyPlanOneOff], billingSchedule: BillingSchedule, contact: Contact, billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
@@ -50,9 +50,9 @@
 
                 <p>
                 @if(subscription.termEndDate.isAfter(LocalDate.now)) {
-                    Your current subscription is due to expire on @prettyDate(subscription.termEndDate).
+                    Your current subscription is due to expire on @prettyDate(subscription.renewalDate).
                 } else {
-                    Your subscription expired on @prettyDate(subscription.termEndDate).
+                    Your subscription expired on @prettyDate(subscription.renewalDate).
                 }
                 Please complete the form below to renew your subscription.
                 </p>

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -1,5 +1,4 @@
 @import com.gu.memsub.BillingSchedule
-@import com.gu.memsub.subsv2.SubscriptionPlan
 @import com.gu.memsub.subsv2.Subscription
 @import model.DigitalEdition.UK
 @import com.gu.salesforce.Contact
@@ -7,12 +6,12 @@
 @import com.gu.i18n.Country
 @import controllers.ManageWeekly.WeeklyPlanInfo
 @import model.SubscriptionOps._
-@import org.joda.time.LocalDate
 @import play.api.libs.json.Json
 @import controllers.CachedAssets.hashedPathFor
 
 @import com.gu.i18n.Currency
 @import com.gu.memsub.promo.PromoCode
+@import org.joda.time.LocalDate.now
 @(
     subscription: Subscription[WeeklyPlanOneOff], billingSchedule: BillingSchedule, contact: Contact, billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
@@ -41,7 +40,7 @@
                 @views.html.account.fragments.yourDetails(
                     subscriptionName = subscription.name.get,
                     plan = subscription.latestPlan,
-                    maybeStartDate = Some(subscription.firstPaymentDate).filter(d => d.isAfter(LocalDate.now.minusMonths(1))),
+                    maybeStartDate = Some(subscription.latestPlan.start),
                     maybeContact = Some(contact))()
             </section>
 
@@ -49,10 +48,10 @@
                 <h3 class="mma-section__header">Renew your subscription</h3>
 
                 <p>
-                @if(subscription.termEndDate.isAfter(LocalDate.now)) {
-                    Your current subscription is due to expire on @prettyDate(subscription.renewalDate).
+                @if(subscription.termEndDate.isAfter(now)) {
+                    Your current subscription is due to expire on @prettyDate(subscription.termEndDate).
                 } else {
-                    Your subscription expired on @prettyDate(subscription.renewalDate).
+                    Your subscription expired on @prettyDate(subscription.termEndDate).
                 }
                 Please complete the form below to renew your subscription.
                 </p>

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.339-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.342",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.342",
+    "com.gu" %% "membership-common" % "0.344",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.338",
+    "com.gu" %% "membership-common" % "0.339-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
A few changes to ensure the renewal dates and display of the renew funnel make sense.
Requires: https://github.com/guardian/membership-common/pull/398

- We always set the effective and acceptance date of the renewal amendment to be the end of the one-off term
- We now show when the sub will switch from the one-off to the renewed one if the renewal date is in the future (latestPlan stuff)
- We always add the new product with a future date if the renewal is in the future, or today's date. Never a past date.
- Updated copy on the thank you page and the weeklyDetails page.

![picture 17](https://cloud.githubusercontent.com/assets/1515970/21809813/3192cc46-d741-11e6-8eff-83ad2799f1e9.png)
![picture 15](https://cloud.githubusercontent.com/assets/1515970/21809814/34222574-d741-11e6-82ad-4c4ec10aa3d2.png)

cc @jacobwinch @johnduffell @AWare 