### PR TITLE
fix bug with duplicate plans shown in /manage

### DIFF
--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -29,7 +29,7 @@
                     plan = subscription.planToManage,
                     maybeStartDate = Some(subscription.planToManage.start),
                     maybeContact = Some(contact),
-                    maybeFuturePlan = Some(subscription.nextPlan).filter(_.start.isAfter(now))
+                    maybeFuturePlan = Some(subscription.nextPlan).filter { plan => plan.start.isAfter(now) && plan != subscription.planToManage }
                 )()
             </section>
 


### PR DESCRIPTION
When creating a weekly subscription the plan start date is set to next Friday.
This makes it possible for the start date of the "current" plan to be in the future, which caused problems when displaying current and renewal plans in /manage:

![bug](https://cloud.githubusercontent.com/assets/15324270/22932743/f632dd30-f2c0-11e6-9d18-e30835ab3eb5.png)
