### PR TITLE
extra logging for manage weekly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.345",
+    "com.gu" %% "membership-common" % "0.347-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.347-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.348",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -17,7 +17,7 @@ https://www.playframework.com/documentation/2.4.x/SettingsLogger#Using-a-configu
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%.-30thread] %logger[%file:%L] %highlight(%level: %msg%n%xException{3})</pattern>
+            <pattern>%date %logger[%file:%L] %level: %msg%n%xException</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
This pulls in the updates in https://github.com/guardian/membership-common/pull/406 to convert discounts to tracking promos if they don't apply to the rate plan.

I have also tidied up the logging, tried to make a context sensitive log prefixer using implicits.  I'm not entirely convinced it's the way to go, but I'm putting it out there for a start!  We could possibly apply a similar thing for when we return errors via eithers in lieu of stack traces.  Thoughts would be appreciated!

```
2017-01-18 14:22:26,772 model.SubscriptionOps$EnrichedPaperSubscription[AccountManagement.scala:231] INFO: {sub: A-S00042679} testing if renewable - wontAutoRenew: false, startedAlready: false, isOneOffPlan: true
2017-01-18 14:22:26,772 controllers.ManageWeekly$[AccountManagement.scala:231] INFO: {sub: A-S00042679} sub is not renewable - showing weeklyDetails page
```

@jacobwinch @AWare @paulbrown1982 