### PR TITLE
Handle expired subs in renewal flow

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -237,7 +237,7 @@ object ManageWeekly extends ContextLogging {
         renewableSub <- weeklySub.asRenewable.toRightDisjunction("subscription is not renewable")
         renew <- parseRenewalRequest(request, tpBackend.catalogService.unsafeCatalog)
       } yield {
-        info(s"renewing ${renew.plan.name} for ${renewableSub.id} with promo code: ${renew.promoCode}")(sub)
+        info(s"Attempting to renew ${renew.plan.name} for ${renewableSub.id} with promo code: ${renew.promoCode}")(sub)
         tpBackend.checkoutService.renewSubscription(renewableSub, renew, description(renewableSub, renew)).map(_ => Ok(Json.obj("redirect" -> routes.AccountManagement.renewThankYou().url)))
           .recover{
             case e: Throwable =>

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -300,7 +300,7 @@ class CheckoutService(identityService: IdentityService,
 
     def addPlan(contact: Contact) = {
       val newRatePlan = RatePlan(renewal.plan.id.get, None)
-
+      val currentVersionExpired = subscription.termEndDate.isBefore(now)
       val renewCommand = Renew(
         subscriptionId = subscription.id.get,
         currentTermStartDate = subscription.termStartDate,
@@ -309,7 +309,8 @@ class CheckoutService(identityService: IdentityService,
         contractEffectiveDate = contractEffective,
         customerAcceptanceDate = customerAcceptance,
         promoCode = None,
-        autoRenew = renewal.plan.charges.billingPeriod.isRecurring
+        autoRenew = renewal.plan.charges.billingPeriod.isRecurring,
+        currentVersionExpired = currentVersionExpired
       )
 
       val validPromotion = for {

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -292,9 +292,6 @@ class CheckoutService(identityService: IdentityService,
       }
     }
 
-    val ratePlan = RatePlan(renewal.plan.id.get, None, Nil)
-    val amend =   Amend(subscriptionId = subscription.id.get, plansToRemove = Nil, newRatePlans = NonEmptyList(ratePlan))
-
     val contractEffective = Seq(subscription.termEndDate, now).max // The sub may have 'expired' before the customer gets round to renewing it.
     val customerAcceptance = contractEffective
 
@@ -310,7 +307,7 @@ class CheckoutService(identityService: IdentityService,
         customerAcceptanceDate = customerAcceptance,
         promoCode = None,
         autoRenew = renewal.plan.charges.billingPeriod.isRecurring,
-        currentVersionExpired = currentVersionExpired
+        startRenewedTermToday = currentVersionExpired // If the sub has expired, we want to shift the term dates forward
       )
 
       val validPromotion = for {

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.367",
+    "com.gu" %% "membership-common" % "0.369",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
This PR brings in the membership-common changes here:
https://github.com/guardian/membership-common/pull/437

This enables us to renew expired subs correctly.

@paulbrown1982 @pvighi @johnduffell 