### PR TITLE
Enable quarterly and annual subscribers to set holiday credits

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -82,7 +82,7 @@ object ManageDelivery extends ContextLogging {
       newHoliday = PaymentHoliday(sub.name, form.startDate, form.endDate)
       // 14 because + 2 extra months needed in calculation to cover setting a 6-week suspension on the day before your 12th billing day!
       oldBS <- EitherT(tpBackend.commonPaymentService.billingSchedule(sub.id, numberOfBills = 14).map(_ \/> "Error getting billing schedule"))
-      result <- EitherT(tpBackend.suspensionService.addHoliday(newHoliday, oldBS, billCycleDay)).leftMap(getAndLogRefundError(_).map(_.code).list.mkString(","))
+      result <- EitherT(tpBackend.suspensionService.addHoliday(newHoliday, oldBS, billCycleDay, sub.termEndDate)).leftMap(getAndLogRefundError(_).map(_.code).list.mkString(","))
       newBS <- EitherT(tpBackend.commonPaymentService.billingSchedule(sub.id, numberOfBills = 12).map(_ \/> "Error getting billing schedule"))
       newHolidays <- EitherT(tpBackend.suspensionService.getHolidays(sub.name)).leftMap(_ => "Error getting holidays")
       pendingHolidays = pendingHolidayRefunds(newHolidays)

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -20,10 +20,6 @@
     suspendedDays: Int,
     errorCodes: Set[String]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
-@avgPeriodBetweenInvoices = @{
-    val dates = billingSchedule.invoices.list.filter(_.totalGross > 0).map(_.date)
-    Math.floor(Days.daysBetween(dates.head, dates.last).getDays / dates.size)
-}
 @main("Cancel your papers while you're away | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
 
     <main class="page-container gs-container">
@@ -70,7 +66,6 @@
 
             @if((suspendableDays - suspendedDays) > 0) {
                 <section class="mma-section">
-                @if(subscription.plan.charges.billingPeriod == BillingPeriod.month && avgPeriodBetweenInvoices <= 31) {
                     <form class="form js-suspend-form" action="@routes.AccountManagement.processSuspension().url" method="POST" novalidate>
                         <fieldset>
                             <legend class="mma-section__header">
@@ -101,11 +96,6 @@
                         Please give us at least 5 days notice to process the delivery holiday. You can line up to @suspendableWeeks weeks of holidays.<strong>
                         All dates are inclusive</strong>.
                     </span>
-                } else {
-                    <h3 class="mma-section__header">Book a delivery holiday</h3>
-                    <p>Unfortunately you cannot set up a delivery holiday online at the moment. Please call Customer Services on <a class="u-link" href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
-                        or email <a class="u-link" href="mailto:homedelivery@@theguardian.com">homedelivery@@theguardian.com</a>.</p>
-                }
                 </section>
             }
 

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ resolvers ++= Seq(
     "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
     Resolver.sonatypeRepo("releases"))
 
-addCommandAlias("devrun", "run -Dconfig.resource=DEV.conf 9200")
+addCommandAlias("devrun", "run -Dconfig.resource=PROD.conf 9200")
 addCommandAlias("fast-test", "testOnly -- -l Acceptance")
 addCommandAlias("acceptance-test", "testOnly acceptance.CheckoutSpec")
 

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ resolvers ++= Seq(
     "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
     Resolver.sonatypeRepo("releases"))
 
-addCommandAlias("devrun", "run -Dconfig.resource=PROD.conf 9200")
+addCommandAlias("devrun", "run -Dconfig.resource=DEV.conf 9200")
 addCommandAlias("fast-test", "testOnly -- -l Acceptance")
 addCommandAlias("acceptance-test", "testOnly acceptance.CheckoutSpec")
 

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.348",
+    "com.gu" %% "membership-common" % "0.349",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
Fixed the restriction where holiday credit amounts could only be calculated for monthly subscribers. This previously meant quarterly and annual subscribers were advised to call the call centre.

There was a bug in subscriptions frontend where we weren't properly identifying the billing period for Echo Legacy subs which didn't have a paper on one or more days of the week, and instead showed the suspend form rather than the advice message. This meant some quarterly and annual customers could create a holiday suspension and the refund would be for a massive amount! The bug was in the avgPeriodBetweenInvoices method in suspend.scala.html. It should have filtered out invoices with a gross of zero. However rather than doing that fix, this change takes in the latest membership common which now actually calculates the refund correctly, so that restriction/call centre message can now be removed.

Requires: https://github.com/guardian/membership-common/pull/407

cc @johnduffell @jacobwinch @jayceb1 @AWare 