### PR TITLE
in checkout page show associated plan as a "and then"

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -187,9 +187,9 @@ object ManageWeekly extends ContextLogging {
             zuoraContact.country.map { billToCountry =>
               val catalog = tpBackend.catalogService.unsafeCatalog
               val weeklyPlans = weeklySubscription.planToManage.product match {
-                case Product.WeeklyZoneA => catalog.weeklyZoneA.toList
-                case Product.WeeklyZoneB => catalog.weeklyZoneB.toList
-                case Product.WeeklyZoneC => catalog.weeklyZoneC.toList
+                case Product.WeeklyZoneA => catalog.weeklyZoneA.plans
+                case Product.WeeklyZoneB => catalog.weeklyZoneB.plans
+                case Product.WeeklyZoneC => catalog.weeklyZoneC.plans
               }
 
               val renewalPlans = weeklyPlans.filter(_.availableForRenewal)

--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -27,11 +27,11 @@ object PromoLandingPage extends Controller {
   private val tpBackend = TouchpointBackend.Normal
   private val catalog = tpBackend.catalogService.unsafeCatalog
 
-  private val digitalPackRatePlanIds = catalog.digipack.toList.map(_.id).toSet
+  private val digitalPackRatePlanIds = catalog.digipack.plans.map(_.id).toSet
   private val allPaperPackages = catalog.delivery.list ++ catalog.voucher.list
   private val paperPlusPackageRatePlanIds = allPaperPackages.filter(_.charges.benefits.list.contains(Digipack)).map(_.id).toSet
   private val paperOnlyPackageRatePlanIds = allPaperPackages.filterNot(_.charges.benefits.list.contains(Digipack)).map(_.id).toSet
-  private val guardianWeeklyRatePlanIds = catalog.weeklyZoneA.toList.map(_.id).toSet ++ catalog.weeklyZoneC.toList.map(_.id).toSet
+  private val guardianWeeklyRatePlanIds = catalog.weeklyZoneA.plans.map(_.id).toSet ++ catalog.weeklyZoneC.plans.map(_.id).toSet
 
   private def isActive(promotion: AnyPromotion): Boolean = {
     val isTest = tpBackend.environmentName != "PROD"

--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -20,14 +20,14 @@ class SubscriptionsForm(catalog: Catalog) {
 
   implicit val pf1 = new Formatter[CatalogPlan.Digipack[BillingPeriod]] {
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], CatalogPlan.Digipack[BillingPeriod]] =
-      data.get(key).map(ProductRatePlanId).flatMap(prpId => catalog.digipack.toList.find(_.id == prpId)).toRight(Seq(FormError(key, "Bad plan")))
+      data.get(key).map(ProductRatePlanId).flatMap(prpId => catalog.digipack.plans.find(_.id == prpId)).toRight(Seq(FormError(key, "Bad plan")))
     override def unbind(key: String, value: CatalogPlan.Digipack[BillingPeriod]): Map[String, String] =
       Map(key -> value.id.get)
   }
 
   implicit val pf2 = new Formatter[CatalogPlan.Paper] {
 
-    val validPlans = catalog.delivery.list ++ catalog.voucher.list ++ catalog.weeklyZoneA.toList.filter(_.availableForCheckout) ++ catalog.weeklyZoneB.toList.filter(_.availableForCheckout) ++ catalog.weeklyZoneC.toList
+    val validPlans = catalog.delivery.list ++ catalog.voucher.list ++ catalog.weeklyZoneA.plans.filter(_.availableForCheckout) ++ catalog.weeklyZoneB.plans.filter(_.availableForCheckout) ++ catalog.weeklyZoneC.plans
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], CatalogPlan.Paper] =
       data.get(key).map(ProductRatePlanId).flatMap(prpId => validPlans.find(_.id == prpId)).toRight(Seq(FormError(key, "Bad plan")))
     override def unbind(key: String, value: CatalogPlan.Paper): Map[String, String] =

--- a/app/model/Renewal.scala
+++ b/app/model/Renewal.scala
@@ -9,7 +9,7 @@ import play.api.libs.json._
 case class Renewal(email: String, plan: Paper, paymentData: PaymentData, promoCode: Option[PromoCode])
 
 class RenewalReads(catalog: Catalog) {
-  val weeklyPlans = catalog.weeklyZoneA.toList ++ catalog.weeklyZoneB.toList ++ catalog.weeklyZoneC.toList
+  val weeklyPlans = catalog.weeklyZoneA.plans ++ catalog.weeklyZoneB.plans ++ catalog.weeklyZoneC.plans
   implicit val paperReads = new Reads[Paper] {
     override def reads(json: JsValue): JsResult[Paper] = json match {
       case JsString(ratePlanId) => weeklyPlans.find(_.id.get == ratePlanId).map(JsSuccess(_)).getOrElse(JsError("invalid plan"))

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -24,27 +24,22 @@
     countryAndCurrencySettings: CountryAndCurrencySettings
 )(implicit request: RequestHeader)
 
-@priceOption(plan: CatalogPlan.Paid, currency: Currency) = {
+@priceOption(plan: CatalogPlan.Paid, currency: Currency, associatedPlan: Option[CatalogPlan.Paid]) = {
     <label class="option" data-currency="@currency">
         <span class="option__input">
             <input
             type="radio" name="ratePlanId"
-            data-option-label-prefix="@plan.prefix"
-            data-option-mirror-payment-default="@plan.charges.prettyPricing(currency)"
-            data-option-mirror-payment="@plan.charges.prettyPricing(currency)"
-            data-option-mirror-description="@for(s <- plan.subtitle) {(@s)}"
+            data-option-mirror-payment="@plan.charges.prettyPricing(currency) @for(ap <- associatedPlan.map(_.charges.prettyPricing(currency))) { and then @ap}"
+            data-option-mirror-description="@for(s <- plan.subtitle) {(@s@for(ap <- associatedPlan.flatMap(_.subtitle)) { and then @ap})}"
             data-option-mirror-package="@plan.packageName"
-            data-amount="@plan.charges.unsafePrice(currency).prettyAmount"
-            data-name="@plan.name"
-            data-number-of-months="@plan.charges.billingPeriod.monthsInPeriod"
+            data-name="@plan.name @for(ap <- associatedPlan.map(_.name)) { and then @ap}"
 
             data-currency="@currency"
-            data-frequency="@plan.charges.billingPeriod.frequencyInMonths"
             value="@plan.id.get"
             @if(plan == productData.plans.default && currency == countryAndCurrencySettings.defaultCurrency){ checked="checked" }
             >
         </span>
-        <span class="option__label" id="label-for-@plan.id.get-@currency">@plan.prettyName(currency)</span>
+        <span class="option__label" id="label-for-@plan.id.get-@currency">@plan.prettyName(currency) @for(ap <- associatedPlan.map(_.charges.prettyPricing(currency))) { and then @ap}</span>
     </label>
 }
 
@@ -106,7 +101,7 @@
                 <fieldset class="basket-billing-options is-hidden js-rate-plans js-option-mirror-group" id="change-payment-frequency">
                     @productData.plans.list.map { p =>
                         @p.charges.price.currencies.map { c =>
-                            @priceOption(p, c)
+                            @priceOption(p, c, productData.plans.associationFor(p))
                         }
                     }
                 </fieldset>

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -29,6 +29,8 @@
         <span class="option__input">
             <input
             type="radio" name="ratePlanId"
+            data-option-label-prefix="@plan.prefix"
+            data-option-mirror-payment-default="@plan.charges.prettyPricing(currency) @for(ap <- associatedPlan.map(_.charges.prettyPricing(currency))) { and then @ap}"
             data-option-mirror-payment="@plan.charges.prettyPricing(currency) @for(ap <- associatedPlan.map(_.charges.prettyPricing(currency))) { and then @ap}"
             data-option-mirror-description="@for(s <- plan.subtitle) {(@s@for(ap <- associatedPlan.flatMap(_.subtitle)) { and then @ap})}"
             data-option-mirror-package="@plan.packageName"

--- a/app/views/fragments/promotion/fullTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/fullTermsAndConditions.scala.html
@@ -5,7 +5,7 @@
 @import com.gu.memsub.promo.PromoCode
 
 @(promoCode: PromoCode, catalog: Catalog, promotion: AnyPromotion, md: MarkdownRenderer)
-@isDigipack = @{catalog.digipack.toList.exists(plan => promotion.appliesTo.productRatePlanIds.contains(plan.id))}
+@isDigipack = @{catalog.digipack.plans.exists(plan => promotion.appliesTo.productRatePlanIds.contains(plan.id))}
 @if(promotion.asIncentive.isDefined) {
     <p>@Html(md.render(promotion.getIncentiveLegalTerms))</p>
 } else {

--- a/app/views/support/BillingPeriod.scala
+++ b/app/views/support/BillingPeriod.scala
@@ -8,7 +8,7 @@ object BillingPeriod {
       case Month => "every month"
       case Quarter => "every 3 months"
       case Year => "every 12 months"
-      case period: OneOffPeriod => s"one off payment to cover ${period.noun}"
+      case period: OneOffPeriod => s"for ${period.noun}"
     }
   }
 }

--- a/app/views/support/ProductPopulationData.scala
+++ b/app/views/support/ProductPopulationData.scala
@@ -1,11 +1,14 @@
 package views.support
 import com.gu.memsub._
 import com.gu.memsub.subsv2.CatalogPlan
+import com.gu.memsub.subsv2.CatalogPlan.{ContentSubscription, RecurringPlan}
 
 
-case class PlanList[+A](default: A, others: A*) {
-  def map[B](f: A => B): PlanList[B] = PlanList(f(default), others.map(f):_*)
+case class PlanList[+A](associations: List[(ContentSubscription, ContentSubscription)], default: A, others: A*) {
+  def map[B](f: A => B): PlanList[B] = PlanList(associations, f(default), others.map(f):_*)
   def list = Seq(default) ++ others
+  def associationFor(p: ContentSubscription) =
+    associations.toMap.get(p)
 }
 
 case class ProductPopulationData(deliveryAddress: Option[Address], plans: PlanList[CatalogPlan.ContentSubscription])

--- a/app/views/support/WeeklyPromotion.scala
+++ b/app/views/support/WeeklyPromotion.scala
@@ -35,7 +35,7 @@ object WeeklyPromotion {
           title = requestCountry.name,
           description = "Posted to you by air mail",
           countries = Set(requestCountry),
-          discountedPlans = plansForPromotion(promotion, promoCode, Set(requestCountry), catalog.weeklyZoneC.toList)
+          discountedPlans = plansForPromotion(promotion, promoCode, Set(requestCountry), catalog.weeklyZoneC.plans)
         ))
       } else {
         Seq()
@@ -45,7 +45,7 @@ object WeeklyPromotion {
         title = "Rest of the world",
         description = "Posted to you by air mail",
         countries = ZONEC - requestCountry,
-        discountedPlans = plansForPromotion(promotion, promoCode, ZONEC - requestCountry, catalog.weeklyZoneC.toList)
+        discountedPlans = plansForPromotion(promotion, promoCode, ZONEC - requestCountry, catalog.weeklyZoneC.plans)
       ))
 
     val UKregion: Set[DiscountedRegion] = {
@@ -53,19 +53,19 @@ object WeeklyPromotion {
         title = "United Kingdom",
         description = "Includes Isle of Man and Channel Islands",
         countries = UK,
-        discountedPlans = plansForPromotion(promotion, promoCode, UK, catalog.weeklyZoneA.toList)
+        discountedPlans = plansForPromotion(promotion, promoCode, UK, catalog.weeklyZoneA.plans)
       )
       val domestic = DiscountedRegion(
         title = "United Kingdom",
         description = "Includes mainland UK only.",
         countries = UKdomestic,
-        discountedPlans = plansForPromotion(promotion, promoCode, UK, catalog.weeklyZoneA.toList)
+        discountedPlans = plansForPromotion(promotion, promoCode, UK, catalog.weeklyZoneA.plans)
       )
       val overseas = DiscountedRegion(
         title = "Isle of Man and Channel Islands",
         description = "",
         countries = UKoverseas,
-        discountedPlans = plansForPromotion(promotion, promoCode, UK, catalog.weeklyZoneA.toList)
+        discountedPlans = plansForPromotion(promotion, promoCode, UK, catalog.weeklyZoneA.plans)
       )
       val countries = promotionCountries intersect UK
       val includesUKDomestic = !(countries intersect UKdomestic).isEmpty
@@ -84,31 +84,31 @@ object WeeklyPromotion {
       title = "United States",
       description = "Includes Alaska and Hawaii",
       countries = US,
-      discountedPlans = plansForPromotion(promotion, promoCode, US, catalog.weeklyZoneA.toList)
+      discountedPlans = plansForPromotion(promotion, promoCode, US, catalog.weeklyZoneA.plans)
     ))
     val AUSregion =  if (AU contains requestCountry) Seq() else Seq(DiscountedRegion(
       title = "Australia",
       description = "Posted to you by air mail",
       countries = AU,
-      discountedPlans = plansForPromotion(promotion, promoCode, AU, catalog.weeklyZoneC.toList)
+      discountedPlans = plansForPromotion(promotion, promoCode, AU, catalog.weeklyZoneC.plans)
     ))
     val NZregion =  if (NZ contains requestCountry) Seq() else Seq(DiscountedRegion(
       title = "New Zealand",
       description = "Posted to you by air mail",
       countries = NZ,
-      discountedPlans = plansForPromotion(promotion, promoCode, NZ, catalog.weeklyZoneC.toList)
+      discountedPlans = plansForPromotion(promotion, promoCode, NZ, catalog.weeklyZoneC.plans)
     ))
     val CAregion =  if (CA contains requestCountry) Seq() else Seq(DiscountedRegion(
       title = "Canada",
       description = "Posted to you by air mail",
       countries = CA,
-      discountedPlans = plansForPromotion(promotion, promoCode, CA, catalog.weeklyZoneC.toList)
+      discountedPlans = plansForPromotion(promotion, promoCode, CA, catalog.weeklyZoneC.plans)
     ))
     val EUregion = Seq(DiscountedRegion(
       title = "Europe",
       description = "Posted to you by air mail",
       countries = EU,
-      discountedPlans = plansForPromotion(promotion, promoCode, EU, catalog.weeklyZoneC.toList)
+      discountedPlans = plansForPromotion(promotion, promoCode, EU, catalog.weeklyZoneC.plans)
     ))
     val regions = regionForZoneCCountry ++ UKregion ++ USregion ++ EUregion ++ AUSregion ++  NZregion ++ CAregion  ++ rowWithoutCountry
     regions.filter(_.discountedPlans.length > 0)

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.369",
+    "com.gu" %% "membership-common" % "0.370-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.370-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.370",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
This is needed to sell 6 for 6

Before:::
![image](https://cloud.githubusercontent.com/assets/7304387/23454439/1f74911c-fe64-11e6-8a7a-d18f4a705bc4.png)

After:::

![image](https://cloud.githubusercontent.com/assets/7304387/23454289/c4fe8c06-fe63-11e6-8b43-c4287d8a9257.png)


depends on https://github.com/guardian/membership-common/pull/440
@paulbrown1982 

I still need to fix the thank you page though cc @pvighi 

