### PR TITLE
use membership common that understands the free id

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -7,8 +7,8 @@ import com.gu.identity.play.ProxiedIP
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.promo.Promotion._
 import com.gu.memsub.promo.{NewUsers, NormalisedPromoCode, PromoCode}
-import com.gu.memsub.subsv2.{CatalogPlan, PaidCharge}
-import com.gu.memsub.{BillingPeriod, OneOffPeriod, Product, SupplierCode}
+import com.gu.memsub.subsv2.CatalogPlan
+import com.gu.memsub.{Product, SupplierCode}
 import com.gu.zuora.soap.models.errors._
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config.Identity.webAppProfileUrl
@@ -36,7 +36,6 @@ import scalaz.std.option._
 import scalaz.std.scalaFuture._
 import scalaz.syntax.applicative._
 import scalaz.{NonEmptyList, OptionT}
-import model.ContentSubscriptionPlanOps._
 object Checkout extends Controller with LazyLogging with CatalogProvider {
 
   import SessionKeys.{Currency => _, UserId => _, _}

--- a/app/model/BillingPeriodOps.scala
+++ b/app/model/BillingPeriodOps.scala
@@ -1,6 +1,7 @@
 package model
 
-import com.gu.memsub.{BillingPeriod, RecurringPeriod}
+import com.gu.memsub.BillingPeriod
+import com.gu.memsub.BillingPeriod.RecurringPeriod
 
 object BillingPeriodOps {
 

--- a/app/model/SubscriptionOps.scala
+++ b/app/model/SubscriptionOps.scala
@@ -1,9 +1,10 @@
 package model
 
-import com.gu.memsub.{OneOffPeriod, Product, Weekly}
+import com.gu.memsub.{Product, Weekly}
 import com.gu.memsub.subsv2.{PaidCharge, PaidSubscriptionPlan, Subscription}
 import com.gu.memsub.subsv2.SubscriptionPlan.{Paid, PaperPlan, WeeklyPlan}
 import com.github.nscala_time.time.OrderingImplicits._
+import com.gu.memsub.BillingPeriod.OneOffPeriod
 import com.typesafe.scalalogging.LazyLogging
 import controllers.ContextLogging
 import org.joda.time.LocalDate.now

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -2,13 +2,13 @@ package services
 
 import com.github.nscala_time.time.OrderingImplicits._
 import com.gu.config.DiscountRatePlanIds
-import com.gu.i18n.{Country, CountryGroup}
 import com.gu.i18n.Currency.GBP
+import com.gu.i18n.{Country, CountryGroup}
 import com.gu.identity.play.{AuthenticatedIdUser, IdMinimalUser}
 import com.gu.memsub.promo._
 import com.gu.memsub.services.{GetSalesforceContactForSub, PromoService, PaymentService => CommonPaymentService}
-import com.gu.memsub.subsv2.{Catalog, Subscription, SubscriptionPlan}
-import com.gu.memsub.{Address, Product, RecurringPeriod}
+import com.gu.memsub.subsv2.{Catalog, Subscription}
+import com.gu.memsub.{Address, Product}
 import com.gu.salesforce.{Contact, ContactId}
 import com.gu.stripe.Stripe
 import com.gu.zuora.api.ZuoraService
@@ -17,13 +17,14 @@ import com.gu.zuora.soap.models.Queries
 import com.gu.zuora.soap.models.Results.SubscribeResult
 import com.gu.zuora.soap.models.errors._
 import com.typesafe.scalalogging.LazyLogging
+import model.BillingPeriodOps._
 import model.SubscriptionOps._
-import model.{Renewal, _}
 import model.error.CheckoutService._
 import model.error.IdentityService._
 import model.error.SubsError
+import model.{Renewal, _}
 import org.joda.time.LocalDate.now
-import org.joda.time.{DateTimeConstants, Days, LocalDate}
+import org.joda.time.{Days, LocalDate}
 import touchpoint.ZuoraProperties
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -31,8 +32,7 @@ import scala.concurrent.Future
 import scalaz.std.option._
 import scalaz.std.scalaFuture._
 import scalaz.syntax.monad._
-import scalaz.{EitherT, Monad, NonEmptyList, OptionT, \/}
-import model.BillingPeriodOps._
+import scalaz.{EitherT, Monad, NonEmptyList, \/}
 
 object CheckoutService {
   def paymentDelay(in: Either[PaperData, DigipackData], zuora: ZuoraProperties)(implicit now: LocalDate): Days = in.fold(

--- a/app/views/account/thankYouRenew.scala.html
+++ b/app/views/account/thankYouRenew.scala.html
@@ -3,7 +3,7 @@
 @import views.support.Pricing._
 @import views.support.Dates._
 @import org.joda.time.LocalDate.now
-@import com.gu.memsub.OneOffPeriod
+@import com.gu.memsub.BillingPeriod.OneOffPeriod
 @(plan: SubscriptionPlan.PaperPlan,
   billingSchedule: BillingSchedule,
   touchpointBackendResolution: services.TouchpointBackend.Resolution

--- a/app/views/fragments/promotion/digipack.scala.html
+++ b/app/views/fragments/promotion/digipack.scala.html
@@ -1,9 +1,9 @@
 @import com.gu.memsub.subsv2.CatalogPlan
-@import com.gu.memsub.Month
+@import com.gu.memsub.BillingPeriod.Month
 @import com.gu.memsub.promo.PromoCode
 @import model.DigitalEdition
 
-@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month], promoCode: PromoCode, roundelHtml: Option[String])
+@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month.type], promoCode: PromoCode, roundelHtml: Option[String])
 <div class="digipack">
     <div class="grid grid--3up-step-phablet grid--flex grid--no-clearfix-before">
         <div class="grid__item grid__item--flex-2-columns grid__item--flex-wrapped">

--- a/app/views/fragments/promotion/discover.scala.html
+++ b/app/views/fragments/promotion/discover.scala.html
@@ -1,10 +1,10 @@
 @import com.gu.memsub.promo.PromoCode
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import com.gu.memsub.subsv2.CatalogPlan
-@import com.gu.memsub.Month
+@import com.gu.memsub.BillingPeriod.Month
 @import model.DigitalEdition
 
-@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month], promoCode: PromoCode, promotion: AnyPromotion)
+@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month.type], promoCode: PromoCode, promotion: AnyPromotion)
 <div>
     <div class="digital-tablet-previews hide-above-phablet">
         <img src="@controllers.CachedAssets.hashedPathFor("images/backgrounds/bg-digital-tablet-previews.jpg")"/>

--- a/app/views/fragments/promotion/pricingCta.scala.html
+++ b/app/views/fragments/promotion/pricingCta.scala.html
@@ -1,12 +1,12 @@
 @import com.gu.memsub.promo.PromoCode
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import com.gu.memsub.subsv2.CatalogPlan
-@import com.gu.memsub.Month
+@import com.gu.memsub.BillingPeriod.Month
 @import model.DigitalEdition
 @import views.support.Catalog._
 @import configuration.Config.Zuora.paymentDelay
 
-@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month], promoCode: PromoCode, promotion: AnyPromotion)
+@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month.type], promoCode: PromoCode, promotion: AnyPromotion)
 <div class="pricing-cta">
     <div class="pricing-cta__pricing">
         <h4 class="pricing-cta__pricing__title">Free for @promotion.asFreeTrial.fold(paymentDelay.getDays)(_.promotionType.duration.getDays) days</h4>

--- a/app/views/fragments/promotion/promotionCta.scala.html
+++ b/app/views/fragments/promotion/promotionCta.scala.html
@@ -1,10 +1,10 @@
 @import com.gu.memsub.promo.PromoCode
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import com.gu.memsub.subsv2.CatalogPlan
-@import com.gu.memsub.Month
+@import com.gu.memsub.BillingPeriod.Month
 @import model.DigitalEdition
 @import org.joda.time.Days
-@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month], promoCode: PromoCode, promotion: AnyPromotion)
+@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month.type], promoCode: PromoCode, promotion: AnyPromotion)
 <div class="promotion-cta">
     <div class="grid grid--3up-step-phablet grid--flex">
         <div class="grid__item grid__item--flex-2-columns">

--- a/app/views/support/BillingPeriod.scala
+++ b/app/views/support/BillingPeriod.scala
@@ -1,13 +1,14 @@
 package views.support
-import com.gu.memsub.{Year, Quarter, Month,OneYear, BillingPeriod => BP}
+import com.gu.memsub.BillingPeriod._
+import com.gu.memsub.{BillingPeriod => BP}
 
 object BillingPeriod {
   implicit class BillingPeriodOps(billingPeriod: BP)  {
     def frequencyInMonths = billingPeriod match {
-      case Month() => "every month"
-      case Quarter() => "every 3 months"
-      case Year() => "every 12 months"
-      case OneYear() => "one off payment"
+      case Month => "every month"
+      case Quarter => "every 3 months"
+      case Year => "every 12 months"
+      case OneYear => "one off payment"
     }
   }
 }

--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -5,6 +5,7 @@ import com.gu.i18n.Currency.GBP
 import com.gu.memsub.promo.PercentDiscount.getDiscountScaledToPeriod
 import com.gu.memsub.promo.{LandingPage, PercentDiscount, Promotion}
 import com.gu.memsub.{BillingPeriod => BP, _}
+import BP._
 import com.gu.memsub.subsv2._
 import views.support.BillingPeriod._
 import views.support.PlanOps._
@@ -34,28 +35,28 @@ object Pricing {
         s"${discountAmount.pretty} ${plan.billingPeriod.frequencyInMonths}"
       } { durationMonths =>
         plan.billingPeriod match {
-          case m: Month =>
+          case Month =>
             val span = durationMonths
             if (span > 1) {
               s"${discountAmount.pretty} for $span months, then ${originalAmount.pretty} every month thereafter"
             } else {
               s"${discountAmount.pretty} for 1 month, then ${originalAmount.pretty} every month thereafter"
             }
-          case q: Quarter =>
-            val span = getDiscountScaledToPeriod(discountPromo.promotionType, q)._2
+          case Quarter =>
+            val span = getDiscountScaledToPeriod(discountPromo.promotionType, Quarter)._2
             if (span > 1) {
               s"${discountAmount.pretty} for ${span.toInt} quarters, then ${originalAmount.pretty} every quarter thereafter"
             } else {
               s"${discountAmount.pretty} for 1 quarter, then ${originalAmount.pretty} every quarter thereafter"
             }
-          case y: Year =>
-            val span = getDiscountScaledToPeriod(discountPromo.promotionType, y)._2
+          case Year =>
+            val span = getDiscountScaledToPeriod(discountPromo.promotionType, Year)._2
             if (span > 1) {
               s"${discountAmount.pretty} for ${span.toInt} years, then ${originalAmount.pretty} every year thereafter"
             } else {
               s"${discountAmount.pretty} for 1 year, then ${originalAmount.pretty} every year thereafter"
             }
-          case oneYear: OneYear => s"${discountAmount.pretty} for 1 year"
+          case OneYear => s"${discountAmount.pretty} for 1 year"
 
         }
       }

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.359",
+    "com.gu" %% "membership-common" % "0.360-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.358",
+    "com.gu" %% "membership-common" % "0.359",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.360-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.360",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/test/services/CheckoutServiceTest.scala
+++ b/test/services/CheckoutServiceTest.scala
@@ -28,7 +28,7 @@ class CheckoutServiceTest extends Specification {
     id = ProductRatePlanId("p"),
     name = "name",
     description = "desc",
-    charges = PaidCharge(Digipack, BillingPeriod.month, PricingSummary(Map.empty)),
+    charges = PaidCharge(Digipack, BillingPeriod.Month, PricingSummary(Map.empty)),
     product = Product.Digipack,
     saving = None,
     s = Status.current


### PR DESCRIPTION
https://github.com/guardian/membership-common/pull/423 understand free id
edit:
https://github.com/guardian/membership-common/pull/424 don't read the untagged rateplans
https://github.com/guardian/membership-common/pull/425 use billing period as an object not a case class