### PR TITLE
Fix TestUser sensitivity to clock drift which had been throwing exceptions

### DIFF
--- a/app/utils/TestUsers.scala
+++ b/app/utils/TestUsers.scala
@@ -1,6 +1,7 @@
 package utils
 
-import com.github.nscala_time.time.Imports._
+import java.time.Duration.ofDays
+
 import com.gu.identity.play.IdMinimalUser
 import com.gu.identity.testing.usernames.TestUsernames
 import configuration.Config
@@ -11,11 +12,11 @@ import services.AuthenticationService.authenticatedUserFor
 
 object TestUsers {
 
-  val ValidityPeriod = 2.days
+  val ValidityPeriod = ofDays(2)
 
   lazy val testUsers = TestUsernames(
     com.gu.identity.testing.usernames.Encoder.withSecret(Config.Identity.testUsersSecret),
-    recency = ValidityPeriod.standardDuration
+    recency = ValidityPeriod
   )
 
   private def isTestUser(username: String): Boolean = TestUsers.testUsers.isValid(username)

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ libraryDependencies ++= Seq(
     PlayImport.specs2,
     "com.gu" %% "membership-common" % "0.353",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
+    "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",

--- a/test/acceptance/util/TestUser.scala
+++ b/test/acceptance/util/TestUser.scala
@@ -1,12 +1,13 @@
 package acceptance.util
 
-import com.github.nscala_time.time.Imports._
+import java.time.Duration.ofDays
+
 import com.gu.identity.testing.usernames.TestUsernames
 
 class TestUser {
   private val testUsers = TestUsernames(
     com.gu.identity.testing.usernames.Encoder.withSecret(Config.testUsersSecret),
-    recency = 2.days.standardDuration
+    recency = ofDays(2)
   )
 
   private def addTestUserCookies(testUsername: String) = {


### PR DESCRIPTION
The acceptance tests were intermittently failing - this was happened when the TestUser token was stamped with a time ahead of the clock time on the `subscriptions-frontend` appserver.

    "IllegalArgumentException: The end instant must be greater the start"

See https://github.com/guardian/identity-test-users/commit/410a7fec for the details of the fix, and accompanying tests that check for tolerance of clock drift.

I noticed this problem with https://github.com/guardian/subscriptions-frontend/pull/781#issuecomment-276336674, but [looking at Sentry](https://sentry.io/the-guardian/subscriptions/issues/181087071/events/4866537246/) there are quite a few errors of this format.

cc @jacobwinch 
