### PR TITLE
Fix where tracking code was removed from the session if it was not in the URL to the checkout page

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -130,7 +130,7 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
           supplierCode = resolvedSupplierCode,
           edition = digitalEdition,
           countryAndCurrencySettings = countryAndCurrencySettings
-        )).withSession(trackingCodeSessionData ++ supplierCodeSessionData: _*)
+        )).withSession(request.session.data.toSeq ++ trackingCodeSessionData ++ supplierCodeSessionData: _*)
       }
 
       matchingPlanList match {


### PR DESCRIPTION
A better refactoring of this method needs to happen. Weirdly my IntelliJ CPU goes up to 300% when opening Checkout.scala, so I'll do this small fix first. 

cc @jacobwinch @AWare @pvighi @johnduffell 