### PR TITLE
Ensure the correct TsandCs are on Guardian Weekly checkout + manage page copy

### DIFF
--- a/app/configuration/Links.scala
+++ b/app/configuration/Links.scala
@@ -15,6 +15,10 @@ object Links {
     "https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions",
     "Terms and Conditions"
   )
+  val weeklyTerms = Links(
+    "https://www.theguardian.com/info/2014/jul/10/guardian-weekly-print-subscription-services-terms-conditions",
+    "Terms and Conditions"
+  )
   val privacyPolicy = Links(
     "https://www.theguardian.com/help/privacy-policy",
     "Privacy Policy"

--- a/app/model/ContentSubscriptionPlanOps.scala
+++ b/app/model/ContentSubscriptionPlanOps.scala
@@ -2,7 +2,7 @@ package model
 
 import com.gu.i18n._
 import Currency._
-import com.gu.memsub.BillingPeriod.{OneYear, SixWeeks}
+import com.gu.memsub.BillingPeriod.{OneYear, Quarter, SixWeeks}
 import com.gu.memsub.Product
 import com.gu.memsub.subsv2.CatalogPlan
 import views.support.CountryWithCurrency
@@ -51,7 +51,7 @@ object ContentSubscriptionPlanOps {
     }
 
     def availableForCheckout: Boolean = in.charges.billingPeriod.isRecurring || in.charges.billingPeriod == SixWeeks
-    def availableForRenewal: Boolean = in.charges.billingPeriod.isRecurring || in.charges.billingPeriod == OneYear
+    def availableForRenewal: Boolean = in.charges.billingPeriod == Quarter || in.charges.billingPeriod == OneYear
 
   }
 

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -17,24 +17,10 @@
             </div>
 
             <div>
-                <p>In this section all subscribers can see their subscription details and billing schedule.</p>
-                <ul>
-                    <li>Digital Pack subscribers can see when their free trial ends</li>
-                    <li>Home Delivery subscribers can create holiday suspensions</li>
-                    <li>Voucher subscribers can see their billing schedule</li>
-                    <li>Guardian Weekly subscribers can renew their 1/2/3-year plans onto 1-year or recurring plans</li>
-                </ul>
-                @*
-                <h4>Coming soon?:</h4>
-                <ul>
-                    <li>All subscribers will be able to link their subscription to a <a class="u-link" target="_blank" href="@idWebAppSigninUrl(routes.AccountManagement.manage(None, None))">Guardian account</a></li>
-                    <li>Customers who have multiple subscriptions can manage each one independently</li>
-                    <li>Update card or Direct Debit details (will require signing in to your Guardian account)</li>
-                    <li>Update paper delivery address details (will require signing in to your Guardian account)</li>
-                    <li>Upgrade paper subscription to include the <a class="u-link" target="_blank" href="@routes.DigitalPack.redirect()">Guardian Digital Pack</a></li>
-                    <li>Online subscription cancellation</li>
-                </ul>
-                *@
+                <p>All subscribers - check your subscription details and payment schedule here.</p>
+                <p>In addition:</p>
+                <p>Home Delivery subscribers - suspend your deliveries while you're away.</p>
+                <p>Guardian Weekly subscribers - renew your subscription here.</p>
             </div>
 
             <br/>

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -20,7 +20,7 @@
                 <p>All subscribers - check your subscription details and payment schedule here.</p>
                 <p>In addition:</p>
                 <p>Home Delivery subscribers - suspend your deliveries while you're away.</p>
-                <p>Guardian Weekly subscribers - renew your subscription here.</p>
+                <p>Guardian Weekly subscribers - renew your subscription here (available from 8 March 2017).</p>
             </div>
 
             <br/>

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -111,11 +111,17 @@
         @if(productData.isDigitalPack) {
             By proceeding you agree to the
             <a href="@Links.digipackTerms.href" target="_blank">@Links.digipackTerms.title</a>
-            for Guardian Digital Pack subscriptions.
+            for Guardian and Observer digital subscriptions.
         } else {
-            By proceeding you agree to the
-            <a href="@Links.paperTerms.href" target="_blank">@Links.paperTerms.title</a>
-            for Guardian voucher and home delivery subscription services.
+            @if(productData.isGuardianWeekly) {
+                By proceeding you agree to the
+                <a href="@Links.weeklyTerms.href" target="_blank">@Links.weeklyTerms.title</a>
+                for the Guardian Weekly print subscription service.
+            } else {
+                By proceeding you agree to the
+                <a href="@Links.paperTerms.href" target="_blank">@Links.paperTerms.title</a>
+                for the Guardian and Observer voucher and home delivery subscription services.
+            }
         }
         </p>
 


### PR DESCRIPTION
- Ensure the correct TsandCs are on Guardian Weekly checkout: https://trello.com/c/eljyP97J/148-check-we-are-showing-the-right-terms-and-conditions-on-checkout
- Don't offer the 'Annual' plan on the renewal page: https://trello.com/c/dfYC790d/141-renewal-page-polishing
- Updated copy on the /manage homepage, making clear that renewals will only be available from 8th March. Comms have gone out already to existing customers explaining of the renewal site move so this message will hopefully help reduce call centre calls. https://trello.com/c/VEnxIElX/152-update-manage-page-copy

cc @johnduffell @AWare @jacobwinch @pvighi @jayceb1 