### PR TITLE
Fixed bug where the Digital Pack's edition hint was dropped from the …

### DIFF
--- a/app/controllers/DigitalPack.scala
+++ b/app/controllers/DigitalPack.scala
@@ -13,7 +13,7 @@ object DigitalPack extends Controller {
   private val queryParamHint = "edition"
 
   private def redirectResult(digitalEdition: DigitalEdition)(implicit request: Request[AnyContent]) = {
-    val queryString = request.queryString.-(queryParamHint)
+    val queryString = request.queryString - queryParamHint
     Redirect(routes.DigitalPack.landingPage(digitalEdition.id).url, queryString, SEE_OTHER)
   }
 

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -22,7 +22,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/p/DHOMEUK1" data-test-id="subscriptions-uk-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="/p/DHOMEUK1?edition=@UK.id" data-test-id="subscriptions-uk-digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper-digital">

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -22,7 +22,7 @@
                 </ul>
             </div>
             <div class="block__footer">
-                <a class="button button--large button--primary button--arrow" href="/p/DHOMEINT" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
+                <a class="button button--large button--primary button--arrow" href="/p/DHOMEINT?edition=@edition.id" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
             </div>
         </div>
         <div class="row__item block block--primary block--weekly">

--- a/app/views/offers/offers_international.scala.html
+++ b/app/views/offers/offers_international.scala.html
@@ -22,7 +22,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary button--arrow" href="/p/DOFFINT">Subscribe now</a>
+                    <a class="button button--large button--primary button--arrow" href="/p/DOFFINT?edition=@edition.id">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--weekly">

--- a/app/views/offers/offers_uk.scala.html
+++ b/app/views/offers/offers_uk.scala.html
@@ -22,7 +22,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/p/DOFFUK1">Subscribe now</a>
+                    <a class="button button--large button--primary" href="/p/DOFFUK1?edition=@UK.id">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper-digital">


### PR DESCRIPTION
Fixed bug where the Digital Pack's edition hint was dropped from the international version of the homepage, as it now uses tracking promo codes which don't support it. I've added it back in via a query parameter, which overrides the GEO-IP logic in the DigitalPack redirect action.

cc @jacobwinch @AWare 