### PR TITLE
Use the new wildcard cert for *.thegulocal.com, clean up Nginx config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,27 @@
 # Subscriptions frontend
 
-### NGinx
+## NGinx
 
-   To run standalone you can use the default nginx installation as follows:
+#### Setup Nginx for `Identity-Platform`
 
-   Install nginx:
-
-   Mac OSX: `brew install nginx`
-
-   Make sure you have a sites-enabled folder under your nginx home. This should be
-
-   Mac OSX: `~/Developers/etc/nginx/sites-enabled` or `/usr/local/etc/nginx/`
-   Make sure your nginx.conf (found in your nginx home) contains the following line in the `http{...}` block: `include sites-enabled/*`;
-
-	Get Janus credentials for subscription so you can download the nginx keys.
+Subscriptions depends on Nginx config and SSL certs from Identity, so you'll need to perform the
+[Nginx setup for identity-platform](https://github.com/guardian/identity-platform/blob/master/README.md#setup-nginx-for-local-development)
+first, before you do anything else.
 
    Run: `./nginx/setup.sh` and enter your password where prompted.
+
+#### Run Subscription's Nginx setup script
+
+Run the Subscription-specific [setup.sh](nginx/setup.sh) script from the root
+of the `subscriptions-frontend` project:
+
+```
+./nginx/setup.sh
+```
+
+The script doesn't start Nginx. To manually start it run `sudo nginx` or `sudo systemctl start nginx`
+depending on your system.
+
 
 ## General Setup
 

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,18 +1,9 @@
 #!/bin/bash
 
-GU_KEYS="${HOME}/.gu/keys"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NGINX_HOME=$(nginx -V 2>&1 | grep 'configure arguments:' | sed 's#.*conf-path=\([^ ]*\)/nginx\.conf.*#\1#g')
 
-echo this script needs root access and membership AWS credentials
-echo configuring nginx, please enter your sudo password if prompted
+echo this script needs root access to configure nginx, please enter your sudo password if prompted
 sudo mkdir -p $NGINX_HOME/sites-enabled
 sudo ln -fs $DIR/subscribe.conf $NGINX_HOME/sites-enabled/subscribe.conf
 
-aws s3 cp s3://identity-local-ssl/sub-thegulocal-com-exp2017-03-31-bundle.crt ${GU_KEYS}/ --profile membership
-aws s3 cp s3://identity-local-ssl/sub-thegulocal-com-exp2017-03-31.key ${GU_KEYS}/ --profile membership
-sudo ln -fs ${GU_KEYS}/ $NGINX_HOME/keys
-
-sudo nginx -s stop
-sleep 1
-sudo nginx

--- a/nginx/subscribe.conf
+++ b/nginx/subscribe.conf
@@ -12,8 +12,8 @@ server {
     server_name sub.thegulocal.com;
 
     ssl on;
-    ssl_certificate keys/sub-thegulocal-com-exp2017-03-31-bundle.crt;
-    ssl_certificate_key keys/sub-thegulocal-com-exp2017-03-31.key;
+    ssl_certificate wildcard-thegulocal-com-exp2019-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
+    ssl_certificate_key wildcard-thegulocal-com-exp2019-01-09.key; ## ditto
 
     ssl_session_timeout 5m;
 


### PR DESCRIPTION
Relying on the new CA-signed wildcard-cert that's provided by https://github.com/guardian/identity-platform/pull/149 means we can delete some code - there's no point in us having different certificates for our dev environment, and this matches the approach used in Membership, reducing some of the setup cost if you're working on both projects.

This is a repeat for Subs of these two Membership PRs:

* https://github.com/guardian/membership-frontend/pull/1441
* https://github.com/guardian/membership-frontend/pull/1447

cc @paulbrown1982 @mario-galic @AWare 
