### PR TITLE
Fix /manage for expired subs

### DIFF
--- a/app/model/SubscriptionOps.scala
+++ b/app/model/SubscriptionOps.scala
@@ -69,8 +69,8 @@ object SubscriptionOps extends LazyLogging {
   }
 
   implicit class EnrichedWeeklySubscription[P <: WeeklyPlan](subscription: Subscription[P]) {
-    val asRenewable = if (subscription.renewable) Some(subscription.asInstanceOf[Subscription[WeeklyPlanOneOff]]) else None
-    val secondPaymentDate = if (subscription.hasIntroductoryPeriod) subscription.acceptanceDate else subscription.acceptanceDate plusMonths subscription.plan.charges.billingPeriod.monthsInPeriod
+    def asRenewable = if (subscription.renewable) Some(subscription.asInstanceOf[Subscription[WeeklyPlanOneOff]]) else None
+    def secondPaymentDate = if (subscription.hasIntroductoryPeriod) subscription.acceptanceDate else subscription.acceptanceDate plusMonths subscription.plan.charges.billingPeriod.monthsInPeriod
 
   }
 }


### PR DESCRIPTION
By converting these vals to defs, we avoid calling .plan on an expired sub.

@pvighi 