### PR TITLE
Add terms and condition sections to Guardian Weekly promo landing page and /terms page

### DIFF
--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -116,7 +116,7 @@
             @if(productData.isGuardianWeekly) {
                 By proceeding you agree to the
                 <a href="@Links.weeklyTerms.href" target="_blank">@Links.weeklyTerms.title</a>
-                for the Guardian Weekly print subscription service.
+                for the Guardian Weekly print subscription services.
             } else {
                 By proceeding you agree to the
                 <a href="@Links.paperTerms.href" target="_blank">@Links.paperTerms.title</a>

--- a/app/views/fragments/promotion/digitalpackLegalTerms.scala.html
+++ b/app/views/fragments/promotion/digitalpackLegalTerms.scala.html
@@ -10,7 +10,7 @@ s"""
 3. By entering the promotion you are accepting these terms and conditions.
 4. To enter the promotion, you must: (i) either go to [subscribe.theguardian.com](https://subscribe.theguardian.com/) or call 0330 333 6767 and quote promotion code ${promoCode.get} (ii) purchase a Digital Pack subscription and maintain that subscription for at least three months.
 5. Entry to this promotion is available only to new subscribers: this means that you must not already have a subscription to the Digital Pack to be eligible to participate in this Promotion.
-6. Please note that purchasing a subscription as referred to in paragraph 4 above will also be subject to the terms and conditions for Guardian and Observer Subscriptions available at [theguardian.com/subscriber-direct/subscription-terms-and-conditions](https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions)
+6. Please note that purchasing a subscription as referred to in paragraph 4 above will also be subject to the terms and conditions for Guardian and Observer Digital subscriptions available at [theguardian.com/digital-subscriptions-terms-conditions](https://www.theguardian.com/digital-subscriptions-terms-conditions)
 7. The opening date and time of the Promotion is ${prettyLegalDate(promotion.starts)}. ${promotion.expires.map(expires => s"The closing date and time of the promotion is ${prettyLegalDate(expires)}. Purchases after that date and time will not be eligible for the promotion.").mkString}
 8. If you opt to use the SMS response service to place your order you will be charged your standard network rate.
 9. Only one entry to this Promotion per person. Entries on behalf of another person will not be accepted.

--- a/app/views/fragments/promotion/fullTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/fullTermsAndConditions.scala.html
@@ -5,7 +5,7 @@
 @import com.gu.memsub.promo.PromoCode
 
 @(promoCode: PromoCode, catalog: Catalog, promotion: AnyPromotion, md: MarkdownRenderer)
-@isDigipack = @{(catalog.digipack.toList.map(_.id).toSet intersect promotion.appliesTo.productRatePlanIds).nonEmpty}
+@isDigipack = @{(catalog.digipack.plans.map(_.id).toSet intersect promotion.appliesTo.productRatePlanIds).nonEmpty}
 @isGuardianWeekly = @{(catalog.weekly.flatten.map(_.id).toSet intersect promotion.appliesTo.productRatePlanIds).nonEmpty}
 @if(promotion.asIncentive.isDefined) {
     <p>@Html(md.render(promotion.getIncentiveLegalTerms))</p>

--- a/app/views/fragments/promotion/fullTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/fullTermsAndConditions.scala.html
@@ -5,13 +5,18 @@
 @import com.gu.memsub.promo.PromoCode
 
 @(promoCode: PromoCode, catalog: Catalog, promotion: AnyPromotion, md: MarkdownRenderer)
-@isDigipack = @{catalog.digipack.plans.exists(plan => promotion.appliesTo.productRatePlanIds.contains(plan.id))}
+@isDigipack = @{(catalog.digipack.toList.map(_.id).toSet intersect promotion.appliesTo.productRatePlanIds).nonEmpty}
+@isGuardianWeekly = @{(catalog.weekly.flatten.map(_.id).toSet intersect promotion.appliesTo.productRatePlanIds).nonEmpty}
 @if(promotion.asIncentive.isDefined) {
     <p>@Html(md.render(promotion.getIncentiveLegalTerms))</p>
 } else {
     @if(isDigipack) {
         <p>@fragments.promotion.digitalpackLegalTerms(promoCode, promotion, md)</p>
     } else {
-        <p>@fragments.promotion.newspaperLegalTerms(promoCode, promotion, md)</p>
+        @if(isGuardianWeekly) {
+            <p>@fragments.promotion.guardianWeeklyLegalTerms(promoCode, catalog, promotion, md)</p>
+        } else {
+            <p>@fragments.promotion.newspaperLegalTerms(promoCode, promotion, md)</p>
+        }
     }
 }

--- a/app/views/fragments/promotion/guardianWeeklyLegalTerms.scala.html
+++ b/app/views/fragments/promotion/guardianWeeklyLegalTerms.scala.html
@@ -1,0 +1,43 @@
+@import com.gu.memsub.BillingPeriod.SixWeeks
+@import com.gu.memsub.promo.PromoCode
+@import com.gu.memsub.promo.Promotion.AnyPromotion
+@import com.gu.memsub.subsv2.Catalog
+@import views.support.MarkdownRenderer
+
+@(promoCode: PromoCode, catalog: Catalog, promotion: AnyPromotion, md: MarkdownRenderer)
+@isSixForSix = @{(catalog.weekly.flatten.filter(_.charges.billingPeriod == SixWeeks).map(_.id).toSet intersect promotion.appliesTo.productRatePlanIds).nonEmpty}
+@Html(md.render(
+    if (isSixForSix) {
+s"""
+Offer not available to current subscribers of Guardian Weekly. You must be 18+ to be eligible for this offer. Guardian Weekly reserve the right to end this offer at any time.
+
+**United Kingdom:** Offer is £6 for the first 6 issues followed by quarterly (13 weeks) subscription payments of £30 thereafter, saving 20% off the cover price.
+
+**USA and Canada:** Offer is $$6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $$60, saving 30% off the cover price ($$US) and 20% ($$CAN).
+
+**Australia and New Zealand:** Offer is $$6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $$78AUD (Australia) or $$98NZD (New Zealand) thereafter, saving 18% off the cover price.
+
+**Europe:**  Offer is €6 for the first 6 issues followed by quarterly (13 weeks) subscription payments of €49, saving 30% off the cover price. Excluding Cyprus, Malta and Republic of Ireland.
+
+**Rest of World:** Offer is £6 the first 6 issues, followed by quarterly (13 weeks) subscription payments of £48.
+"""
+    } else {
+s"""
+You must be 18+ to be eligible for a Guardian Weekly subscription.
+
+**United Kingdom:** Quarterly (13 weeks) subscription rate £30 and annual rate £120, saving 20% off the cover price.
+
+**USA and Canada:** Quarterly (13 weeks) subscription rate $$60 and annual rate $$240, saving 30% off the cover price ($$US) and 20% ($$CAN).
+
+**Australia:** Quarterly (13 weeks) subscription payments of $$78 and annual rate $$312, saving 18% off the cover price.
+
+**New Zealand:** Quarterly (13 weeks) subscription rate of $$98 and annual rate $$392, saving 18% off the cover price.
+
+**Europe:** Quarterly (13 weeks) subscription rate of €49 and annual rate €196, saving 30% off the cover price. Excluding Cyprus, Malta and Republic of Ireland.
+
+**Rest of World:** Quarterly (13 weeks) subscription payments of £48 or US$$65 and annual rates £192 or US $$260.
+"""
+    }
++ "For full subscription terms and conditions visit [https://www.theguardian.com/guardian-weekly-subscription-terms-conditions](theguardian.com/guardian-weekly-subscription-terms-conditions)"
+
+))

--- a/app/views/fragments/promotion/promotionTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/promotionTermsAndConditions.scala.html
@@ -2,7 +2,7 @@
 @import views.support.MarkdownRenderer
 @import views.support.LandingPageOps._
 @(promotion: AnyPromotion, md: MarkdownRenderer)
-<h4>Promotion terms and conditions</h4>
+<h3>Promotion terms and conditions</h3>
 <p>Offer subject to availability. Guardian News and Media Limited ("GNM") reserves the right to withdraw this promotion at any time.</p>
 @promotion.asIncentive.map { p =>
     @if(p.promotionType.termsAndConditions.isDefined) {

--- a/app/views/fragments/promotion/subscriptionTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/subscriptionTermsAndConditions.scala.html
@@ -22,9 +22,19 @@
         <a class="u-link" href="@Links.digipackTerms.href" target="_blank">theguardian.com/digital-subscriptions-terms-conditions</a>.
     </p>
 } else {
-    <h4>Subscription terms and conditions</h4>
-    <p>Subscriptions available to people aged 18 and over with a valid email address.</p>
-    <p>
-        For full subscription terms and conditions visit <a class="u-link" href="@Links.paperTerms.href" target="_blank">theguardian.com/subscriber-direct/subscription-terms-and-conditions</a>
-    </p>
+    @if(promotion.asWeekly) {
+        <h4>Guardian Weekly subscription terms and conditions</h4>
+        <p>Subscriptions available to people aged 18 and over with a valid email address.</p>
+        <p>
+            For full details of Guardian Weekly print subscription services and their terms and conditions - see
+            <a class="u-link" href="@Links.weeklyTerms.href" target="_blank">theguardian.com/guardian-weekly-subscription-terms-conditions</a>
+        </p>
+    } else {
+        <h4>Newspaper subscription terms and conditions</h4>
+        <p>Subscriptions available to people aged 18 and over with a valid email address.</p>
+        <p>
+            For full details of Guardian and Observer voucher and home delivery subscription services and their terms and conditions - see
+            <a class="u-link" href="@Links.paperTerms.href" target="_blank">theguardian.com/subscriber-direct/subscription-terms-and-conditions</a>
+        </p>
+    }
 }


### PR DESCRIPTION
- Add a new Promo /terms page terms and conditions section for Guardian Weekly (in fullTermsAndConditions.scala.html)
- Fix the general terms link in the Digital pack terms and conditions section (in digitalpackLegalTerms.scala.html)
- Ensure the full terms are linked to on the Guardian Weekly promo landing page (in subscriptionTermsAndConditions.scala.html)
- Used a h3 rather than h4 title on all promo landing pages (in promoTermsAndConditions.scala.html)

cc @AWare @jacobwinch @jayceb1 @pvighi @johnduffell 