### PR TITLE
allow donor renewal

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -178,7 +178,7 @@ object ManageWeekly extends ContextLogging {
     implicit val tpBackend = resolution.backend
     implicit val flash = request.flash
     implicit val subContext = weeklySubscription
-    if (weeklySubscription.readerType == ReaderType.Direct) {
+    if (weeklySubscription.readerType != ReaderType.Agent) {
       // go to SF to get the contact mailing information etc
       GetSalesforceContactForSub.zuoraAccountFromSub(weeklySubscription)(tpBackend.zuoraService, tpBackend.salesforceService.repo, global).flatMap { account =>
         val futureSfContact = GetSalesforceContactForSub.sfContactForZuoraAccount(account)(tpBackend.zuoraService, tpBackend.salesforceService.repo, global)
@@ -223,7 +223,7 @@ object ManageWeekly extends ContextLogging {
         }
       }
     } else {
-      info(s"don't support gifts, can't manage sub")
+      info(s"don't support agents, can't manage sub")
       Future.successful(Ok(views.html.account.details(None, promoCode))) // don't support gifts (yet) as they have related contacts in salesforce of unknown structure
     }
   }

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -13,6 +13,7 @@
 @import com.gu.i18n.Currency
 @import com.gu.memsub.promo.PromoCode
 @import org.joda.time.LocalDate.now
+@import com.gu.memsub.subsv2.ReaderType
 @(
     subscription: Subscription[WeeklyPlanOneOff], contact: Contact, billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
@@ -57,7 +58,7 @@
                 </p>
 
                 <div class="js-weekly-renew"
-                data-email="@contact.email"
+                data-email="@if(subscription.readerType == ReaderType.Direct) {@contact.email} else {}"
                 data-billing-country="@billToCountry.alpha2"
                 data-promo-code="@promoCode.map(_.get)"
                 data-currency="@currency.iso"


### PR DESCRIPTION
donors couldn't renew before, this should handle it.

In the long term we need to make it only use the email in zuora billto, then it will handle gifts properly

@paulbrown1982 @pvighi @jacobwinch 