### PR TITLE
hide delivery instructions label in review panel …

### DIFF
--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -22,7 +22,7 @@
             <div class="review-details__list">
                 <ul class="o-unstyled-list">
                     <li class="js-checkout-review-delivery-address"></li>
-                    <li><span class="review-details__detail">Delivery instructions:</span> <span class="js-checkout-review-delivery-instructions"></span></li>
+                    <li><span class="review-details__detail js-checkout-review-delivery-instructions-field">Delivery instructions:</span> <span class="js-checkout-review-delivery-instructions"></span></li>
                     <li><span class="review-details__detail">Date of first paper:</span> <span class="js-checkout-review-delivery-start-date"></span></li>
                 </ul>
             </div>

--- a/assets/javascripts/modules/checkout/formElements.js
+++ b/assets/javascripts/modules/checkout/formElements.js
@@ -100,6 +100,7 @@ define(['$'], function ($) {
         $REVIEW_EMAIL: $('.js-checkout-review-email'),
         $REVIEW_PHONE: $('.js-checkout-review-phone'),
         $REVIEW_PHONE_FIELD: $('.js-checkout-review-phone-field'),
+        $REVIEW_DELIVERY_INSTRUCTIONS_FIELD : $('.js-checkout-review-delivery-instructions-field'),
 
         $FIELDSET_BILLING_ADDRESS: $('.js-fieldset-billing-address'),
         $FIELDSET_PAYMENT_DETAILS: $('.js-fieldset-payment-details'),

--- a/assets/javascripts/modules/checkout/reviewDetails.js
+++ b/assets/javascripts/modules/checkout/reviewDetails.js
@@ -71,7 +71,17 @@ define([
         formEls.$REVIEW_ACCOUNT.text(formEls.$ACCOUNT.val());
         formEls.$REVIEW_SORTCODE.text(formEls.$SORTCODE.val());
         formEls.$REVIEW_HOLDER.text(formEls.$HOLDER.val());
-        formEls.$REVIEW_DELIVERY_INSTRUCTIONS.text(formEls.getDeliveryInstructions().val());
+
+        var DELIVERY_INSTRUCTIONS = formEls.getDeliveryInstructions().val();
+
+        if (!DELIVERY_INSTRUCTIONS) {
+            formEls.$REVIEW_DELIVERY_INSTRUCTIONS_FIELD.hide();
+        }
+        else {
+            formEls.$REVIEW_DELIVERY_INSTRUCTIONS_FIELD.show();
+        }
+
+        formEls.$REVIEW_DELIVERY_INSTRUCTIONS.text(DELIVERY_INSTRUCTIONS);
         formEls.$REVIEW_DELIVERY_START_DATE.text(formEls.getPaperCheckoutField().val());
     }
 


### PR DESCRIPTION
… if no instructions were provided

https://trello.com/c/KTq405HT/154-there-should-not-be-any-delivery-instructions-text-on-review-and-confirm-section

@paulbrown1982 @AWare 