### PR TITLE
Fix one-off renewal with promo code + ordering of email fields

### DIFF
--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -223,14 +223,14 @@ class ExactTargetService(
 
     val sentMessage = (for {
       paymentMethod <- EitherT(getPaymentMethod(oldSub.accountId))
-      row = GuardianWeeklyRenewalDataExtensionRow(oldSub.name,
-        renewal.plan.name,
-        subscriptionDetails,
-        contact,
-        paymentMethod,
-        email,
-        customerAcceptance,
-        contractEffective)
+      row = GuardianWeeklyRenewalDataExtensionRow(subscriptionName = oldSub.name,
+        subscriptionDetails = subscriptionDetails,
+        planName = renewal.plan.name,
+        contact = contact,
+        paymentMethod = paymentMethod,
+        email = email,
+        customerAcceptance = customerAcceptance,
+        contractEffective = contractEffective)
       sendMessage <- EitherT(sendToQueue(row))
     } yield (sendMessage)).run
 

--- a/app/views/account/thankYouRenew.scala.html
+++ b/app/views/account/thankYouRenew.scala.html
@@ -13,10 +13,7 @@
     <main class="page-container gs-container gs-container--slim">
         @fragments.page.header("Thank you", None, List("l-padded"))
         <section class="section-slice section-slice--bleed section-slice--limited">
-            <p>Your Guardian Weekly subscription has been renewed. @plan.charges.billingPeriod match {
-                    case _: OneOffPeriod => { We will take a @plan.charges.prettyPricing(plan.charges.currencies.head) from your account. }
-                    case _ => { We will take @plan.charges.prettyPricing(plan.charges.currencies.head) from your account, starting @if(plan.start.isAfter(now)) { @prettyDate(plan.start). } else { today. } }
-            } </p>
+            <p>Your Guardian Weekly subscription has been renewed.</p>
         </section>
         <section class="section-slice--bleed section-slice--limited">
             <h3 class="mma-section__header">

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.377",
+    "com.gu" %% "membership-common" % "0.378",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
@paulbrown1982 @pvighi 

- Bump membership common to pull in: https://github.com/guardian/membership-common/pull/447
- Remove text from renewal thankyou page - this is incorrect if you renew with a promo code (I also think it's superfluous as we show the full billing schedule anyway).
- Correct the order of fields for GuardianWeeklyRenewalDataExtensionRow