### PR TITLE
Support for empty billing schedule in /manage

### DIFF
--- a/app/views/account/delivery.scala.html
+++ b/app/views/account/delivery.scala.html
@@ -14,7 +14,7 @@
 @(
     subscription: Subscription[DailyPaper],
     holidayRefunds: Seq[HolidayRefund] = Seq.empty,
-    billingSchedule: BillingSchedule,
+    billingSchedule: Option[BillingSchedule],
     chosenPaperDays: List[PaperDay],
     suspendableDays: Int,
     suspendedDays: Int,
@@ -103,11 +103,13 @@
                 <h3 class="mma-section__header">Upcoming delivery holidays</h3>
                 @account.fragments.suspensions(holidayRefunds, suspendableDays, suspendedDays)
             </section>
+            @billingSchedule.map { bs =>
+                <section class="mma-section">
+                    <h3 class="mma-section__header">Your billing schedule</h3>
+                    @account.fragments.billingSchedule(bs, subscription.currency)
+                </section>
+            }
 
-            <section class="mma-section">
-                <h3 class="mma-section__header">Your billing schedule</h3>
-                @account.fragments.billingSchedule(billingSchedule, subscription.currency)
-            </section>
 
             <section class="mma-section">
                 <a class="button button--primary button--large" href="@routes.AccountManagement.logout">Sign Out</a>

--- a/app/views/account/digitalpack.scala.html
+++ b/app/views/account/digitalpack.scala.html
@@ -9,7 +9,7 @@
 @import views.support.Pricing._
 
 @(
-    subscription: Subscription[Digipack], billingSchedule: BillingSchedule
+    subscription: Subscription[Digipack], billingSchedule: Option[BillingSchedule]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian Digital Pack subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
@@ -48,12 +48,14 @@
                 </dl>
             </section>
 
-            <section class="mma-section">
-                <h3 class="mma-section__header">
-                    Your billing schedule
-                </h3>
-                @views.html.account.fragments.billingSchedule(billingSchedule, subscription.currency)
-            </section>
+            @billingSchedule.map { bs =>
+                <section class="mma-section">
+                    <h3 class="mma-section__header">
+                        Your billing schedule
+                    </h3>
+                    @views.html.account.fragments.billingSchedule(bs, subscription.currency)
+                </section>
+            }
             <section class="mma-section">
                 <a class="button button--primary button--large" href="@routes.AccountManagement.logout">Sign Out</a>
             </section>

--- a/app/views/account/voucher.scala.html
+++ b/app/views/account/voucher.scala.html
@@ -4,7 +4,7 @@
 @import model.SubscriptionOps._
 @import com.gu.memsub.subsv2.SubscriptionPlan.Voucher
 @(
-    subscription: Subscription[Voucher], billingSchedule: BillingSchedule
+    subscription: Subscription[Voucher], billingSchedule: Option[BillingSchedule]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
@@ -26,13 +26,14 @@
                     maybeStartDate = Some(subscription.firstPaymentDate)
                 )()
             </section>
-
-            <section class="mma-section">
-                <h3 class="mma-section__header">
-                    Your billing schedule
-                </h3>
-                @views.html.account.fragments.billingSchedule(billingSchedule, subscription.currency)
-            </section>
+            @billingSchedule.map { bs =>
+                <section class="mma-section">
+                    <h3 class="mma-section__header">
+                        Your billing schedule
+                    </h3>
+                    @views.html.account.fragments.billingSchedule(bs, subscription.currency)
+                </section>
+            }
             <section class="mma-section">
                 <a class="button button--primary button--large" href="@routes.AccountManagement.logout">Sign Out</a>
             </section>

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -6,7 +6,7 @@
 @import model.SubscriptionOps._
 @import org.joda.time.LocalDate.now
 @(
-    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: BillingSchedule, contact: Contact
+    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: Option[BillingSchedule], contact: Contact
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
@@ -32,13 +32,14 @@
                     maybeFuturePlan = Some(subscription.nextPlan).filter { plan => plan.start.isAfter(now) && plan != subscription.planToManage }
                 )()
             </section>
-
-            <section class="mma-section">
-                <h3 class="mma-section__header">
-                    Your billing schedule
-                </h3>
-                @views.html.account.fragments.billingSchedule(billingSchedule, subscription.currency)
-            </section>
+            @billingSchedule.map { bs =>
+                <section class="mma-section">
+                    <h3 class="mma-section__header">
+                        Your billing schedule
+                    </h3>
+                    @views.html.account.fragments.billingSchedule(bs, subscription.currency)
+                </section>
+            }
             <section class="mma-section">
                 <a class="button button--primary button--large" href="@routes.AccountManagement.logout">Sign Out</a>
             </section>

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -13,7 +13,7 @@
 @import com.gu.memsub.promo.PromoCode
 @import org.joda.time.LocalDate.now
 @(
-    subscription: Subscription[WeeklyPlanOneOff], billingSchedule: BillingSchedule, contact: Contact, billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
+    subscription: Subscription[WeeklyPlanOneOff], contact: Contact, billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {


### PR DESCRIPTION
A quick fix for the problem where a subscription with no future payments scheduled cannot log in to the manage page.

Maybe a longer term solution for this could be to redefine billing schedules so that they allow empty schedules.

@johnduffell 