### PR TITLE
fix JS errors when there's no default plan (zone c)

### DIFF
--- a/assets/javascripts/modules/checkout/promoCode.js
+++ b/assets/javascripts/modules/checkout/promoCode.js
@@ -91,7 +91,8 @@ define([
         var promoCode = $inputBox.val().trim(),
             ratePlanId = ratePlanChoice.getSelectedRatePlanId(),
             country = formElements.DELIVERY.$COUNTRY_SELECT.val().trim() || formElements.BILLING.$COUNTRY_SELECT.val().trim(),
-            currency = document.querySelector('.js-rate-plans input:checked').dataset.currency;
+            selectedPlan = document.querySelector('.js-rate-plans input:checked'),
+            currency = selectedPlan === null ? null : selectedPlan.dataset.currency;
 
         if (promoCode === '') {
             clearDown();


### PR DESCRIPTION
So for zone C, the default plan for zone C might not have the same currency as the assumed currency in the backend.. This results in no plan appearing on the right hand side until a country is selected (which is fine) but then the promocode stuff throws an error.

This just adds a check so it won't trigger until there is a rate plan selected.

@AWare @jacobwinch @pvighi 