### PR TITLE
More copy tweaks for SEO and T&Cs

### DIFF
--- a/app/views/fragments/promotion/guardianWeeklyLegalTerms.scala.html
+++ b/app/views/fragments/promotion/guardianWeeklyLegalTerms.scala.html
@@ -7,7 +7,7 @@
 @(promoCode: PromoCode, catalog: Catalog, promotion: AnyPromotion, md: MarkdownRenderer)
 @isSixForSix = @{(catalog.weekly.flatten.filter(_.charges.billingPeriod == SixWeeks).map(_.id).toSet intersect promotion.appliesTo.productRatePlanIds).nonEmpty}
 @Html(md.render(
-    if (isSixForSix) {
+    (if (isSixForSix) {
 s"""
 Offer not available to current subscribers of Guardian Weekly. You must be 18+ to be eligible for this offer. Guardian Weekly reserve the right to end this offer at any time.
 
@@ -37,7 +37,8 @@ You must be 18+ to be eligible for a Guardian Weekly subscription.
 
 **Rest of World:** Quarterly (13 weeks) subscription payments of £48 or US$$65 and annual rates £192 or US $$260.
 """
-    }
-+ "For full subscription terms and conditions visit [https://www.theguardian.com/guardian-weekly-subscription-terms-conditions](theguardian.com/guardian-weekly-subscription-terms-conditions)"
-
+    }) +
+"""
+For full subscription terms and conditions visit [theguardian.com/guardian-weekly-subscription-terms-conditions](https://www.theguardian.com/guardian-weekly-subscription-terms-conditions)
+"""
 ))

--- a/app/views/promotion/weeklyLandingPage.scala.html
+++ b/app/views/promotion/weeklyLandingPage.scala.html
@@ -21,7 +21,7 @@
     @anyPromotion = @{promotion.map(asAnyPromotion)}
     @isSixForSix = @{anyPromotion.filter(p => (catalog.weekly.flatten.filter(_.charges.billingPeriod == SixWeeks).map(_.id).toSet intersect p.appliesTo.productRatePlanIds).nonEmpty)}
     @nonTrackingPromotion = @{anyPromotion.flatMap(p => p.asDiscount orElse p.asFreeTrial orElse p.asIncentive) orElse isSixForSix}
-    @title = @{"The Guardian Weekly"}
+    @title = @{"The Guardian Weekly Subscriptions"}
     @defaultImage = @{ResponsiveImageGroup(None,None,None,ResponsiveImageGenerator("021b11f82c8fb43da5ef308dc6d6c5bf2fecb9c8/0_0_2560_300",Seq(2560)))}
     @discountedRegions = @{WeeklyPromotion.validRegionsForPromotion(promotion, promoCode, country)(catalog)}
     @main(title = s"$title | The Guardian", bodyClasses = List("is-wide")) {


### PR DESCRIPTION
- Improve title of Guardian Weekly landing page
- Correctly show full terms and conditions link at bottom of /terms page

cc @jacobwinch @AWare 