### PR TITLE
display correct email address for weekly landing page

### DIFF
--- a/app/configuration/Links.scala
+++ b/app/configuration/Links.scala
@@ -29,10 +29,6 @@ object Links {
     "Why your data matter to us"
   )
 
-  val guardianSubscriptionFaqs = Links(
-    "https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions",
-    "Frequently Asked Questions"
-  )
 }
 
 object ProfileLinks {

--- a/app/views/account/thankYouRenew.scala.html
+++ b/app/views/account/thankYouRenew.scala.html
@@ -9,7 +9,7 @@
   touchpointBackendResolution: services.TouchpointBackend.Resolution
 )(implicit request: RequestHeader)
 
-@main(s"Confirmation | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution), plan = None) {
+@main(s"Confirmation | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution), product = Some(plan.product)) {
     <main class="page-container gs-container gs-container--slim">
         @fragments.page.header("Thank you", None, List("l-padded"))
         <section class="section-slice section-slice--bleed section-slice--limited">

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -61,7 +61,7 @@
     jsVars = JsVars(userIsSignedIn = personalData.isDefined, ignorePageLoadTracking = true, currency = countryAndCurrencySettings.defaultCurrency, country = countryAndCurrencySettings.defaultCountry),
     bodyClasses = List("is-wide"),
     touchpointBackendResolutionOpt = Some(touchpointBackendResolution),
-    plan = Some(productData.plans.default),
+    product = Some(productData.plans.default.product),
     edition = edition
 ) {
 <script>

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -14,7 +14,7 @@
     startDate: String
 )(implicit request: RequestHeader)
 
-@main(s"Confirmation | Subscribe to the ${plan.title} | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution), plan = Some(plan)) {
+@main(s"Confirmation | Subscribe to the ${plan.title} | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution), product = Some(plan.product)) {
 
 <script type="text/javascript">
     guardian.pageInfo.slug="GuardianDigiPack:Order Complete";
@@ -43,7 +43,7 @@
                     you'll receive email confirmation of this shortly.
                 </p>
                 <p>Here are the details of your subscription, if any of these are incorrect please get in touch with us straight away via email at
-                    <a href="mailto:@plan.email">@plan.email</a> or on <strong>@plan.phone</strong>.
+                    <a href="mailto:@plan.product.email">@plan.product.email</a> or on <strong>@plan.phone</strong>.
                     Lines open weekdays 8am-8pm, weekend 8pm-6pm.</p>
             </div>
             @fragments.checkout.reviewPanel(subscriptionName, plan, promotion, currency)

--- a/app/views/fragments/checkout/noticesDirectDebit.scala.html
+++ b/app/views/fragments/checkout/noticesDirectDebit.scala.html
@@ -25,7 +25,7 @@
 
     <ul class="o-unstyled-list">
         <li>Tel: @plan.phone</li>
-        <li><a href="mailto:@plan.email">@plan.email</a></li>
+        <li><a href="mailto:@plan.product.email">@plan.product.email</a></li>
     </ul>
 
     <aside class="direct-debit">

--- a/app/views/fragments/global/footer.scala.html
+++ b/app/views/fragments/global/footer.scala.html
@@ -5,9 +5,9 @@
 @import com.gu.memsub.subsv2.CatalogPlan
 @import com.gu.memsub.Current
 @import model.DigitalEdition
-@import model.DigitalEdition
+@import com.gu.memsub.Product
 
-@(plan: Option[CatalogPlan.Paid], edition: DigitalEdition)
+@(product: Option[Product], edition: DigitalEdition)
 
 <footer class="global-footer">
 
@@ -18,13 +18,13 @@
         <div class="gs-container">
             <p>
               For help with Guardian and Observer subscription services please email
-                  <a href="mailto:@plan.fold("subscriptions@theguardian.com")(_.email)">@plan.fold("subscriptions@theguardian.com")(_.email)</a> or call @plan.fold("+44 (0) 330 333 6767")(_.phone). Open BST 8am to 8pm, Monday to Sunday.
+                  <a href="mailto:@product.fold("subscriptions@theguardian.com")(_.email)">@product.fold("subscriptions@theguardian.com")(_.email)</a> or call +44 (0) 330 333 6767. Open BST 8am to 8pm, Monday to Sunday.
             </p>
             <p>
                 You may also find help in our
-                <a href="@Links.guardianSubscriptionFaqs.href"
-                   title="@Links.guardianSubscriptionFaqs.title">
-                   @Links.guardianSubscriptionFaqs.title.
+                <a href="@product.map(_.faqHref).getOrElse("https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions")"
+                   title="Frequently Asked Questions">
+                   Frequently Asked Questions.
                 </a>
             </p>
             <small class="global-footer__copyright">

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -3,7 +3,7 @@
 @import utils.TestUsers.{PreSigninTestCookie, NameEnteredInForm, SignedInUsername}
 @import com.gu.memsub.subsv2.CatalogPlan
 @import com.gu.memsub.BillingPeriod
-@import com.gu.memsub.Current
+@import com.gu.memsub.Product
 @import model.DigitalEdition
 
 @(
@@ -12,7 +12,7 @@
     jsVars: model.JsVars = model.JsVars(),
     bodyClasses: Seq[String] = Nil,
     touchpointBackendResolutionOpt: Option[services.TouchpointBackend.Resolution] = None,
-    plan: Option[CatalogPlan.Paid] = None,
+    product: Option[Product] = None,
     edition: DigitalEdition = DigitalEdition.INT,
     managementPage: Boolean = false
 )(content: Html)
@@ -45,7 +45,7 @@
             @content
         </div>
 
-        @fragments.global.footer(plan, edition)
+        @fragments.global.footer(product, edition)
         @fragments.footerJavaScript()
     </body>
 </html>

--- a/app/views/promotion/weeklyLandingPage.scala.html
+++ b/app/views/promotion/weeklyLandingPage.scala.html
@@ -17,6 +17,7 @@
 @import com.gu.memsub.images.ResponsiveImageGenerator
 @import com.gu.memsub.BillingPeriod.SixWeeks
 
+@import com.gu.memsub.Product.WeeklyZoneA
 @(country: Country, catalog: Catalog, promoCode: Option[PromoCode], promotion: Option[PromoWithWeeklyLandingPage],description:Html, md: MarkdownRenderer)
     @anyPromotion = @{promotion.map(asAnyPromotion)}
     @isSixForSix = @{anyPromotion.filter(p => (catalog.weekly.plans.flatten.filter(_.charges.billingPeriod == SixWeeks).map(_.id).toSet intersect p.appliesTo.productRatePlanIds).nonEmpty)}
@@ -24,7 +25,7 @@
     @title = @{"The Guardian Weekly Subscriptions"}
     @defaultImage = @{ResponsiveImageGroup(None,None,None,ResponsiveImageGenerator("021b11f82c8fb43da5ef308dc6d6c5bf2fecb9c8/0_0_2560_300",Seq(2560)))}
     @discountedRegions = @{WeeklyPromotion.validRegionsForPromotion(promotion, promoCode, country)(catalog)}
-    @main(title = s"$title | The Guardian", bodyClasses = List("is-wide")) {
+    @main(title = s"$title | The Guardian", bodyClasses = List("is-wide"), product = Some(WeeklyZoneA)) {
 
         @fragments.heroBanner(promotion.flatMap(_.landingPage.image).getOrElse(defaultImage)){
             @title

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -6,6 +6,7 @@ import com.gu.memsub._
 import com.gu.memsub.images.{ResponsiveImage, ResponsiveImageGenerator, ResponsiveImageGroup}
 import com.gu.memsub.subsv2.CatalogPlan
 import com.netaporter.uri.dsl._
+import configuration.Links
 
 import scala.reflect.internal.util.StringOps
 import scalaz.syntax.std.boolean._
@@ -53,13 +54,6 @@ object PlanOps {
       case _ => "Add more"
     }
 
-    def email: String = (
-      in.isHomeDelivery.option("homedelivery@theguardian.com") orElse
-      in.isVoucher.option("vouchersubs@theguardian.com") orElse
-      in.hasDigitalPack.option("digitalpack@theguardian.com") orElse
-      in.isGuardianWeekly.option("gwsubs@theguardian.com")
-    ).getOrElse("subscriptions@theguardian.com")
-
     def isHomeDelivery: Boolean = in.product == Delivery
 
     def isVoucher: Boolean = in.product == Voucher
@@ -90,6 +84,25 @@ object PlanOps {
         "Unknown"
       }
     }
+  }
+
+  implicit class ProductOps(product: Product) {
+
+    def email: String =
+      product match {
+        case Delivery => "homedelivery@theguardian.com"
+        case Voucher => "vouchersubs@theguardian.com"
+        case Product.Digipack => "digitalpack@theguardian.com"
+        case _:Product.Weekly => "gwsubs@theguardian.com"
+        case _ => "subscriptions@theguardian.com"
+      }
+
+    def faqHref: String =
+      product match {
+        case _:Product.Weekly => "https://www.theguardian.com/help/2012/jan/19/guardian-weekly-faqs"
+        case _ => "https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
+      }
+
   }
 
   implicit class ProductPopulationDataOps(in: ProductPopulationData) {


### PR DESCRIPTION
Just need to make sure the FAQ and email address are right.
Trello: https://trello.com/c/BJSC1eD2/164-put-correct-contact-details-and-faqs-at-bottom-of-gw-page

before
![image](https://cloud.githubusercontent.com/assets/7304387/23619720/7744add8-028c-11e7-80c6-4e0e0fcda3d6.png)
after
![image](https://cloud.githubusercontent.com/assets/7304387/23619768/97cad384-028c-11e7-891a-1e9340039096.png)

new link to faqs is https://www.theguardian.com/help/2012/jan/19/guardian-weekly-faqs

@pvighi @paulbrown1982 