### PR TITLE
Display any existing customer account credit balance in the first positive invoice

### DIFF
--- a/app/views/account/fragments/billingSchedule.scala.html
+++ b/app/views/account/fragments/billingSchedule.scala.html
@@ -14,7 +14,7 @@
                 <span class="mma-section__calendar--main">@bill.date.getDayOfMonth</span>
                 <span class="mma-section__calendar--sub">@bill.date.shortMonth</span>
             </div>
-            <p class="mma-section__calendar--amount @bill.isDiscounted("mma-section__calendar--amount--discounted")">
+            <p class="mma-section__calendar--amount @bill.whenDiscounted("mma-section__calendar--amount--discounted")">
               @currency.glyph@bill.amount.currency
             </p>
         </div>

--- a/app/views/support/BillingScheduleOps.scala
+++ b/app/views/support/BillingScheduleOps.scala
@@ -5,6 +5,6 @@ import scalaz.syntax.std.boolean._
 object BillingScheduleOps {
   implicit class InvoiceOps(bill: Bill) {
     def isDiscounted(str: String): Option[String] =
-      bill.items.list.exists(_.amount < 0).option(str)
+      (bill.accountCredit.isDefined || bill.items.list.exists(_.amount < 0)).option(str)
   }
 }

--- a/app/views/support/BillingScheduleOps.scala
+++ b/app/views/support/BillingScheduleOps.scala
@@ -4,7 +4,7 @@ import scalaz.syntax.std.boolean._
 
 object BillingScheduleOps {
   implicit class InvoiceOps(bill: Bill) {
-    def isDiscounted(str: String): Option[String] =
+    def whenDiscounted(str: String): Option[String] =
       (bill.accountCredit.isDefined || bill.items.list.exists(_.amount < 0)).option(str)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.349",
+    "com.gu" %% "membership-common" % "0.350-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.350-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.350",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
Tweaks to use the new billingSchedule API which now takes an account as it applies any existing credit balance to the first positive invoice.

Requires: https://github.com/guardian/membership-common/pull/410

cc @johnduffell @pvighi @jacobwinch @AWare @jayceb1 

![picture 2](https://cloud.githubusercontent.com/assets/1515970/22249418/cf35d994-e23a-11e6-93e4-82f51a30c6fe.png)
