### PR TITLE
Fixed description of plans to which a promotion is applicable on promotion terms page

### DIFF
--- a/app/views/promotion/termsPage.scala.html
+++ b/app/views/promotion/termsPage.scala.html
@@ -28,8 +28,8 @@
 
             <h4>Applies to products</h4>
             <ul class="promotion-applies-to">
-                @catalog.allSubs.flatten.filter(plan => promotion.appliesTo.productRatePlanIds.contains(plan.id)).map { plan =>
-                    <li>@{plan.product.toString.replace("Digipack", "")} @plan.name</li>
+                @catalog.allSubs.flatten.filter(plan => promotion.appliesTo.productRatePlanIds.contains(plan.id)).map(_.name).distinct.sorted.map { name =>
+                    <li>@name</li>
                 }
             </ul>
 


### PR DESCRIPTION
Fixed description of plans to which a promotion is applicable on promotion terms page. I've tested it for other products like newspaper and digital pack and it looks good there too.

Before:

![picture 21](https://cloud.githubusercontent.com/assets/1515970/23369320/df44e2e2-fd08-11e6-8809-5754a5e99491.png)

After:

![picture 20](https://cloud.githubusercontent.com/assets/1515970/23369319/ddf535d6-fd08-11e6-825c-f3127b98ae66.png)

cc @johnduffell @pvighi @jacobwinch @AWare 