### PR TITLE
pass through the promo code for renewal logins

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -309,8 +309,8 @@ object AccountManagement extends Controller with ContextLogging with CatalogProv
     val loginRequest = AccountManagementLoginForm.mappings.bindFromRequest().value
     val promoCode = loginRequest.flatMap(_.promoCode).map(NormalisedPromoCode.safeFromString)
     subscriptionFromUserDetails(loginRequest).map {
-        case Some(sub) => SessionSubscription.set(Redirect(routes.AccountManagement.manage(None,None,promoCode)), sub)
-        case _ => Redirect(routes.AccountManagement.manage(None, None,None)).flashing(
+        case Some(sub) => SessionSubscription.set(Redirect(routes.AccountManagement.manage(None, None, promoCode)), sub)
+        case _ => Redirect(routes.AccountManagement.manage(None, None, promoCode)).flashing(
           "error" -> "Unable to verify your details."
         )
     }

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -89,7 +89,7 @@
                                     @fragments.forms.errorMessage("This field is required")
                                 </div>
                                 @promoCode.map{promo=>
-                                    <input type="hidden" value="@promo" name="promoCode"/>
+                                    <input type="hidden" value="@promo.get" name="promoCode"/>
                                 }
                                 @if(flash.get("error").isDefined) {
                                     <div class="form-field__error-message-visible">@flash.get("error")</div>


### PR DESCRIPTION
When someone logs in to manage my account with a promo code already in the url, we need to pass that through into the renew field.
This adds the remaining links in the chain to make that work correctly.
after typing in log in details...
![image](https://cloud.githubusercontent.com/assets/7304387/22470256/94aa4710-e7c6-11e6-9c0f-fd1e9f78c08b.png)

@pvighi @paulbrown1982 