### PR TITLE
Use next available shipping date as start date when renewing an expired sub.

### DIFF
--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -34,10 +34,24 @@ import scalaz.std.scalaFuture._
 import scalaz.syntax.monad._
 import scalaz.{EitherT, Monad, NonEmptyList, \/}
 
-object CheckoutService {
+object CheckoutService extends LazyLogging {
+
   def paymentDelay(in: Either[PaperData, DigipackData], zuora: ZuoraProperties)(implicit now: LocalDate): Days = in.fold(
     p => Days.daysBetween(now, p.startDate), d => zuora.gracePeriodInDays.plus(zuora.paymentDelayInDays)
   )
+
+  def determineFirstAvailablePaperDate(now: LocalDate): LocalDate = {
+    val dayOfWeek = now.getDayOfWeek
+    logger.info(s"Today is day number: $dayOfWeek")
+    val daysToFastForward = if (dayOfWeek <= 5) {
+      (5 - dayOfWeek) + 7 // Skips to a week on Friday
+    } else {
+      (5 - dayOfWeek) + 14 // We've just missed Saturday's fulfillment file creation, so we have to skip another Friday
+    }
+    val nextAvailableDate = now.plusDays(daysToFastForward)
+    nextAvailableDate
+  }
+
 }
 
 class CheckoutService(identityService: IdentityService,
@@ -296,12 +310,14 @@ class CheckoutService(identityService: IdentityService,
       }
     }
 
-    val contractEffective = Seq(subscription.termEndDate, now).max // The sub may have 'expired' before the customer gets round to renewing it.
-    val customerAcceptance = contractEffective
+    val currentVersionExpired = subscription.termEndDate.isBefore(now)
+    // For a renewal, all dates should be identical. If the sub has expired, this date should be fast-forwarded to the next available paper date
+    val startDateForRenewal = if (currentVersionExpired) CheckoutService.determineFirstAvailablePaperDate(now) else subscription.termEndDate
+    val contractEffective = startDateForRenewal
+    val customerAcceptance = startDateForRenewal
 
     def addPlan(contact: Contact) = {
       val newRatePlan = RatePlan(renewal.plan.id.get, None)
-      val currentVersionExpired = subscription.termEndDate.isBefore(now)
       val renewCommand = Renew(
         subscriptionId = subscription.id.get,
         currentTermStartDate = subscription.termStartDate,
@@ -311,7 +327,7 @@ class CheckoutService(identityService: IdentityService,
         customerAcceptanceDate = customerAcceptance,
         promoCode = None,
         autoRenew = renewal.plan.charges.billingPeriod.isRecurring,
-        startRenewedTermToday = currentVersionExpired // If the sub has expired, we want to shift the term dates forward
+        fastForwardTermStartDate = currentVersionExpired // If the sub has expired, we need to shift the term dates forward
       )
 
       val validPromotion = for {

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -34,7 +34,7 @@ import scalaz.std.scalaFuture._
 import scalaz.syntax.monad._
 import scalaz.{EitherT, Monad, NonEmptyList, \/}
 
-object CheckoutService extends LazyLogging {
+object CheckoutService {
 
   def paymentDelay(in: Either[PaperData, DigipackData], zuora: ZuoraProperties)(implicit now: LocalDate): Days = in.fold(
     p => Days.daysBetween(now, p.startDate), d => zuora.gracePeriodInDays.plus(zuora.paymentDelayInDays)
@@ -42,7 +42,6 @@ object CheckoutService extends LazyLogging {
 
   def determineFirstAvailablePaperDate(now: LocalDate): LocalDate = {
     val dayOfWeek = now.getDayOfWeek
-    logger.info(s"Today is day number: $dayOfWeek")
     val daysToFastForward = if (dayOfWeek <= 5) {
       (5 - dayOfWeek) + 7 // Skips to a week on Friday
     } else {

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.376",
+    "com.gu" %% "membership-common" % "0.377",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/test/services/CheckoutServiceTest.scala
+++ b/test/services/CheckoutServiceTest.scala
@@ -49,4 +49,21 @@ class CheckoutServiceTest extends Specification {
       CheckoutService.paymentDelay(paperData, zuora) mustEqual Days.days(8)
     }
   }
+
+  "determineNextAvailablePaperDate" should {
+
+    "Calculate the next available Friday correctly (if today is a Monday)" in {
+       CheckoutService.determineFirstAvailablePaperDate(new LocalDate("2017-03-06")) mustEqual(new LocalDate("2017-03-17"))
+    }
+
+    "Calculate the next available Friday correctly (if today is a Friday)" in {
+      CheckoutService.determineFirstAvailablePaperDate(new LocalDate("2017-03-10")) mustEqual(new LocalDate("2017-03-17"))
+    }
+
+    "Calculate the next available Friday correctly (if today is a Sunday)" in {
+      CheckoutService.determineFirstAvailablePaperDate(new LocalDate("2017-03-12")) mustEqual(new LocalDate("2017-03-24"))
+    }
+
+  }
+
 }

--- a/test/services/CheckoutServiceTest.scala
+++ b/test/services/CheckoutServiceTest.scala
@@ -50,7 +50,7 @@ class CheckoutServiceTest extends Specification {
     }
   }
 
-  "determineNextAvailablePaperDate" should {
+  "determineFirstAvailablePaperDate" should {
 
     "Calculate the next available Friday correctly (if today is a Monday)" in {
        CheckoutService.determineFirstAvailablePaperDate(new LocalDate("2017-03-06")) mustEqual(new LocalDate("2017-03-17"))


### PR DESCRIPTION
This PR:

- Enables us to calculate the next available shipping date when renewing an expired sub 
- Pulls in membership-common changes here: https://github.com/guardian/membership-common/pull/446
- Sets all three dates (contract effective, customer acceptance, term start date) as the next available shipping date (when renewing an expired sub).

@paulbrown1982 @pvighi @johnduffell 