### PR TITLE
Fix promotion currency look up (and manage page)

### DIFF
--- a/app/controllers/Promotion.scala
+++ b/app/controllers/Promotion.scala
@@ -32,7 +32,7 @@ object Promotion extends Controller with LazyLogging with CatalogProvider {
     case class RatePlanPrice(ratePlanId: ProductRatePlanId, chargeList: PaidChargeList)
     promo.asDiscount.map { discountPromo =>
     catalog.allSubs.flatten
-        .filter(plan => promo.appliesTo.productRatePlanIds.contains(plan.id))
+        .filter(plan => promo.appliesTo.productRatePlanIds contains plan.id)
         .filter(plan => plan.charges.currencies contains currency)
         .map(plan => RatePlanPrice(plan.id, plan.charges)).map { ratePlanPrice =>
           ratePlanPrice.ratePlanId.get -> ratePlanPrice.chargeList.prettyPricingForDiscountedPeriod(discountPromo, currency)

--- a/app/controllers/Promotion.scala
+++ b/app/controllers/Promotion.scala
@@ -31,10 +31,11 @@ object Promotion extends Controller with LazyLogging with CatalogProvider {
 
     case class RatePlanPrice(ratePlanId: ProductRatePlanId, chargeList: PaidChargeList)
     promo.asDiscount.map { discountPromo =>
-      catalog.allSubs.flatten
+    catalog.allSubs.flatten
         .filter(plan => promo.appliesTo.productRatePlanIds.contains(plan.id))
+        .filter(plan => plan.charges.currencies contains currency)
         .map(plan => RatePlanPrice(plan.id, plan.charges)).map { ratePlanPrice =>
-        ratePlanPrice.ratePlanId.get -> ratePlanPrice.chargeList.prettyPricingForDiscountedPeriod(discountPromo, currency)
+          ratePlanPrice.ratePlanId.get -> ratePlanPrice.chargeList.prettyPricingForDiscountedPeriod(discountPromo, currency)
       }.toMap
     }
   }
@@ -50,7 +51,7 @@ object Promotion extends Controller with LazyLogging with CatalogProvider {
       } {
         promo =>
           val result = promo.validateFor(prpId, country)
-          val body = Json.obj(
+          def body = Json.obj(
             "promotion" -> Json.toJson(promo),
             "adjustedRatePlans" -> Json.toJson(getAdjustedRatePlans(promo, country, currency)),
             "isValid" -> result.isRight,
@@ -71,7 +72,7 @@ object Promotion extends Controller with LazyLogging with CatalogProvider {
         NotFound(Json.obj("errorMessage" -> s"Sorry, we can't find that code."))
       } { promo =>
         val result = promo.validate(country)
-        val body = Json.obj(
+        def body = Json.obj(
           "promotion" -> Json.toJson(promo),
           "adjustedRatePlans" -> Json.toJson(getAdjustedRatePlans(promo, country, currency)),
           "isValid" -> result.isRight,

--- a/app/views/account/digitalpack.scala.html
+++ b/app/views/account/digitalpack.scala.html
@@ -12,7 +12,7 @@
     subscription: Subscription[Digipack], billingSchedule: Option[BillingSchedule]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
-@main("Your Guardian Digital Pack subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = false) {
+@main("Your Guardian Digital Pack subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {
 
     <main class="page-container gs-container">
         <section class="suspend-container">

--- a/app/views/account/voucher.scala.html
+++ b/app/views/account/voucher.scala.html
@@ -7,7 +7,7 @@
     subscription: Subscription[Voucher], billingSchedule: Option[BillingSchedule]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
-@main("Your Guardian subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = false) {
+@main("Your Guardian subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {
 
     <main class="page-container gs-container">
         <section class="suspend-container">


### PR DESCRIPTION
We were getting 500 errors on promos where the plan did not have the desired currency. (mostly due to zone B)
https://sentry.io/the-guardian/subscriptions/issues/199120847/

also making the json response body into a def so it's not eagerly calculated for incorrect promos

(and fixing my last pr, I left a few fixes in my checkin)