### PR TITLE
tolerate empty billing schedules when renewing a sub

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -260,7 +260,7 @@ object ManageWeekly extends ContextLogging {
 
     val res = for {
       subscription <- OptionT(SessionSubscription.subscriptionFromRequest)
-      billingSchedule <- OptionT(tpBackend.commonPaymentService.billingSchedule(subscription.id, subscription.accountId, 13))
+      billingSchedule <- OptionT(tpBackend.commonPaymentService.billingSchedule(subscription.id, subscription.accountId, numberOfBills = 13).map(Some(_):Option[Option[BillingSchedule]]))
     } yield {
       Ok(thankYouRenew(subscription.nextPlan, billingSchedule, touchpoint))
     }

--- a/app/views/account/thankYouRenew.scala.html
+++ b/app/views/account/thankYouRenew.scala.html
@@ -5,7 +5,7 @@
 @import org.joda.time.LocalDate.now
 @import com.gu.memsub.BillingPeriod.OneOffPeriod
 @(plan: SubscriptionPlan.ContentSubscription,
-  billingSchedule: BillingSchedule,
+  maybeBillingSchedule: Option[BillingSchedule],
   touchpointBackendResolution: services.TouchpointBackend.Resolution
 )(implicit request: RequestHeader)
 
@@ -15,13 +15,17 @@
         <section class="section-slice section-slice--bleed section-slice--limited">
             <p>Your Guardian Weekly subscription has been renewed.</p>
         </section>
-        <section class="section-slice--bleed section-slice--limited">
-            <h3 class="mma-section__header">
-                Your billing schedule
-            </h3>
-            @views.html.account.fragments.billingSchedule(billingSchedule, plan.charges.price.currencies.head)
 
-        </section>
+            @for(billingSchedule <- maybeBillingSchedule) {
+                <section class="section-slice--bleed section-slice--limited">
+                    <h3 class="mma-section__header">
+                Your billing schedule
+                    </h3>
+                    @views.html.account.fragments.billingSchedule(billingSchedule, plan.charges.price.currencies.head)
+                </section>
+            }
+
+
         <section class="section-slice--bleed mma-section">
             <a class="button button--primary button--large" href="@routes.AccountManagement.processLogin">
                 Back to subscription details</a>


### PR DESCRIPTION
Asking for the billing schedule of a sub with no current plan seems to make Zuora return an empty response. This change allows the customer to see the thank you page after renewing a subscription even if there is no billing period.
When we have more time we should probably change the definition of BillingPeriod to allow empty response and remove the options on all the places where we handle Option[BillingPeriod].

As far as I know this only happens when renewing a sub that has no current plan but has a term end date in the future

@johnduffell @jacobwinch @paulbrown1982 