### PR TITLE
Renew weekly one off

### DIFF
--- a/app/views/account/thankYouRenew.scala.html
+++ b/app/views/account/thankYouRenew.scala.html
@@ -3,7 +3,7 @@
 @import views.support.Pricing._
 @import views.support.Dates._
 @import org.joda.time.LocalDate.now
-
+@import com.gu.memsub.OneOffPeriod
 @(plan: SubscriptionPlan.PaperPlan,
   billingSchedule: BillingSchedule,
   touchpointBackendResolution: services.TouchpointBackend.Resolution
@@ -13,7 +13,10 @@
     <main class="page-container gs-container gs-container--slim">
         @fragments.page.header("Thank you", None, List("l-padded"))
         <section class="section-slice section-slice--bleed section-slice--limited">
-            <p>Your Guardian Weekly subscription has been renewed. We will take @plan.charges.prettyPricing(plan.charges.currencies.head) from your account, starting @if(plan.start.isAfter(now)) { @prettyDate(plan.start). } else { today. }</p>
+            <p>Your Guardian Weekly subscription has been renewed. @plan.charges.billingPeriod match {
+                    case _: OneOffPeriod => { We will take a @plan.charges.prettyPricing(plan.charges.currencies.head) from your account. }
+                    case _ => { We will take @plan.charges.prettyPricing(plan.charges.currencies.head) from your account, starting @if(plan.start.isAfter(now)) { @prettyDate(plan.start). } else { today. } }
+            } </p>
         </section>
         <section class="section-slice--bleed section-slice--limited">
             <h3 class="mma-section__header">

--- a/app/views/support/BillingPeriod.scala
+++ b/app/views/support/BillingPeriod.scala
@@ -7,7 +7,7 @@ object BillingPeriod {
       case Month() => "every month"
       case Quarter() => "every 3 months"
       case Year() => "every 12 months"
-      case OneYear() => "One off Payment"
+      case OneYear() => "one off payment"
     }
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.349",
+    "com.gu" %% "membership-common" % "0.350-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.350-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.351",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
Add the option to renew weekly zone A & B into one off plans but don't allow buying them from checkout
needs changes from https://github.com/guardian/membership-common/pull/411
@paulbrown1982 @johnduffell 