### PR TITLE
Temporarily hard-code the first available paper date for expired renewals

### DIFF
--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -44,13 +44,7 @@ object CheckoutService {
   )
 
   def determineFirstAvailablePaperDate(now: LocalDate): LocalDate = {
-    val dayOfWeek = now.getDayOfWeek
-    val daysToFastForward = if (dayOfWeek <= 5) {
-      (5 - dayOfWeek) + 7 // Skips to a week on Friday
-    } else {
-      (5 - dayOfWeek) + 14 // We've just missed Saturday's fulfillment file creation, so we have to skip another Friday
-    }
-    val nextAvailableDate = now.plusDays(daysToFastForward)
+    val nextAvailableDate = new LocalDate("2017-03-24")
     nextAvailableDate
   }
 

--- a/test/services/CheckoutServiceTest.scala
+++ b/test/services/CheckoutServiceTest.scala
@@ -52,12 +52,12 @@ class CheckoutServiceTest extends Specification {
 
   "determineFirstAvailablePaperDate" should {
 
-    "Calculate the next available Friday correctly (if today is a Monday)" in {
-       CheckoutService.determineFirstAvailablePaperDate(new LocalDate("2017-03-06")) mustEqual(new LocalDate("2017-03-17"))
-    }
+//    "Calculate the next available Friday correctly (if today is a Monday)" in {
+//       CheckoutService.determineFirstAvailablePaperDate(new LocalDate("2017-03-06")) mustEqual(new LocalDate("2017-03-17"))
+//    }
 
     "Calculate the next available Friday correctly (if today is a Friday)" in {
-      CheckoutService.determineFirstAvailablePaperDate(new LocalDate("2017-03-10")) mustEqual(new LocalDate("2017-03-17"))
+      CheckoutService.determineFirstAvailablePaperDate(new LocalDate("2017-03-10")) mustEqual(new LocalDate("2017-03-24"))
     }
 
     "Calculate the next available Friday correctly (if today is a Sunday)" in {


### PR DESCRIPTION
@paulbrown1982 

I realised that we need to do this, in addition to https://github.com/guardian/subscriptions-frontend/pull/870

This must be reverted before 18th March.