### PR TITLE
Fix promo code validation on GW renewal page

### DIFF
--- a/app/controllers/Promotion.scala
+++ b/app/controllers/Promotion.scala
@@ -16,6 +16,7 @@ import utils.TestUsers.PreSigninTestCookie
 import views.html.{checkout => view}
 import views.support.Pricing._
 import views.support.{BillingPeriod => _}
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object Promotion extends Controller with LazyLogging with CatalogProvider {
@@ -66,7 +67,7 @@ object Promotion extends Controller with LazyLogging with CatalogProvider {
     implicit val tpBackend = resolution.backend
 
     tpBackend.promoService.findPromotionFuture(promoCode).map { promotion =>
-      promotion.filterNot(_.isTracking).fold {
+      promotion.fold {
         NotFound(Json.obj("errorMessage" -> s"Sorry, we can't find that code."))
       } { promo =>
         val result = promo.validate(country)


### PR DESCRIPTION
On the renewal flow we _do_ want to show 'Promotion applied' and the description for a tracking promo code [in this context aka an Effort code]. This is not the case on the checkout, so the filter can be removed from one of the two controller endpoints.

cc @AWare @jacobwinch 