### PR TITLE
Remove `InsecureOkHttpClient` as we have proper certs in dev now

### DIFF
--- a/test/acceptance/util/Dependencies.scala
+++ b/test/acceptance/util/Dependencies.scala
@@ -1,14 +1,13 @@
 package acceptance.util
 
-import java.security.cert.X509Certificate
-import javax.net.ssl.{X509TrustManager, SSLContext, SSLSession, HostnameVerifier}
-import okhttp3.Request.Builder
-import okhttp3.OkHttpClient
 import com.gu.lib.okhttpscala._
+import okhttp3.OkHttpClient
+import okhttp3.Request.Builder
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.util.Try
 import scala.language.postfixOps
+import scala.util.Try
 
 object Dependencies {
 
@@ -24,40 +23,10 @@ object Dependencies {
     val url: String
     def isAvailable: Boolean = {
       val request = new Builder().url(url).build()
-      Try(Await.result(insecureClient.execute(request), 30 second).isSuccessful).getOrElse(false)
+      Try(Await.result(client.execute(request), 30 second).isSuccessful).getOrElse(false)
     }
   }
 
   private val client = new OkHttpClient()
-  private val insecureClient = InsecureOkHttpClient()
 
- /*
-  * Get OkHttpClient which ignores all SSL errors.
-  *
-  * Needed when running against local servers which might not have a valid cert.
-  * https://stackoverflow.com/questions/25509296/trusting-all-certificates-with-okhttp
-  */
-  private object InsecureOkHttpClient {
-
-   def apply() = {
-     client.newBuilder().sslSocketFactory(SSL.InsecureSocketFactory).hostnameVerifier(new HostnameVerifier {
-       override def verify(hostname: String, sslSession: SSLSession): Boolean = true }).build()
-   }
-
-    private object SSL {
-      val InsecureSocketFactory = {
-        val sslcontext = SSLContext.getInstance("TLS")
-        sslcontext.init(null, Array(TrustEveryoneTrustManager), null)
-        sslcontext.getSocketFactory
-      }
-
-      object TrustEveryoneTrustManager extends X509TrustManager {
-        def checkClientTrusted(chain: Array[X509Certificate], authType: String) {}
-
-        def checkServerTrusted(chain: Array[X509Certificate], authType: String) {}
-
-        val getAcceptedIssuers = new Array[X509Certificate](0)
-      }
-    }
-  }
 }


### PR DESCRIPTION
The `InsecureOkHttpClient` used in acceptance tests is unnecessary now, because we have a valid CA-signed certificate.

For this to work, update your `identity-platform` to the latest version (which includes https://github.com/guardian/identity-platform/pull/154 ) and re-run `./ngnix/setup.sh`.

This is an echo of https://github.com/guardian/membership-frontend/pull/1510

cc @AWare @Ap0c 