### PR TITLE
Fix supplier code being carried through from homepage

### DIFF
--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -87,7 +87,7 @@ object PromoLandingPage extends Controller {
     getBrochureRouteForPromotion(promotion) map { route =>
       val result = Redirect(route.url, request.queryString)
       if (promotion.promotionType == Tracking) {
-        result.withSession(PromotionTrackingCode -> promoCode.get)
+        result.withSession(request.session.data.toSeq ++ Seq(PromotionTrackingCode -> promoCode.get) :_*)
       } else {
         result
       }


### PR DESCRIPTION
Ensure the other items in the session (for example the Supplier Code) aren't blatted when the promo brochure page redirection happens.

cc @johnduffell @AWare @pvighi @jacobwinch 