### PR TITLE
Allow multiple currencies on to Digital Pack promotion page

### DIFF
--- a/app/views/fragments/promotion/digipack.scala.html
+++ b/app/views/fragments/promotion/digipack.scala.html
@@ -1,9 +1,9 @@
+@import com.gu.i18n.Country
 @import com.gu.memsub.subsv2.CatalogPlan
 @import com.gu.memsub.BillingPeriod.Month
 @import com.gu.memsub.promo.PromoCode
-@import model.DigitalEdition
 
-@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month.type], promoCode: PromoCode, roundelHtml: Option[String])
+@(country: Country, plan: CatalogPlan.Digipack[Month.type], promoCode: PromoCode, roundelHtml: Option[String])
 <div class="digipack">
     <div class="grid grid--3up-step-phablet grid--flex grid--no-clearfix-before">
         <div class="grid__item grid__item--flex-2-columns grid__item--flex-wrapped">
@@ -15,7 +15,7 @@
         <div class="grid__item u-vertically-center-flexbox">
             <p class="digipack__benefit">Experience your newspaper in full, on your tablet with the Guardian & Observer daily edition</p>
             <p class="digipack__benefit">Enjoy an advert-free experience on The Guardian's app with access to our daily crosswords and exclusive content</p>
-            @fragments.promotion.subscribeNow(edition, promoCode)
+            @fragments.promotion.subscribeNow(country, promoCode)
         </div>
     </div>
 </div>

--- a/app/views/fragments/promotion/discover.scala.html
+++ b/app/views/fragments/promotion/discover.scala.html
@@ -1,10 +1,11 @@
+@import com.gu.i18n.Country
+@import com.gu.i18n.Currency
 @import com.gu.memsub.promo.PromoCode
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import com.gu.memsub.subsv2.CatalogPlan
 @import com.gu.memsub.BillingPeriod.Month
-@import model.DigitalEdition
 
-@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month.type], promoCode: PromoCode, promotion: AnyPromotion)
+@(currency: Currency, country: Country, plan: CatalogPlan.Digipack[Month.type], promoCode: PromoCode, promotion: AnyPromotion)
 <div>
     <div class="digital-tablet-previews hide-above-phablet">
         <img src="@controllers.CachedAssets.hashedPathFor("images/backgrounds/bg-digital-tablet-previews.jpg")"/>
@@ -44,8 +45,8 @@
                     <h3>Every day; every section; every supplement</h3>
                     <div class="feature__text">The Guide; Cook; and food Monthly plus our daily crossword tailored for your tablet.</div>
                     <div class="feature__cta">
-                        @fragments.promotion.pricingCta(edition, plan, promoCode, promotion)
-                        @fragments.promotion.subscribeNow(edition, promoCode)
+                        @fragments.promotion.pricingCta(currency, plan, promoCode, promotion)
+                        @fragments.promotion.subscribeNow(country, promoCode)
                     </div>
                 </div>
             </div>

--- a/app/views/fragments/promotion/paymentDetails.scala.html
+++ b/app/views/fragments/promotion/paymentDetails.scala.html
@@ -1,17 +1,17 @@
+@import com.gu.i18n.Currency
 @import com.gu.memsub.subsv2.CatalogPlan
-@import com.gu.memsub.promo.Promotion._
+@import com.gu.memsub.promo.Promotion.AnyPromotion
 @import views.support.Catalog._
 
-@(plan: CatalogPlan.Paid, promotion: AnyPromotion)
-
+@(plan: CatalogPlan.Paid, currency: Currency, promotion: AnyPromotion)
 @promotion.asDiscount.find(_.promotionType.durationMonths.isDefined).fold {
-    Monthly price <strong>@formatPrice(plan, promotion)</strong>
+    Monthly price <strong>@formatPrice(plan, currency, promotion)</strong>
 } { p =>
     @if(p.promotionType.durationMonths.get > 1) {
-        <strong>@formatPrice(plan, promotion)</strong> per month for @p.promotionType.durationMonths.get months
+        <strong>@formatPrice(plan, currency, promotion)</strong> per month for @p.promotionType.durationMonths.get months
     } else {
-        <strong>@formatPrice(plan, promotion)</strong> for 1 month
+        <strong>@formatPrice(plan, currency, promotion)</strong> for 1 month
     }
     <br/>
-    Then <strong>@formatPrice(plan)</strong> every month thereafter
+    Then <strong>@formatPrice(plan, currency)</strong> every month thereafter
 }

--- a/app/views/fragments/promotion/pricingCta.scala.html
+++ b/app/views/fragments/promotion/pricingCta.scala.html
@@ -1,26 +1,26 @@
+@import com.gu.i18n.Currency
 @import com.gu.memsub.promo.PromoCode
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import com.gu.memsub.subsv2.CatalogPlan
 @import com.gu.memsub.BillingPeriod.Month
-@import model.DigitalEdition
 @import views.support.Catalog._
 @import configuration.Config.Zuora.paymentDelay
 
-@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month.type], promoCode: PromoCode, promotion: AnyPromotion)
+@(currency: Currency, plan: CatalogPlan.Digipack[Month.type], promoCode: PromoCode, promotion: AnyPromotion)
 <div class="pricing-cta">
     <div class="pricing-cta__pricing">
         <h4 class="pricing-cta__pricing__title">Free for @promotion.asFreeTrial.fold(paymentDelay.getDays)(_.promotionType.duration.getDays) days</h4>
         <p class="pricing-cta__pricing__value">
             @promotion.asDiscount.find(_.promotionType.durationMonths.isDefined).fold {
-                Then @formatPrice(plan, promotion)/month
+                Then @formatPrice(plan, currency, promotion)/month
             } { p =>
                 @if(p.promotionType.durationMonths.get > 1) {
-                    Then @formatPrice(plan, promotion)/month for @p.promotionType.durationMonths.get months
+                    Then @formatPrice(plan, currency, promotion)/month for @p.promotionType.durationMonths.get months
                 } else {
-                    Then @formatPrice(plan, promotion) for 1 month
+                    Then @formatPrice(plan, currency, promotion) for 1 month
                 }
                 <br/>
-                Then @formatPrice(plan) every month thereafter
+                Then @formatPrice(plan, currency) every month thereafter
             }
         </p>
     </div>

--- a/app/views/fragments/promotion/promotionCta.scala.html
+++ b/app/views/fragments/promotion/promotionCta.scala.html
@@ -1,10 +1,10 @@
+@import com.gu.i18n.Country
+@import com.gu.i18n.Currency
 @import com.gu.memsub.promo.PromoCode
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import com.gu.memsub.subsv2.CatalogPlan
 @import com.gu.memsub.BillingPeriod.Month
-@import model.DigitalEdition
-@import org.joda.time.Days
-@(edition: DigitalEdition, plan: CatalogPlan.Digipack[Month.type], promoCode: PromoCode, promotion: AnyPromotion)
+@(currency: Currency, country: Country, plan: CatalogPlan.Digipack[Month.type], promoCode: PromoCode, promotion: AnyPromotion)
 <div class="promotion-cta">
     <div class="grid grid--3up-step-phablet grid--flex">
         <div class="grid__item grid__item--flex-2-columns">
@@ -14,8 +14,8 @@
         </div>
         <div class="grid__item u-vertically-center-flexbox">
             <div class="promotion-cta__pricing">
-                @fragments.promotion.pricingCta(edition, plan, promoCode, promotion)
-                @fragments.promotion.subscribeNow(edition, promoCode)
+                @fragments.promotion.pricingCta(currency, plan, promoCode, promotion)
+                @fragments.promotion.subscribeNow(country, promoCode)
             </div>
         </div>
     </div>

--- a/app/views/fragments/promotion/subscribeNow.scala.html
+++ b/app/views/fragments/promotion/subscribeNow.scala.html
@@ -1,12 +1,10 @@
 @import com.gu.memsub.promo.PromoCode
-@import model.DigitalEdition
-@import views.support.DigitalEdition._
-@(edition: DigitalEdition, promoCode: PromoCode)
+@import com.gu.i18n.Country
+@(country: Country, promoCode: PromoCode)
 <div class="pricing-cta">
     <div class="pricing-cta__action">
         <a class="button button--large button--primary"
-        href="@edition.redirect&promoCode=@promoCode.get"
-        data-test-id="digital-pack-@edition.id-trial-header"
+        href="/checkout?countryGroup=@country.alpha2&promoCode=@promoCode.get"
         >Subscribe now</a>
     </div>
 </div>

--- a/app/views/fragments/promotion/subscriptionTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/subscriptionTermsAndConditions.scala.html
@@ -1,18 +1,20 @@
+@import com.gu.i18n.Currency
+@import com.gu.i18n.Currency.GBP
 @import com.gu.memsub.subsv2.Catalog
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import views.support.Catalog._
 @import configuration.Links
 @import configuration.Config.Zuora.paymentDelay
 
-@(catalog: Catalog, promotion: AnyPromotion)
+@(catalog: Catalog, promotion: AnyPromotion, currency: Currency = GBP)
 @if(promotion.asDigitalPack.isDefined) {
     <h4>Digital subscription terms and conditions</h4>
     <p>
         Subscriptions available to people aged 18 and over with a valid email address. Free trial open to new digital pack subscribers only. Free trial period lasts
         @promotion.asFreeTrial.fold(paymentDelay.getDays.toString)(_.promotionType.duration.getDays.toString)
         days from receipt of subscriber ID, up to and including the day before your first payment falls due. At the end of the free trial,
-        the subscription is charged at @promotion.asIncentive.map { p => standard price (currently @formatPrice(catalog.digipack.month, promotion) a month) }
-        @promotion.asDiscount.map { p => the special price of @formatPrice(catalog.digipack.month, promotion) a month } unless cancelled.
+        the subscription is charged at @promotion.asIncentive.map { p => standard price (currently @formatPrice(catalog.digipack.month, currency, promotion) a month) }
+        @promotion.asDiscount.map { p => the special price of @formatPrice(catalog.digipack.month, currency), promotion) a month } unless cancelled.
         Requires Internet connection (additional charges may apply) and an Apple, Android or Kindle Fire device.
     </p>
     <p>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -22,7 +22,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/p/DHOMEUK1?edition=@UK.id" data-test-id="subscriptions-uk-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DHOMEUK1", None).url?edition=@UK.id" data-test-id="subscriptions-uk-digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper-digital">
@@ -36,7 +36,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/p/NHOMEUKD" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("NHOMEUKD", None).url" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper">
@@ -50,7 +50,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/p/NHOMEUKP" data-test-id="subscriptions-uk-paper">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("NHOMEUKP", None).url" data-test-id="subscriptions-uk-paper">Subscribe now</a>
                 </div>
             </div>
         </div>

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -17,12 +17,12 @@
                     <li class="block__list-item">Access to the Daily Edition, the digital version of the UK Guardian newspaper</li>
                     <li class="block__list-item">Access to the Guardian App Premium Tier, an advert-free experience</li>
                     <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
-                    @edition.digitalPackSaving.map {saving => <li class="block__list-item"><strong>Save up to @{saving}%</strong></li>}
+                    @edition.digitalPackSaving.map {saving => <li class="block__list-item"><strong>Save up to @{saving}% on the app store price</strong></li>}
                     <li class="block__list-item">14-day free trial</li>
                 </ul>
             </div>
             <div class="block__footer">
-                <a class="button button--large button--primary button--arrow" href="/p/DHOMEINT?edition=@edition.id" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
+                <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render("DHOMEINT", None).url?edition=@edition.id" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
             </div>
         </div>
         <div class="row__item block block--primary block--weekly">

--- a/app/views/offers/offers_international.scala.html
+++ b/app/views/offers/offers_international.scala.html
@@ -14,15 +14,15 @@
                 <h2 class="block__title">Subscribe to the Guardian <span class="break-tablet">digital pack</span></h2>
                 <div class="block__info">
                     <ul class="block__list">
+                        <li class="block__list-item">14-day free trial</li>
+                        <li class="block__list-item"><strong>Subscribe today and save an additional 50% off the subscription price for 3 months</strong></li>
                         <li class="block__list-item">Access to the Daily Edition, the digital version of the UK Guardian newspaper</li>
                         <li class="block__list-item">Access to the Guardian App Premium Tier, an advert-free experience</li>
                         <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
-                        @edition.digitalPackSaving.map {saving => <li class="block__list-item"><strong>Save up to @saving%</strong></li>}
-                        <li class="block__list-item">14-day free trial</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary button--arrow" href="/p/DOFFINT?edition=@edition.id">Subscribe now</a>
+                    <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render("DAJ41X", edition.countryGroup.defaultCountry).url">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--weekly">

--- a/app/views/offers/offers_uk.scala.html
+++ b/app/views/offers/offers_uk.scala.html
@@ -15,14 +15,14 @@
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">14-day free trial of our digital pack</li>
-                        @UK.digitalPackSaving.map { saving => <li class="block__list-item"><strong>Save up to @saving% on the app store price</strong></li> }
+                        <li class="block__list-item"><strong>Subscribe today and save an additional 50% off the subscription price for 3 months</strong></li>
                         <li class="block__list-item">Access to the Daily Edition and the advert-free Guardian App Premium Tier</li>
                         <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
                         <li class="block__list-item">Use on up to 10 devices</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/p/DOFFUK1?edition=@UK.id">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DAI41X", UK.countryGroup.defaultCountry).url">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper-digital">
@@ -37,7 +37,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/p/GAH80I">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GAH41G", None).url">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper">
@@ -52,7 +52,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="/p/GAH80P">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GAH41F", None).url">Subscribe now</a>
                 </div>
             </div>
         </div>

--- a/app/views/promotion/digitalpackLandingPage.scala.html
+++ b/app/views/promotion/digitalpackLandingPage.scala.html
@@ -1,15 +1,16 @@
+@import com.gu.i18n.Currency
+@import com.gu.i18n.Country
 @import com.gu.memsub.promo.PromoCode
 @import com.gu.memsub.promo.Promotion.{PromoWithDigitalPackLandingPage, asAnyPromotion}
 @import com.gu.memsub.subsv2.Catalog
-@import model.DigitalEdition
 @import views.support.LandingPageOps._
 @import views.support.MarkdownRenderer
 
-@(edition: DigitalEdition, catalog: Catalog, promoCode: PromoCode, promotion: PromoWithDigitalPackLandingPage, md: MarkdownRenderer)
+@(currency: Currency, country: Country, catalog: Catalog, promoCode: PromoCode, promotion: PromoWithDigitalPackLandingPage, md: MarkdownRenderer)
 @plan = @{catalog.digipack.month}
 @anyPromotion = @{asAnyPromotion(promotion)}
 @main(
-    title = "Subscribe to the Guardian Digital Pack offer | The Guardian (${edition.name})",
+    title = "Subscribe to the Guardian Digital Pack offer | The Guardian",
     bodyClasses = Seq("is-wide")
 ) {
 
@@ -23,14 +24,14 @@
         </section>
         <section class="section-grey section--dark-sides">
             <div class="gs-container gs-container--slim page-slice">
-                @fragments.promotion.digipack(edition, plan, promoCode, promotion.landingPage.roundelHtml.map(md.render))
+                @fragments.promotion.digipack(country, plan, promoCode, promotion.landingPage.roundelHtml.map(md.render))
             </div>
         </section>
         <section class="section-white section--dark-sides">
             <div class="gs-container gs-container--slim page-slice">
                 <div class="page-slice__content">
                     <h2 class="promo-landing-page__section-head">Discover the Guardian Daily Edition</h2>
-                    @fragments.promotion.discover(edition, plan, promoCode, anyPromotion)
+                    @fragments.promotion.discover(currency, country, plan, promoCode, anyPromotion)
                 </div>
             </div>
         </section>
@@ -62,7 +63,7 @@
             <div class="gs-container gs-container--slim page-slice page-slice">
                 <div class="page-slice__content">
                     <h2 class="promo-landing-page__section-head">Subscribe&nbsp;to&nbsp;the Digital&nbsp;Pack</h2>
-                    @fragments.promotion.promotionCta(edition, plan, promoCode, anyPromotion)
+                    @fragments.promotion.promotionCta(currency, country, plan, promoCode, anyPromotion)
                 </div>
             </div>
         </section>
@@ -71,7 +72,7 @@
                 <div class="page-slice__content">
                     @fragments.promotion.promotionTermsAndConditions(anyPromotion, md)
                     <p>For full promotion terms and conditions visit <a class="u-link" href="/p/@promoCode.get/terms">subscribe.theguardian.com/p/@promoCode.get/terms</a></p>
-                    @fragments.promotion.subscriptionTermsAndConditions(catalog, anyPromotion)
+                    @fragments.promotion.subscriptionTermsAndConditions(catalog, anyPromotion, currency)
                     @fragments.promotion.copyrightNotice()
                 </div>
             </div>

--- a/app/views/support/Catalog.scala
+++ b/app/views/support/Catalog.scala
@@ -1,5 +1,6 @@
 package views.support
 
+import com.gu.i18n.Currency
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.promo.PercentDiscount._
 import com.gu.memsub.promo.Promotion.AnyPromotion
@@ -68,14 +69,16 @@ object Catalog {
         ).some, _ => None)
   }
 
-  def adjustPrice(plan: CatalogPlan.Paid, promotion: AnyPromotion): Price =
-    promotion.asDiscount.fold(plan.charges.gbpPrice)(_.promotionType.applyDiscount(plan.charges.gbpPrice, plan.charges.billingPeriod))
-  
-  def formatPrice(plan: CatalogPlan.Paid, promotion: AnyPromotion): String = {
-    adjustPrice(plan, promotion).pretty
+  def adjustPrice(plan: CatalogPlan.Paid, currency: Currency, promotion: AnyPromotion): Price = {
+    val price = plan.charges.price.getPrice(currency).getOrElse(plan.charges.gbpPrice)
+    promotion.asDiscount.map(_.promotionType.applyDiscount(price, plan.charges.billingPeriod)).getOrElse(price)
   }
 
-  def formatPrice(plan: CatalogPlan.Paid): String = {
-    plan.charges.gbpPrice.pretty
+  def formatPrice(plan: CatalogPlan.Paid, currency: Currency, promotion: AnyPromotion): String = {
+    adjustPrice(plan, currency, promotion).pretty
+  }
+
+  def formatPrice(plan: CatalogPlan.Paid, currency: Currency): String = {
+    plan.charges.price.getPrice(currency).getOrElse(plan.charges.gbpPrice).pretty
   }
 }

--- a/app/views/support/LandingPageOps.scala
+++ b/app/views/support/LandingPageOps.scala
@@ -1,6 +1,7 @@
 package views.support
 
 import com.gu.i18n.CountryGroup.UK
+import com.gu.i18n.Currency.GBP
 import com.gu.memsub.promo.Promotion._
 import com.gu.memsub.promo._
 import com.gu.memsub.subsv2.CatalogPlan
@@ -45,9 +46,9 @@ object LandingPageOps {
   }
 
   def planToOptions(promoCode: PromoCode, promotion: AnyPromotion)(in: CatalogPlan.Paid): SubscriptionOption = {
-    val planPrice = promotion.asDiscount.map(adjustPrice(in, _)).getOrElse(in.charges.gbpPrice)
+    val planPrice = promotion.asDiscount.map(adjustPrice(in, GBP, _)).getOrElse(in.charges.gbpPrice)
     val saving = if (promotion.asDiscount.isDefined) None else in.saving
-    val paymentDetails = promotion.asDiscount.map(views.html.fragments.promotion.paymentDetails(in, _))
+    val paymentDetails = promotion.asDiscount.map(views.html.fragments.promotion.paymentDetails(in, GBP, _))
 
     SubscriptionOption(in.id.get,
       in.name,

--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,7 @@ resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"))
 
 addCommandAlias("devrun", "run -Dconfig.resource=DEV.conf 9200")
+addCommandAlias("prodrun", "run -Dconfig.resource=PROD.conf 9200")
 addCommandAlias("fast-test", "testOnly -- -l Acceptance")
 addCommandAlias("acceptance-test", "testOnly acceptance.CheckoutSpec")
 

--- a/conf/routes
+++ b/conf/routes
@@ -66,11 +66,11 @@ GET         /assets/*file                    controllers.CachedAssets.at(path="/
 GET         /test-users                      controllers.Testing.testUser
 
 # Promotions
-GET         /p/:promoCodeStr                 controllers.PromoLandingPage.render(promoCodeStr: String)
+GET         /p/:promoCodeStr                 controllers.PromoLandingPage.render(promoCodeStr: String, country: Option[Country])
 GET         /p/:promoCodeStr/terms           controllers.PromoLandingPage.terms(promoCodeStr: String)
 
 # NOCSRF
-POST        /q                               controllers.PromoLandingPage.preview
+POST        /q                               controllers.PromoLandingPage.preview(country: Option[Country])
 
 # Promotions
 GET         /s/:supplierCodeStr              controllers.Homepage.supplierRedirect(supplierCodeStr: String)


### PR DESCRIPTION
- Part of this was to localise the Digital Pack promotion page (hooray!) so that it now carries forward the provided or GEO-IP'd country, and, renders a price in an appropriate currency. There was quite a bit of template collateral swapping out the not-appropriate DigitalEdition to being a Country and Currency.
- This will allow us to build a per-country view in the promo tool preview page.
- Updated the promotions available on the /offers page now that this capability is available. Also used the proper ```@routes...``` command rather than hard coding the URL paths.

cc @AWare @johnduffell @pvighi @jacobwinch 
