### PR TITLE
Fix bug identifying quarterly/annual subscriptions

### DIFF
--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -21,7 +21,7 @@
     errorCodes: Set[String]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 @avgPeriodBetweenInvoices = @{
-    val dates = billingSchedule.invoices.list.map(_.date)
+    val dates = billingSchedule.invoices.list.filter(_.totalGross > 0).map(_.date)
     Math.floor(Days.daysBetween(dates.head, dates.last).getDays / dates.size)
 }
 @main("Cancel your papers while you're away | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {


### PR DESCRIPTION
Only invoices with a positive gross amount should be considered when trying to work out the billing period. There was a bug where we weren't properly identifying the billing period for Echo Legacy subs which didn't have a paper on one or more days of the week.

cc @johnduffell @jacobwinch @jayceb1 @AWare 