### PR TITLE
Set Guardian Weekly first paper delay to 24th a day sooner than normal

### DIFF
--- a/assets/javascripts/modules/checkout/deliveryFields.jsx
+++ b/assets/javascripts/modules/checkout/deliveryFields.jsx
@@ -15,7 +15,7 @@ const MAX_WEEKS_AVAILABLE = 4;
 function getFirstSelectableDate(filterFn) {
     let weekly = formElements.$DELIVERED_PRODUCT_TYPE.val() === 'weekly';
     if (weekly){
-        return moment('20170317','YYYYMMDD');
+        return moment('20170324','YYYYMMDD');
     }
     let NUMBER_OF_DAYS_IN_ADVANCE = weekly?7:3;
     var firstSelectableDate = moment().add(NUMBER_OF_DAYS_IN_ADVANCE, 'days');

--- a/assets/javascripts/modules/checkout/deliveryFields.jsx
+++ b/assets/javascripts/modules/checkout/deliveryFields.jsx
@@ -14,6 +14,9 @@ const MAX_WEEKS_AVAILABLE = 4;
 
 function getFirstSelectableDate(filterFn) {
     let weekly = formElements.$DELIVERED_PRODUCT_TYPE.val() === 'weekly';
+    if (weekly){
+        return moment('20170317','YYYYMMDD');
+    }
     let NUMBER_OF_DAYS_IN_ADVANCE = weekly?7:3;
     var firstSelectableDate = moment().add(NUMBER_OF_DAYS_IN_ADVANCE, 'days');
     while (filterFn && !filterFn(firstSelectableDate)) {


### PR DESCRIPTION
Set Guardian Weekly first paper delay to 24th a day early. Merge this by 10am, 10 March.

cc @jayceb1 @ajosephides @jacobwinch @johnduffell @pvighi @AWare 