### PR TITLE
updated membership common version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.370",
+    "com.gu" %% "membership-common" % "0.373",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
to support sf contacts with no identity id
related common PR: https://github.com/guardian/membership-common/pull/442
@paulbrown1982 @johnduffell @jacobwinch @AWare 