### PR TITLE
Fix that Euros currency is not getting selected when countryGroup=eu

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -179,7 +179,7 @@
                                     @if(productData.isVoucher) {
                                         @fragments.checkout.fieldsVoucher(productData, deliveryCountries)
                                     }else{
-                                        @fragments.checkout.fieldsDelivery(productData, deliveryCountries)
+                                        @fragments.checkout.fieldsDelivery(productData, deliveryCountries, countryAndCurrencySettings.defaultCurrency)
                                     }
                                     @continueButton("#paymentDetails", "js-checkout-delivery-details-submit")
                                 </div>
@@ -202,7 +202,7 @@
                             <a href="#yourDetails" class="text-button u-button-reset js-edit-billing-address" title="Edit your personal details">Edit</a>
                         </div>
                         <div class="field-panel__fields">
-                            @fragments.checkout.fieldsBilling(personalData.map(_.address), canBeHidden = !productData.isDigitalPack, countryAndCurrencySettings.availableBillingCountries, productData.plans.default, !productData.isPhysical)
+                            @fragments.checkout.fieldsBilling(personalData.map(_.address), canBeHidden = !productData.isDigitalPack, countryAndCurrencySettings.availableBillingCountries, productData.plans.default, !productData.isPhysical, countryAndCurrencySettings.defaultCurrency)
                             @continueButton("#paymentDetails", "js-checkout-billing-address-submit")
                         </div>
                     </fieldset>

--- a/app/views/fragments/checkout/address.scala.html
+++ b/app/views/fragments/checkout/address.scala.html
@@ -1,3 +1,4 @@
+@import com.gu.i18n.Currency
 @import com.gu.memsub.Address
 @import com.gu.memsub.subsv2.CatalogPlan
 @import views.support.AddressValidationRulesOps._
@@ -5,7 +6,7 @@
 @import views.support.CountryWithCurrency
 @import views.support.PlanOps._
 
-@(address: Option[Address], namePrefix: String, countriesWithCurrency: List[CountryWithCurrency], plan: CatalogPlan.Paid, usePostcodeLookup: Boolean, determinesPriceBanding: Boolean)
+@(address: Option[Address], namePrefix: String, countriesWithCurrency: List[CountryWithCurrency], plan: CatalogPlan.Paid, usePostcodeLookup: Boolean, determinesPriceBanding: Boolean, defaultCurrency: Currency)
 
 
 @attrs(field: String) = @{
@@ -68,7 +69,7 @@
         <label class="label" @labelFor("country")>Country</label>
         <select @attrs("country") class=" select select--wide js-country" required>
             @if(countriesWithCurrency.size > 1) {
-                <option data-currency-choice="USD"></option>
+                <option data-currency-choice="@defaultCurrency"></option>
             }
             @for(c <- countriesWithCurrency) {
                 <option value="@c.alpha2" @c.country.validationRules.toAttributes @c.country.addressLabels data-currency-choice="@c.currency">@c.name</option>

--- a/app/views/fragments/checkout/fieldsBilling.scala.html
+++ b/app/views/fragments/checkout/fieldsBilling.scala.html
@@ -1,3 +1,4 @@
+@import com.gu.i18n.Currency
 @import com.gu.memsub.Address
 @import views.support.AddressOps._
 @import views.support.CountryWithCurrency
@@ -5,7 +6,7 @@
 @import com.gu.memsub.subsv2.CatalogPlan
 @import views.html.fragments.checkout.address
 
-@(billingAddress: Option[Address], canBeHidden: Boolean, countriesWithCurrency: List[CountryWithCurrency], plan: CatalogPlan.Paid, determinesPriceBanding : Boolean)
+@(billingAddress: Option[Address], canBeHidden: Boolean, countriesWithCurrency: List[CountryWithCurrency], plan: CatalogPlan.Paid, determinesPriceBanding: Boolean, currency: Currency)
 
 @if(canBeHidden) {
   <div class="js-checkout-use-delivery">
@@ -27,5 +28,7 @@
         countriesWithCurrency = countriesWithCurrency,
         plan = plan,
         usePostcodeLookup = false,
-        determinesPriceBanding = determinesPriceBanding)
+        determinesPriceBanding = determinesPriceBanding,
+        defaultCurrency = currency
+    )
 </div>

--- a/app/views/fragments/checkout/fieldsDelivery.scala.html
+++ b/app/views/fragments/checkout/fieldsDelivery.scala.html
@@ -1,9 +1,10 @@
+@import com.gu.i18n.Currency
 @import views.support.CountryWithCurrency
 @import views.html.fragments.checkout.address
 @import views.support.PlanOps._
 @import views.support.ProductPopulationData
 
-@(data: ProductPopulationData, countriesWithCurrency: List[CountryWithCurrency])
+@(data: ProductPopulationData, countriesWithCurrency: List[CountryWithCurrency], currency: Currency)
 
 @renderFields(usePostcodeLookup: Boolean, showDeliveryInstructions: Boolean, productName: String, firstPaperLabel: String) = {
 @address(
@@ -12,7 +13,8 @@
     countriesWithCurrency = countriesWithCurrency,
     plan = data.plans.default,
     usePostcodeLookup = usePostcodeLookup,
-    determinesPriceBanding = true)
+    determinesPriceBanding = true,
+    defaultCurrency = currency)
 
     <div class="js-checkout-delivery-data" id="deliveryFields">
         @if(showDeliveryInstructions) {

--- a/app/views/fragments/checkout/fieldsVoucher.scala.html
+++ b/app/views/fragments/checkout/fieldsVoucher.scala.html
@@ -1,3 +1,4 @@
+@import com.gu.i18n.Currency
 @import views.support.CountryWithCurrency
 @import views.html.fragments.checkout.address
 @import views.support.ProductPopulationData
@@ -10,7 +11,9 @@
     countriesWithCurrency = countriesWithCurrency,
     plan = data.plans.default,
     usePostcodeLookup = true,
-    determinesPriceBanding = true)
+    determinesPriceBanding = true,
+    defaultCurrency = Currency.GBP
+)
 
 <div class="js-checkout-delivery-data" id="voucherFields">
     <div class="form-field js-checkout-delivery">


### PR DESCRIPTION
- Fix that Euros currency is not getting set when countryGroup=eu. 
- Fix that Zone C does not default to USD currency.

This is a systemic fix that makes currency selection work properly for all products.

cc @pvighi @johnduffell @AWare @jacobwinch