### PR TITLE
A few small copy tweaks to the Guardian Weekly checkout page

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -24,24 +24,28 @@
     countryAndCurrencySettings: CountryAndCurrencySettings
 )(implicit request: RequestHeader)
 
+@andThenPricing(currency: Currency, associatedPlan: Option[CatalogPlan.Paid]) = {
+    @for(ap <- associatedPlan.map(_.charges.prettyPricing(currency))) {
+        and then @ap
+    }
+}
 @priceOption(plan: CatalogPlan.Paid, currency: Currency, associatedPlan: Option[CatalogPlan.Paid]) = {
     <label class="option" data-currency="@currency">
         <span class="option__input">
             <input
             type="radio" name="ratePlanId"
             data-option-label-prefix="@plan.prefix"
-            data-option-mirror-payment-default="@plan.charges.prettyPricing(currency) @for(ap <- associatedPlan.map(_.charges.prettyPricing(currency))) { and then @ap}"
-            data-option-mirror-payment="@plan.charges.prettyPricing(currency) @for(ap <- associatedPlan.map(_.charges.prettyPricing(currency))) { and then @ap}"
-            data-option-mirror-description="@for(s <- plan.subtitle) {(@s@for(ap <- associatedPlan.flatMap(_.subtitle)) { and then @ap})}"
+            data-option-mirror-payment-default="@plan.charges.prettyPricing(currency) @andThenPricing(currency, associatedPlan)"
+            data-option-mirror-payment="@plan.charges.prettyPricing(currency) @andThenPricing(currency, associatedPlan)"
+            data-option-mirror-description="@for(s <- plan.subtitle) { (@s) }"
             data-option-mirror-package="@plan.packageName"
-            data-name="@plan.name @for(ap <- associatedPlan.map(_.name)) { and then @ap}"
-
+            data-name="@plan.name"
             data-currency="@currency"
             value="@plan.id.get"
             @if(plan == productData.plans.default && currency == countryAndCurrencySettings.defaultCurrency){ checked="checked" }
             >
         </span>
-        <span class="option__label" id="label-for-@plan.id.get-@currency">@plan.prettyName(currency) @for(ap <- associatedPlan.map(_.charges.prettyPricing(currency))) { and then @ap}</span>
+        <span class="option__label" id="label-for-@plan.id.get-@currency">@plan.prettyName(currency) @andThenPricing(currency, associatedPlan)</span>
     </label>
 }
 

--- a/app/views/fragments/checkout/basketPreview.scala.html
+++ b/app/views/fragments/checkout/basketPreview.scala.html
@@ -1,8 +1,5 @@
-@import com.gu.memsub.Current
-@import com.gu.memsub.BillingPeriod
-@import com.gu.memsub.ProductFamily
-@import views.support.PlanOps._
 @import com.gu.memsub.subsv2.CatalogPlan
+@import views.support.PlanOps._
 
 @(plan: CatalogPlan.Paid)
 
@@ -20,7 +17,7 @@
             @plan.packageName
         </span>
         <span class="basket-preview__product__caption js-option-mirror-description-display">
-            (@plan.subtitle)
+            @for(s <- plan.subtitle) { (@s) }
         </span>
         <span class="basket-preview__product__payment js-option-mirror-payment-display"></span>
     </div>

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -20,7 +20,7 @@ object PlanOps {
 
     def packageName: String = in.charges.benefits.list match {
       case Digipack :: Nil => "Guardian Digital Pack"
-      case Weekly :: Nil => "Guardian Weekly"
+      case Weekly :: Nil => "The Guardian Weekly"
       case _ => s"${in.name} package"
     }
 

--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -2,14 +2,14 @@ package views.support
 
 import com.gu.i18n.Currency
 import com.gu.i18n.Currency.GBP
+import com.gu.memsub.BillingPeriod._
+import com.gu.memsub.Digipack
+import com.gu.memsub.Weekly
 import com.gu.memsub.promo.PercentDiscount.getDiscountScaledToPeriod
 import com.gu.memsub.promo.{LandingPage, PercentDiscount, Promotion}
-import com.gu.memsub.{BillingPeriod => BP, _}
-import BP._
 import com.gu.memsub.subsv2._
 import views.support.BillingPeriod._
 import views.support.PlanOps._
-import scalaz.Id
 
 import scala.language.higherKinds
 
@@ -57,7 +57,7 @@ object Pricing {
               s"${discountAmount.pretty} for 1 year, then ${originalAmount.pretty} every year thereafter"
             }
           case OneYear => s"${discountAmount.pretty} for 1 year"
-
+          case _ => ""
         }
       }
     }
@@ -80,6 +80,7 @@ object Pricing {
 
     def prettyName(currency: Currency): String = in.charges.benefits.list match {
       case Digipack :: Nil => planWithPricing.prettyPricing(currency)
+      case Weekly :: Nil => planWithPricing.prettyPricing(currency)
       case _ => s"$prefix${planWithPricing.prettyPricing(currency)}"
     }
   }

--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -57,7 +57,6 @@ object Pricing {
               s"${discountAmount.pretty} for 1 year, then ${originalAmount.pretty} every year thereafter"
             }
           case OneYear => s"${discountAmount.pretty} for 1 year"
-          case _ => ""
         }
       }
     }
@@ -79,8 +78,7 @@ object Pricing {
     }
 
     def prettyName(currency: Currency): String = in.charges.benefits.list match {
-      case Digipack :: Nil => planWithPricing.prettyPricing(currency)
-      case Weekly :: Nil => planWithPricing.prettyPricing(currency)
+      case Digipack :: Nil | Weekly :: Nil => planWithPricing.prettyPricing(currency)
       case _ => s"$prefix${planWithPricing.prettyPricing(currency)}"
     }
   }

--- a/assets/stylesheets/modules/_checkout-basket.scss
+++ b/assets/stylesheets/modules/_checkout-basket.scss
@@ -48,7 +48,7 @@
     }
 }
 .basket-preview__product__caption {
-    display: inline-block;
+    display: inline;
     font-weight: normal;
 
     @include mq($until: desktop) {


### PR DESCRIPTION
- A few small tweaks to the Guardian Weekly checkout page to remove unnecessary bits of copy, whitespace etc.
- Renamed the product to The Guardian Weekly instead of Guardian Weekly
- Removed the repeating product name from each payment frequency (making GW like Digital Pack)
- Refactored the 'and then' generators into one helper macro.

Before:
![picture 30](https://cloud.githubusercontent.com/assets/1515970/23506026/fe780658-ff3d-11e6-9dea-4ed0d3dadf1c.png)

After:
![picture 31](https://cloud.githubusercontent.com/assets/1515970/23506468/51ae2da0-ff40-11e6-8a30-ee662303cfad.png)

cc @johnduffell @AWare @pvighi @jacobwinch 