### PR TITLE
One off auto renew

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -36,7 +36,7 @@ import scalaz.std.option._
 import scalaz.std.scalaFuture._
 import scalaz.syntax.applicative._
 import scalaz.{NonEmptyList, OptionT}
-
+import model.ContentSubscriptionPlanOps._
 object Checkout extends Controller with LazyLogging with CatalogProvider {
 
   import SessionKeys.{Currency => _, UserId => _, _}
@@ -56,14 +56,12 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
 
     val matchingPlanList: Option[PlanList[CatalogPlan.ContentSubscription]] = {
 
-      def oneOffPlan(plan: CatalogPlan[_, PaidCharge[_, BillingPeriod], _]) = plan.charges.billingPeriod.isInstanceOf[OneOffPeriod]
-
-      val testOnlyPlans = if (tpBackend == TouchpointBackend.Test) List(catalog.weeklyZoneB.toList.filterNot(oneOffPlan)) else List.empty
+      val testOnlyPlans = if (tpBackend == TouchpointBackend.Test) List(catalog.weeklyZoneB.toList.filter(_.isRecurring)) else List.empty
 
       val contentSubscriptionPlans = List(
         catalog.delivery.list,
         catalog.voucher.list,
-        catalog.weeklyZoneA.toList.filterNot(oneOffPlan),
+        catalog.weeklyZoneA.toList.filter(_.isRecurring),
         catalog.weeklyZoneC.toList,
         catalog.digipack.toList) ++ testOnlyPlans
 

--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -27,9 +27,7 @@ class SubscriptionsForm(catalog: Catalog) {
 
   implicit val pf2 = new Formatter[CatalogPlan.Paper] {
 
-    def oneOffPlan(plan: CatalogPlan[_, PaidCharge[_, BillingPeriod], _]) = plan.charges.billingPeriod.isInstanceOf[OneOffPeriod]
-
-    val validPlans = catalog.delivery.list ++ catalog.voucher.list ++ catalog.weeklyZoneA.toList.filterNot(oneOffPlan) ++ catalog.weeklyZoneB.toList.filterNot(oneOffPlan) ++ catalog.weeklyZoneC.toList
+    val validPlans = catalog.delivery.list ++ catalog.voucher.list ++ catalog.weeklyZoneA.toList.filter(_.isRecurring) ++ catalog.weeklyZoneB.toList.filter(_.isRecurring) ++ catalog.weeklyZoneC.toList
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], CatalogPlan.Paper] =
       data.get(key).map(ProductRatePlanId).flatMap(prpId => validPlans.find(_.id == prpId)).toRight(Seq(FormError(key, "Bad plan")))
     override def unbind(key: String, value: CatalogPlan.Paper): Map[String, String] =

--- a/app/model/BillingPeriodOps.scala
+++ b/app/model/BillingPeriodOps.scala
@@ -1,0 +1,14 @@
+package model
+
+import com.gu.memsub.{BillingPeriod, RecurringPeriod}
+
+object BillingPeriodOps {
+
+  implicit class EnrichedBillingPeriod(in: BillingPeriod) {
+    def isRecurring = in match {
+      case _: RecurringPeriod => true
+      case _ => false
+    }
+  }
+
+}

--- a/app/model/ContentSubscriptionPlanOps.scala
+++ b/app/model/ContentSubscriptionPlanOps.scala
@@ -49,7 +49,7 @@ object ContentSubscriptionPlanOps {
       }
     }
 
-    def isRecurring =  in.charges.billingPeriod.isRecurring
+    def isRecurring: Boolean = in.charges.billingPeriod.isRecurring
 
   }
 

--- a/app/model/ContentSubscriptionPlanOps.scala
+++ b/app/model/ContentSubscriptionPlanOps.scala
@@ -5,7 +5,7 @@ import Currency._
 import com.gu.memsub.Product
 import com.gu.memsub.subsv2.CatalogPlan
 import views.support.CountryWithCurrency
-
+import model.BillingPeriodOps._
 
 object ContentSubscriptionPlanOps {
   val weeklyUkCountries = CountryGroup.UK.copy(
@@ -48,6 +48,9 @@ object ContentSubscriptionPlanOps {
         case Product.WeeklyZoneC => LocalizationSettings(Some(CountryWithCurrency.whitelisted(supportedCurrencies, USD, weeklyZoneCGroups)), allCountriesWithCurrencyOrGBP)
       }
     }
+
+    def isRecurring =  in.charges.billingPeriod.isRecurring
+
   }
 
 }

--- a/app/model/SubscriptionOps.scala
+++ b/app/model/SubscriptionOps.scala
@@ -42,7 +42,7 @@ object SubscriptionOps extends LazyLogging {
     val renewable = {
       val wontAutoRenew = !subscription.autoRenew
       val startedAlready = !subscription.termStartDate.isAfter(now)
-      val isOneOffPlan = subscription.planToManage.charges.billingPeriod.isRecurring
+      val isOneOffPlan = !subscription.planToManage.charges.billingPeriod.isRecurring
       info(s"testing if renewable - wontAutoRenew: $wontAutoRenew, startedAlready: $startedAlready, isOneOffPlan: $isOneOffPlan")
       wontAutoRenew && startedAlready && isOneOffPlan
     }

--- a/app/model/SubscriptionOps.scala
+++ b/app/model/SubscriptionOps.scala
@@ -7,7 +7,7 @@ import com.github.nscala_time.time.OrderingImplicits._
 import com.typesafe.scalalogging.LazyLogging
 import controllers.ContextLogging
 import org.joda.time.LocalDate.now
-
+import model.BillingPeriodOps._
 object SubscriptionOps extends LazyLogging {
 
   type WeeklyPlanOneOff = PaidSubscriptionPlan[Product.Weekly, PaidCharge[Weekly.type, OneOffPeriod]]
@@ -42,7 +42,7 @@ object SubscriptionOps extends LazyLogging {
     val renewable = {
       val wontAutoRenew = !subscription.autoRenew
       val startedAlready = !subscription.termStartDate.isAfter(now)
-      val isOneOffPlan = subscription.planToManage.charges.billingPeriod.isInstanceOf[OneOffPeriod]
+      val isOneOffPlan = subscription.planToManage.charges.billingPeriod.isRecurring
       info(s"testing if renewable - wontAutoRenew: $wontAutoRenew, startedAlready: $startedAlready, isOneOffPlan: $isOneOffPlan")
       wontAutoRenew && startedAlready && isOneOffPlan
     }

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -275,8 +275,6 @@ class CheckoutService(identityService: IdentityService,
     val customerAcceptance = contractEffective
 
     def addPlan(contact: Contact) = {
-
-
       val newRatePlan = RatePlan(renewal.plan.id.get, None)
 
       val renewCommand = Renew(

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -285,7 +285,11 @@ class CheckoutService(identityService: IdentityService,
         contractEffectiveDate = contractEffective,
         customerAcceptanceDate = customerAcceptance,
         promoCode = None,
-        autoRenew = renewal.plan.charges.billingPeriod.isInstanceOf[RecurringPeriod])
+        autoRenew = renewal.plan.charges.billingPeriod match {
+          case _: RecurringPeriod => true
+          case _ => false
+        }
+      )
 
       val validPromotion = for {
         code <- renewal.promoCode.withLogging("promo code from client")

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -32,7 +32,7 @@ import scalaz.std.option._
 import scalaz.std.scalaFuture._
 import scalaz.syntax.monad._
 import scalaz.{EitherT, Monad, NonEmptyList, OptionT, \/}
-import views.support.BillingPeriod._
+import model.BillingPeriodOps._
 
 object CheckoutService {
   def paymentDelay(in: Either[PaperData, DigipackData], zuora: ZuoraProperties)(implicit now: LocalDate): Days = in.fold(

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -32,7 +32,7 @@ import scalaz.std.option._
 import scalaz.std.scalaFuture._
 import scalaz.syntax.monad._
 import scalaz.{EitherT, Monad, NonEmptyList, OptionT, \/}
-
+import views.support.BillingPeriod._
 
 object CheckoutService {
   def paymentDelay(in: Either[PaperData, DigipackData], zuora: ZuoraProperties)(implicit now: LocalDate): Days = in.fold(
@@ -285,10 +285,7 @@ class CheckoutService(identityService: IdentityService,
         contractEffectiveDate = contractEffective,
         customerAcceptanceDate = customerAcceptance,
         promoCode = None,
-        autoRenew = renewal.plan.charges.billingPeriod match {
-          case _: RecurringPeriod => true
-          case _ => false
-        }
+        autoRenew = renewal.plan.charges.billingPeriod.isRecurring
       )
 
       val validPromotion = for {

--- a/app/views/support/BillingPeriod.scala
+++ b/app/views/support/BillingPeriod.scala
@@ -9,14 +9,5 @@ object BillingPeriod {
       case Year() => "every 12 months"
       case OneYear() => "one off payment"
     }
-
-    def isRecurring = billingPeriod match {
-      case _: RecurringPeriod => true
-      case _ => false
-    }
-
   }
-
-
-
 }

--- a/app/views/support/BillingPeriod.scala
+++ b/app/views/support/BillingPeriod.scala
@@ -1,5 +1,5 @@
 package views.support
-import com.gu.memsub.{Month, OneYear, Quarter, RecurringPeriod, Year, BillingPeriod => BP}
+import com.gu.memsub.{Year, Quarter, Month,OneYear, BillingPeriod => BP}
 
 object BillingPeriod {
   implicit class BillingPeriodOps(billingPeriod: BP)  {

--- a/app/views/support/BillingPeriod.scala
+++ b/app/views/support/BillingPeriod.scala
@@ -1,5 +1,5 @@
 package views.support
-import com.gu.memsub.{Year, Quarter, Month,OneYear, BillingPeriod => BP}
+import com.gu.memsub.{Month, OneYear, Quarter, RecurringPeriod, Year, BillingPeriod => BP}
 
 object BillingPeriod {
   implicit class BillingPeriodOps(billingPeriod: BP)  {
@@ -9,5 +9,14 @@ object BillingPeriod {
       case Year() => "every 12 months"
       case OneYear() => "one off payment"
     }
+
+    def isRecurring = billingPeriod match {
+      case _: RecurringPeriod => true
+      case _ => false
+    }
+
   }
+
+
+
 }

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.351",
+    "com.gu" %% "membership-common" % "0.353-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.353-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.353",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",


### PR DESCRIPTION
When renewing a weekly subscription, don't set it to autoRenew unless the plan we are renewing it to is recurring.
This PR also has some small refactoring to remove duplication and avoid using isInstanceOf in every place of the code we checked if a plan is one off or recurring 
@johnduffell @paulbrown1982 @jacobwinch 