### PR TITLE
Shorten holiday delivery lead time from 5 days to 3

### DIFF
--- a/app/monitoring/Metrics.scala
+++ b/app/monitoring/Metrics.scala
@@ -1,11 +1,9 @@
 package monitoring
 
-import com.amazonaws.regions.{Region, Regions}
 import com.gu.monitoring.CloudWatch
 import configuration.Config
 
 trait Metrics extends CloudWatch {
-  val region = Region.getRegion(Regions.EU_WEST_1)
   val stage = Config.stage
   val application = Config.appName
 }

--- a/app/views/account/suspend.scala.html
+++ b/app/views/account/suspend.scala.html
@@ -93,7 +93,7 @@
                         </fieldset>
                     </form>
                     <span class="mma-dates__request">
-                        Please give us at least 5 days notice to process the delivery holiday. You can line up to @suspendableWeeks weeks of holidays.<strong>
+                        Please give us at least 3 days notice to process the delivery holiday. You can line up to @suspendableWeeks weeks of holidays.<strong>
                         All dates are inclusive</strong>.
                     </span>
                 </section>

--- a/app/views/fragments/checkout/fieldsDelivery.scala.html
+++ b/app/views/fragments/checkout/fieldsDelivery.scala.html
@@ -25,7 +25,7 @@
             <label class="label" for="address-town">@firstPaperLabel</label>
             <div id="deliveryDatePicker" class="form-field__react-datepicker"></div>
         </div>
-        <input type="hidden" name="delivered-product" value=@productName disabled>
+        <input type="hidden" name="delivered-product" value="@productName" disabled>
         <input type="hidden" name="voucher" value="false">
         <input type="hidden" name="digipack" value="false">
     </div>

--- a/app/views/support/BillingScheduleOps.scala
+++ b/app/views/support/BillingScheduleOps.scala
@@ -5,6 +5,6 @@ import scalaz.syntax.std.boolean._
 object BillingScheduleOps {
   implicit class InvoiceOps(bill: Bill) {
     def whenDiscounted(str: String): Option[String] =
-      (bill.accountCredit.exists(_ > 0) || bill.items.list.exists(_.amount < 0)).option(str)
+      (bill.accountCredit.isDefined|| bill.items.list.exists(_.amount < 0)).option(str)
   }
 }

--- a/assets/javascripts/modules/checkout/deliveryFields.jsx
+++ b/assets/javascripts/modules/checkout/deliveryFields.jsx
@@ -10,7 +10,7 @@ import reviewDetails from './reviewDetails'
 
 require('react-datepicker/dist/react-datepicker.css');
 
-const NUMBER_OF_DAYS_IN_ADVANCE = 5;
+const NUMBER_OF_DAYS_IN_ADVANCE = 3;
 const MAX_WEEKS_AVAILABLE = 4;
 
 function getFirstSelectableDate(filterFn) {

--- a/assets/javascripts/modules/suspend/suspendFields.jsx
+++ b/assets/javascripts/modules/suspend/suspendFields.jsx
@@ -9,7 +9,7 @@ import moment from 'moment'
 require('react-datepicker/dist/react-datepicker.css');
 
 const DATE_PATTERN = 'D MMMM YYYY';
-const LEAD_TIME = moment().add(2, 'days');
+const LEAD_TIME = moment().add(3, 'days');
 const LAST_START_DATE = moment().add(1, 'year');
 const MAX_WEEKS = 6;
 
@@ -45,7 +45,7 @@ export default {
         const container = document.getElementById(formElements.SUSPEND_DATE_PICKER_ID);
         if (!container) { return; }
 
-        var firstSelectableDate = getFirstSelectableDate(container.getAttribute('firstPaymentDate')),
+        const firstSelectableDate = getFirstSelectableDate(container.getAttribute('firstPaymentDate')),
             remainingDays = parseInt(container.getAttribute('remainingDays'), 10),
             filterDateFn = filterDate(container.getAttribute('ratePlanName'), container.getAttribute('excludeExistingDays'));
 

--- a/assets/javascripts/modules/suspend/suspendFields.jsx
+++ b/assets/javascripts/modules/suspend/suspendFields.jsx
@@ -9,7 +9,7 @@ import moment from 'moment'
 require('react-datepicker/dist/react-datepicker.css');
 
 const DATE_PATTERN = 'D MMMM YYYY';
-const LEAD_TIME = moment().add(5, 'days');
+const LEAD_TIME = moment().add(2, 'days');
 const LAST_START_DATE = moment().add(1, 'year');
 const MAX_WEEKS = 6;
 

--- a/assets/javascripts/modules/suspend/suspendFields.jsx
+++ b/assets/javascripts/modules/suspend/suspendFields.jsx
@@ -9,14 +9,14 @@ import moment from 'moment'
 require('react-datepicker/dist/react-datepicker.css');
 
 const DATE_PATTERN = 'D MMMM YYYY';
-const LEAD_TIME = moment().add(3, 'days');
+const LEAD_TIME = moment().add(3, 'days').startOf('day'); // might be as short as 2 days and 1 second in the future!
 const LAST_START_DATE = moment().add(1, 'year');
 const MAX_WEEKS = 6;
 
 function getFirstSelectableDate(firstPaymentDate) {
     if (firstPaymentDate) {
         const firstPaymentMoment = moment(firstPaymentDate, DATE_PATTERN);
-        if (firstPaymentMoment.isAfter(LEAD_TIME)) {
+        if (firstPaymentMoment.isSameOrAfter(LEAD_TIME)) {
             return firstPaymentMoment;
         }
     }


### PR DESCRIPTION
Actually we could have set it to 2 but bank holidays require 3 so rather than have a confusing message, we'll just set it at 3.

Also updated to latest membership common and removed the workaround to the green boxes in https://github.com/guardian/subscriptions-frontend/pull/776

cc @johnduffell @jacobwinch @pvighi @AWare @jayceb1 