### PR TITLE
Renewal promo step up text

### DIFF
--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -36,14 +36,18 @@ object Pricing {
         plan.billingPeriod match {
           case Month =>
             val span = durationMonths
-            if (span > 1) {
+            if (span == 12) {
+              s"${discountAmount.pretty} per month for 1 year, then ${originalAmount.pretty} every month thereafter"
+            } else if (span > 1) {
               s"${discountAmount.pretty} for $span months, then ${originalAmount.pretty} every month thereafter"
             } else {
               s"${discountAmount.pretty} for 1 month, then ${originalAmount.pretty} every month thereafter"
             }
           case Quarter =>
             val span = getDiscountScaledToPeriod(discountPromo.promotionType, Quarter)._2
-            if (span > 1) {
+            if (span == 4) {
+              s"${discountAmount.pretty} per quarter for 1 year, then ${originalAmount.pretty} every quarter thereafter"
+            } else if (span > 1) {
               s"${discountAmount.pretty} for ${span.toInt} quarters, then ${originalAmount.pretty} every quarter thereafter"
             } else {
               s"${discountAmount.pretty} for 1 quarter, then ${originalAmount.pretty} every quarter thereafter"
@@ -55,7 +59,7 @@ object Pricing {
             } else {
               s"${discountAmount.pretty} for 1 year, then ${originalAmount.pretty} every year thereafter"
             }
-          case OneYear => s"${discountAmount.pretty} for 1 year"
+          case OneYear => s"${discountAmount.pretty} for 1 year only"
         }
       }
     }

--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -33,34 +33,36 @@ object Pricing {
       discountPromo.promotionType.durationMonths.fold {
         s"${discountAmount.pretty} ${plan.billingPeriod.frequencyInMonths}"
       } { durationMonths =>
-        plan.billingPeriod match {
+
+        val forDuration = plan.billingPeriod match {
           case Month =>
             val span = durationMonths
             if (span == 12) {
-              s"${discountAmount.pretty} per month for 1 year, then standard rate (currently ${originalAmount.pretty} per month)"
+              "every month for 1 year"
             } else if (span > 1) {
-              s"${discountAmount.pretty} for $span months, then standard rate (currently ${originalAmount.pretty} per month)"
+              s"every month for $span months"
             } else {
-              s"${discountAmount.pretty} for 1 month, then standard rate (currently ${originalAmount.pretty} per month)"
+              "for 1 month"
             }
           case Quarter =>
             val span = getDiscountScaledToPeriod(discountPromo.promotionType, Quarter)._2
             if (span == 4) {
-              s"${discountAmount.pretty} per quarter for 1 year, then standard rate (currently ${originalAmount.pretty} per quarter)"
+              "every quarter for 1 year"
             } else if (span > 1) {
-              s"${discountAmount.pretty} for ${span.toInt} quarters, then standard rate (currently ${originalAmount.pretty} per quarter)"
+              s"every quarter for ${span.toInt} quarters"
             } else {
-              s"${discountAmount.pretty} for 1 quarter, then standard rate (currently ${originalAmount.pretty} per quarter)"
+              "for 1 quarter"
             }
           case Year =>
             val span = getDiscountScaledToPeriod(discountPromo.promotionType, Year)._2
             if (span > 1) {
-              s"${discountAmount.pretty} for ${span.toInt} years, then standard rate (currently ${originalAmount.pretty} per year)"
+              s"every year for ${span.toInt} years"
             } else {
-              s"${discountAmount.pretty} for 1 year, then standard rate (currently ${originalAmount.pretty} per year)"
+              "for 1 year"
             }
           case OneYear => s"${discountAmount.pretty} for 1 year only"
         }
+        s"${discountAmount.pretty} $forDuration, then standard rate (${originalAmount.pretty} every ${plan.billingPeriod.noun})"
       }
     }
 

--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -37,27 +37,27 @@ object Pricing {
           case Month =>
             val span = durationMonths
             if (span == 12) {
-              s"${discountAmount.pretty} per month for 1 year, then ${originalAmount.pretty} every month thereafter"
+              s"${discountAmount.pretty} per month for 1 year, then standard rate (currently ${originalAmount.pretty} per month)"
             } else if (span > 1) {
-              s"${discountAmount.pretty} for $span months, then ${originalAmount.pretty} every month thereafter"
+              s"${discountAmount.pretty} for $span months, then standard rate (currently ${originalAmount.pretty} per month)"
             } else {
-              s"${discountAmount.pretty} for 1 month, then ${originalAmount.pretty} every month thereafter"
+              s"${discountAmount.pretty} for 1 month, then standard rate (currently ${originalAmount.pretty} per month)"
             }
           case Quarter =>
             val span = getDiscountScaledToPeriod(discountPromo.promotionType, Quarter)._2
             if (span == 4) {
-              s"${discountAmount.pretty} per quarter for 1 year, then ${originalAmount.pretty} every quarter thereafter"
+              s"${discountAmount.pretty} per quarter for 1 year, then standard rate (currently ${originalAmount.pretty} per quarter)"
             } else if (span > 1) {
-              s"${discountAmount.pretty} for ${span.toInt} quarters, then ${originalAmount.pretty} every quarter thereafter"
+              s"${discountAmount.pretty} for ${span.toInt} quarters, then standard rate (currently ${originalAmount.pretty} per quarter)"
             } else {
-              s"${discountAmount.pretty} for 1 quarter, then ${originalAmount.pretty} every quarter thereafter"
+              s"${discountAmount.pretty} for 1 quarter, then standard rate (currently ${originalAmount.pretty} per quarter)"
             }
           case Year =>
             val span = getDiscountScaledToPeriod(discountPromo.promotionType, Year)._2
             if (span > 1) {
-              s"${discountAmount.pretty} for ${span.toInt} years, then ${originalAmount.pretty} every year thereafter"
+              s"${discountAmount.pretty} for ${span.toInt} years, then standard rate (currently ${originalAmount.pretty} per year)"
             } else {
-              s"${discountAmount.pretty} for 1 year, then ${originalAmount.pretty} every year thereafter"
+              s"${discountAmount.pretty} for 1 year, then standard rate (currently ${originalAmount.pretty} per year)"
             }
           case OneYear => s"${discountAmount.pretty} for 1 year only"
         }


### PR DESCRIPTION
Hopefully improve the text which appears in checkout, renewal and confirmation emails that describes the revised billing schedule when a promotion applies to a sub, by making it slightly more clear that the rate paid for after the promotional period has ended is at the standard rate, which the Ts&Cs hopefully say may be subject to any price rises after a sub's initial 1 year term.

Before:
![picture 41](https://cloud.githubusercontent.com/assets/1515970/23656559/1cd95cbc-0332-11e7-8b79-42808f603d0b.png)

After:

<img width="360" alt="picture 42" src="https://cloud.githubusercontent.com/assets/1515970/23657486/438691b4-0336-11e7-8eb9-08e68479f390.png">

cc @jacobwinch @pvighi @johnduffell @jayceb1 @AWare 