### PR TITLE
don't allow people to buy one year weekly plans

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -68,11 +68,13 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
         catalog.weeklyZoneC.plansWithAssociations
       ) ++ testOnlyPlans
 
-      def matchPlan(planCandidates: List[ContentSubscription], associations: List[(ContentSubscription, ContentSubscription)]): Option[PlanList[ContentSubscription]] =
-        planCandidates.filter(_.availableForCheckout).find(_.slug == forThisPlan).map { planFromSlug =>
-          val otherPlansInProduct = getBetterPlans(planFromSlug, planCandidates)
+      def matchPlan(planCandidates: List[ContentSubscription], associations: List[(ContentSubscription, ContentSubscription)]): Option[PlanList[ContentSubscription]] = {
+        val buyablePlans = planCandidates.filter(_.availableForCheckout)
+        buyablePlans.find(_.slug == forThisPlan).map { planFromSlug =>
+          val otherPlansInProduct = getBetterPlans(planFromSlug, buyablePlans)
           PlanList(associations, planFromSlug, otherPlansInProduct: _*)
         }
+      }
 
       contentSubscriptionPlans.map(plan => matchPlan(plan, List.empty)).find(_.isDefined).flatten orElse
       productsWithIntroductoryPlans.map {

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -69,9 +69,7 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
       ) ++ testOnlyPlans
 
       def matchPlan(planCandidates: List[ContentSubscription], associations: List[(ContentSubscription, ContentSubscription)]): Option[PlanList[ContentSubscription]] =
-        planCandidates.find{ plan =>
-          plan.slug == forThisPlan && plan.availableForCheckout // this will now check all, even digipack
-        }.map { planFromSlug =>
+        planCandidates.filter(_.availableForCheckout).find(_.slug == forThisPlan).map { planFromSlug =>
           val otherPlansInProduct = getBetterPlans(planFromSlug, planCandidates)
           PlanList(associations, planFromSlug, otherPlansInProduct: _*)
         }


### PR DESCRIPTION
following on from https://github.com/guardian/subscriptions-frontend/pull/830

I broke the code for filtering out plans we don't sell
Previously I was showing *all* the plans if the one in the url was available for checkout, rather than filtering the ones available for checkout first and then doing the check.
now:
![image](https://cloud.githubusercontent.com/assets/7304387/23457245/08839772-fe6f-11e6-9526-9aa15bd0f5f3.png)
@paulbrown1982 @pvighi 