### PR TITLE
Create an "current offers" page and better handling for tracking codes

### DIFF
--- a/app/controllers/DigitalPack.scala
+++ b/app/controllers/DigitalPack.scala
@@ -7,7 +7,6 @@ import model.DigitalEdition._
 import play.api.mvc._
 import services.TouchpointBackend
 import utils.RequestCountry._
-import views.support.Pricing._
 
 object DigitalPack extends Controller {
 
@@ -20,12 +19,11 @@ object DigitalPack extends Controller {
     redirectResult(digitalEdition)
   }
 
-  def landingPage(code: String) = CachedAction { implicit request =>
-    getById(code).fold(redirectResult(INT)) { digitalEdition =>
-      val plan = TouchpointBackend.Normal.catalogService.unsafeCatalog.digipack.month
-      val price = plan.charges.price.getPrice(digitalEdition.countryGroup.currency).getOrElse(plan.charges.gbpPrice)
-      Ok(views.html.digitalpack.info(digitalEdition, price))
-    }
+  def landingPage(code: String) = CachedAction { _ =>
+    val digitalEdition = getById(code).getOrElse(INT)
+    val plan = TouchpointBackend.Normal.catalogService.unsafeCatalog.digipack.month
+    val price = plan.charges.price.getPrice(digitalEdition.countryGroup.currency).getOrElse(plan.charges.gbpPrice)
+    Ok(views.html.digitalpack.info(digitalEdition, price))
   }
 
 }

--- a/app/controllers/Offers.scala
+++ b/app/controllers/Offers.scala
@@ -1,0 +1,25 @@
+package controllers
+
+import actions.CommonActions.{CachedAction, NoCacheAction}
+import com.gu.i18n.CountryGroup
+import model.DigitalEdition.{INT, UK, getById}
+import play.api.mvc.Controller
+import utils.RequestCountry._
+
+object Offers extends Controller {
+
+  def offers = NoCacheAction { implicit request =>
+    val countryGroup = request.getFastlyCountryGroup.getOrElse(CountryGroup.UK)
+    val digitalEdition = getById(countryGroup.id).getOrElse(INT)
+    Redirect(routes.Offers.offersPage(digitalEdition.id).url, request.queryString, SEE_OTHER)
+  }
+
+  def offersPage(edition: String) = CachedAction {
+    getById(edition) map {
+      case UK => Ok(views.html.offers.offers_uk())
+      case digitalEdition => Ok(views.html.offers.offers_international(digitalEdition))
+    } getOrElse {
+      NotFound(views.html.error404())
+    }
+  }
+}

--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -1,13 +1,16 @@
 package controllers
 import actions.CommonActions._
 import com.gu.i18n.{Country, CountryGroup}
+import com.gu.i18n.Country
+import com.gu.memsub.Digipack
 import com.gu.memsub.promo.Formatters.PromotionFormatters._
 import com.gu.memsub.promo.Promotion._
 import com.gu.memsub.promo._
 import com.netaporter.uri.dsl._
 import configuration.Config
+import controllers.SessionKeys.PromotionTrackingCode
 import filters.HandleXFrameOptionsOverrideHeader
-import model.DigitalEdition
+import model.DigitalEdition.UK
 import play.api.data.{Form, Forms}
 import play.api.libs.json.Json
 import play.api.mvc._
@@ -15,50 +18,93 @@ import play.twirl.api.Html
 import services.TouchpointBackend
 import utils.RequestCountry.RequestWithFastlyCountry
 import utils.Tracking.internalCampaignCode
+import utils.Tracking._
+import views.html.promotion._
 import views.support.PegdownMarkdownRenderer
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object PromoLandingPage extends Controller {
 
-  val tpBackend = TouchpointBackend.Normal
-  lazy val catalog = tpBackend.catalogService.unsafeCatalog
-  val edition = DigitalEdition.UK
+  private val tpBackend = TouchpointBackend.Normal
+  private val catalog = tpBackend.catalogService.unsafeCatalog
+
+  private val digitalPackRatePlanIds = catalog.digipack.toList.map(_.id).toSet
+  private val allPaperPackages = catalog.delivery.list ++ catalog.voucher.list
+  private val paperOnlyPackageRatePlanIds = allPaperPackages.filter(_.charges.benefits.list.contains(Digipack)).map(_.id).toSet
+  private val paperPlusPackageRatePlanIds = allPaperPackages.filterNot(_.charges.benefits.list.contains(Digipack)).map(_.id).toSet
+  private val guardianWeeklyRatePlanIds = catalog.weeklyZoneA.toList.map(_.id).toSet ++ catalog.weeklyZoneC.toList.map(_.id).toSet
 
   private def isActive(promotion: AnyPromotion): Boolean = {
     val isTest = tpBackend.environmentName != "PROD"
-    isTest || (promotion.starts.isBeforeNow && !promotion.expires.exists(_.isBeforeNow))
+    isTest || (
+      promotion.starts.isBeforeNow &&
+      !promotion.expires.exists(_.isBeforeNow) &&
+      promotion.appliesTo.productRatePlanIds.nonEmpty &&
+      promotion.appliesTo.countries.nonEmpty
+    )
   }
 
   private def getDigitalPackLandingPage(promotion: AnyPromotion)(implicit promoCode: PromoCode): Option[Html] = {
-
-    promotion.asDigitalPack.filter(p => isActive(asAnyPromotion(p))).map { promotionWithLandingPage =>
-      views.html.promotion.digitalpackLandingPage(edition, catalog, promoCode, promotionWithLandingPage, PegdownMarkdownRenderer)
+    // The Digital Pack landing page currently only supports GBP, so only render it for UK-applicative promotions
+    promotion.asDigitalPack.filter(p => isActive(asAnyPromotion(p))).filter(_.appliesTo.countries.contains(Country.UK)).map { promotionWithLandingPage =>
+      digitalpackLandingPage(UK, catalog, promoCode, promotionWithLandingPage, PegdownMarkdownRenderer)
     }
   }
 
   private def getNewspaperLandingPage(promotion: AnyPromotion)(implicit promoCode: PromoCode): Option[Html] = {
     promotion.asNewspaper.filter(p => isActive(asAnyPromotion(p))).map { promotionWithLandingPage =>
-      views.html.promotion.newspaperLandingPage(catalog, promoCode, promotionWithLandingPage, PegdownMarkdownRenderer)
+      newspaperLandingPage(catalog, promoCode, promotionWithLandingPage, PegdownMarkdownRenderer)
     }
   }
 
   private def getWeeklyLandingPage(promotion: AnyPromotion, maybeCountry: Option[Country] = None)(implicit promoCode: PromoCode): Option[Html] = {
     val country = maybeCountry.getOrElse(Country.UK)
     promotion.asWeekly.filter(p => isActive(asAnyPromotion(p))).map { promotionWithLandingPage =>
-      views.html.promotion.weeklyLandingPage(country,catalog, promoCode, promotionWithLandingPage, PegdownMarkdownRenderer)
+      weeklyLandingPage(country, catalog, promoCode, promotionWithLandingPage, PegdownMarkdownRenderer)
     }
   }
 
-  def render(promoCodeStr: String) = NoCacheAction { request =>
-    implicit val promoCode = PromoCode(promoCodeStr)
-    val country = request.getFastlyCountry
-    val promotion = tpBackend.promoService.findPromotionFuture(promoCode)
-    (for {
-      promotion <- tpBackend.promoService.findPromotion(promoCode)
-      html <- getLandingPage(promotion,country)
-    } yield Ok(html)).getOrElse(Redirect("/" ? (internalCampaignCode -> s"FROM_P_${promoCode.get}")))
-  }
-  def getLandingPage(promotion: AnyPromotion, maybeCountry: Option[Country]= None)(implicit promoCode: PromoCode): Option[Html] = {
+  private def getLandingPage(promotion: AnyPromotion, maybeCountry: Option[Country]= None)(implicit promoCode: PromoCode): Option[Html] = {
     getNewspaperLandingPage(promotion) orElse getDigitalPackLandingPage(promotion) orElse getWeeklyLandingPage(promotion, maybeCountry)
+  }
+
+  private def getBrochureRouteForPromotion(promotion: AnyPromotion): Option[Call] = {
+    val applicableRatePlanIds = promotion.appliesTo.productRatePlanIds
+    if (applicableRatePlanIds intersect digitalPackRatePlanIds nonEmpty) {
+      Some(routes.DigitalPack.redirect())
+    } else if (applicableRatePlanIds intersect paperPlusPackageRatePlanIds nonEmpty) {
+      Some(routes.Shipping.viewCollectionPaperDigital())
+    } else if (applicableRatePlanIds intersect paperOnlyPackageRatePlanIds nonEmpty) {
+      Some(routes.Shipping.viewCollectionPaper())
+    } else if (applicableRatePlanIds intersect guardianWeeklyRatePlanIds nonEmpty) {
+      Some(routes.WeeklyLandingPage.index())
+    } else {
+      None
+    }
+  }
+
+  private def redirectToBrochurePage(promotion: AnyPromotion)(implicit promoCode: PromoCode, request: Request[AnyContent]): Option[Result] = {
+    getBrochureRouteForPromotion(promotion) map { route =>
+      val result = Redirect(route.url ? (internalCampaignCode -> s"FROM_P_${promoCode.get}"), request.queryString)
+      if (promotion.promotionType == Tracking) {
+        result.withSession(PromotionTrackingCode -> promoCode.get)
+      } else {
+        result
+      }
+    }
+  }
+
+  def render(promoCodeStr: String): Action[AnyContent] = NoCacheAction.async { implicit request =>
+    implicit val promoCode = PromoCode(promoCodeStr)
+
+    tpBackend.promoService.findPromotionFuture(promoCode) map { maybePromotion =>
+      maybePromotion flatMap { promotion =>
+        getLandingPage(promotion).map(Ok(_)) orElse redirectToBrochurePage(promotion)
+      } getOrElse {
+        Redirect(routes.Homepage.index().url ? (internalCampaignCode -> s"FROM_P_${promoCode.get}"), request.queryString)
+      }
+    }
   }
 
   def preview() = GoogleAuthenticatedStaffAction { implicit request =>
@@ -80,13 +126,15 @@ object PromoLandingPage extends Controller {
     maybeLandingPage.map(OkWithPreviewHeaders).getOrElse(NotFound)
   }
 
-  def terms(promoCodeStr: String) = CachedAction { _ =>
+  def terms(promoCodeStr: String): Action[AnyContent] = CachedAction.async { _ =>
     val promoCode = PromoCode(promoCodeStr)
-    val result = for {
-      promotion <- tpBackend.promoService.findPromotion(promoCode)
-    } yield {
-      Ok(views.html.promotion.termsPage(promoCode, promotion, PegdownMarkdownRenderer, catalog))
+
+    tpBackend.promoService.findPromotionFuture(promoCode) map { maybePromotion =>
+      maybePromotion.map { promotion =>
+        Ok(views.html.promotion.termsPage(promoCode, promotion, PegdownMarkdownRenderer, catalog))
+      } getOrElse {
+        Redirect(routes.Homepage.index().url ? (internalCampaignCode -> s"FROM_PT_${promoCode.get}"))
+      }
     }
-    result.getOrElse(Redirect("/" ? (internalCampaignCode -> s"FROM_PT_${promoCode.get}")))
   }
 }

--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -71,13 +71,13 @@ object PromoLandingPage extends Controller {
 
   private def getBrochureRouteForPromotion(promotion: AnyPromotion): Option[Call] = {
     val applicableRatePlanIds = promotion.appliesTo.productRatePlanIds
-    if (applicableRatePlanIds intersect digitalPackRatePlanIds nonEmpty) {
+    if ((applicableRatePlanIds intersect digitalPackRatePlanIds).nonEmpty) {
       Some(routes.DigitalPack.redirect())
-    } else if (applicableRatePlanIds intersect paperPlusPackageRatePlanIds nonEmpty) {
+    } else if ((applicableRatePlanIds intersect paperPlusPackageRatePlanIds).nonEmpty) {
       Some(routes.Shipping.viewCollectionPaperDigital())
-    } else if (applicableRatePlanIds intersect paperOnlyPackageRatePlanIds nonEmpty) {
+    } else if ((applicableRatePlanIds intersect paperOnlyPackageRatePlanIds).nonEmpty) {
       Some(routes.Shipping.viewCollectionPaper())
-    } else if (applicableRatePlanIds intersect guardianWeeklyRatePlanIds nonEmpty) {
+    } else if ((applicableRatePlanIds intersect guardianWeeklyRatePlanIds).nonEmpty) {
       Some(routes.WeeklyLandingPage.index())
     } else {
       None

--- a/app/views/offers/offers_international.scala.html
+++ b/app/views/offers/offers_international.scala.html
@@ -1,0 +1,44 @@
+@import model.DigitalEdition
+@import views.support.DigitalEdition._
+
+@(edition: DigitalEdition)
+
+@main(s"${edition.name} | Subscriptions and Membership | The Guardian",
+    Some("Subscribe to The Guardian. Support our independent, award-winning journalism."),
+    edition = edition) {
+
+    <main class="page-container gs-container">
+        @fragments.page.header("Subscriptions and Membership", Some("Select your preferred package"))
+        <div class="row row--items-2">
+            <div class="row__item block block--primary block--digital">
+                <h2 class="block__title">Subscribe to the Guardian <span class="break-tablet">digital pack</span></h2>
+                <div class="block__info">
+                    <ul class="block__list">
+                        <li class="block__list-item">Access to the Daily Edition, the digital version of the UK Guardian newspaper</li>
+                        <li class="block__list-item">Access to the Guardian App Premium Tier, an advert-free experience</li>
+                        <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
+                        @edition.digitalPackSaving.map {saving => <li class="block__list-item"><strong>Save up to @saving%</strong></li>}
+                        <li class="block__list-item">14-day free trial</li>
+                    </ul>
+                </div>
+                <div class="block__footer">
+                    <a class="button button--large button--primary button--arrow" href="/@edition.id/digital">Subscribe now</a>
+                </div>
+            </div>
+            <div class="row__item block block--primary block--weekly">
+                <h2 class="block__title">Subscribe to the Guardian Weekly</h2>
+                <div class="block__info">
+                    <ul class="block__list">
+                        <li class="block__list-item">A selection of international editorial from the Guardian, Observer and Washington Post</li>
+                        <li class="block__list-item">A unique blend of international news, politics, culture and comment</li>
+                        <li class="block__list-item">Save on the retail price</li>
+                        <li class="block__list-item">Free delivery to your door, wherever you are in the world</li>
+                    </ul>
+                </div>
+                <div class="block__footer">
+                    <a class="button button--large button--primary" href="https://www.myguardianweekly.co.uk/subscribe/?prom=AAA14&amp;CMP=FAB_2500">Subscribe now</a>
+                </div>
+            </div>
+        </div>
+    </main>
+}

--- a/app/views/offers/offers_uk.scala.html
+++ b/app/views/offers/offers_uk.scala.html
@@ -22,7 +22,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/uk/digital?INTCMP=GU_SUBSCRIPTIONS_DIGITAL" data-test-id="subscriptions-uk-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="/uk/digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper-digital">
@@ -30,13 +30,14 @@
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">Year-round savings of up to 36% off the retail price</li>
-                        <li class="block__list-item">Pick the package you want: Everyday+, Sixday+, Weekend+ and Sunday+</li>
+                        <li class="block__list-item"><strong>Subscribe today and save an additional 30% off the subscription price for 3 months</strong></li>
+                        <li class="block__list-item">Pick the package you want: Everyday+, Sixday+ and Weekend+</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
                         <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/collection/paper-digital?INTCMP=GU_SUBSCRIPTIONS_PACKAGES" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="/p/GAH80I">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper">
@@ -44,24 +45,20 @@
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">Year-round savings of up to 31% off the price of your paper</li>
+                        <li class="block__list-item"><strong>Subscribe today and save an additional 30% off the subscription price for 3 months</strong></li>
                         <li class="block__list-item">Pick the package you want: Everyday, Sixday and Weekend</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
                         <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/collection/paper?INTCMP=GU_SUBSCRIPTIONS_PACKAGES" data-test-id="subscriptions-uk-paper">Subscribe now</a>
+                    <a class="button button--large button--primary" href="/p/GAH80P">Subscribe now</a>
                 </div>
             </div>
         </div>
-        <div class="row row--items-1">
-            <div class="row__item">
-                @fragments.promos.members("uk", UK.membershipLandingPage)
-            </div>
-        </div>
         <div class="row row--items-3">
-            <div class="row__item block">
-                <h2 class="block__title">Guardian Weekly</h2>
+            <div class="row__item block block--primary block--weekly">
+                <h2 class="block__title">Subscribe to the Guardian Weekly</h2>
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">A selection of international editorial from the Guardian, Observer and Washington Post</li>
@@ -71,33 +68,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="https://www.myguardianweekly.co.uk/subscribe/?prom=AAA14&amp;CMP=FAB_2500" data-test-id="subscriptions-uk-guardian-weekly">Subscribe now</a>
-                </div>
-            </div>
-            <div class="row__item block">
-                <h2 class="block__title">Guardian email services</h2>
-                <div class="block__info">
-                    <ul class="block__list">
-                        <li class="block__list-item">Whether it's news, comment, sport or culture - get the content you want, straight to your inbox for free</li>
-                        <li class="block__list-item">Our editors' picks direct to your inbox every day, including our daily editions available for the UK, US and Australia</li>
-                        <li class="block__list-item">Sign up to emails from your favourite Guardian sections, from football to food and fashion</li>
-                    </ul>
-                </div>
-                <div class="block__footer">
-                    <a class="button button--large button--primary" href="https://profile.theguardian.com/email-prefs" data-test-id="subscriptions-uk-email">Sign up</a>
-                </div>
-            </div>
-            <div class="row__item block">
-                <h2 class="block__title">From the app store</h2>
-                <div class="block__info">
-                    <ul class="block__list">
-                        <li class="block__list-item">Subscribe to our daily edition or Guardian app from the appstore.</li>
-                        <li class="block__list-item">Free trials available to new customers.</li>
-                        <li class="block__list-item">Available across iPad, Kindle Fire, Android and iPhone.</li>
-                    </ul>
-                </div>
-                <div class="block__footer">
-                    <a class="button button--large button--primary" href="http://www.theguardian.com/mobile/2014/may/29/the-guardian-for-mobile-and-tablet" data-test-id="subscriptions-uk-app-store">Find out more</a>
+                    <a class="button button--large button--primary" href="https://www.myguardianweekly.co.uk/subscribe/?prom=AAA14&amp;CMP=FAB_2500">Subscribe now</a>
                 </div>
             </div>
         </div>

--- a/conf/routes
+++ b/conf/routes
@@ -78,5 +78,9 @@ GET         /s/:supplierCodeStr              controllers.Homepage.supplierRedire
 # Paths from legacy redirects
 GET         /Voucher                         controllers.Homepage.index
 
+# Offers page or 404
+GET         /offers                          controllers.Offers.offers
+GET         /:edition/offers                 controllers.Offers.offersPage(edition: String)
+
 # Editions hommepage or 404
 GET         /:edition                        controllers.Homepage.landingPage(edition: String)


### PR DESCRIPTION
- Cloned the UK and International homepages into /uk/offers and /int/offers page respectively, and removed the real promotions from the original home page.
- Added better redirect logic for the /p/<promo_code> page such that it will redirect to the promotion's relative page providing it has a hint within the list of appliesTo rate plans on where to land. Otherwise it falls back to the homepage as before.
- Fixed a few deprecation warnings by using the new Future-based promotion lookup

cc @jacobwinch @johnduffell @AWare @pvighi 