### PR TITLE
Correct contract effective date for 6for6

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -68,7 +68,7 @@ object Config {
   object Zuora {
     private val stageConfig = config.getConfig("touchpoint.backend.environments").getConfig(stage)
 
-    val paymentDelay = Days.days(stageConfig.getInt("zuora.paymentDelayInDays"))
+    val defaultDigitalPackFreeTrialPeriod = Days.days(stageConfig.getInt("zuora.paymentDelayInDays"))
   }
 
   val subscriptionsUrl = config.getString("subscriptions.url")

--- a/app/model/exactTarget/DataExtensionRow.scala
+++ b/app/model/exactTarget/DataExtensionRow.scala
@@ -326,8 +326,7 @@ object GuardianWeeklyRenewalDataExtensionRow {
             contact: Contact,
             paymentMethod: PaymentMethod,
             email: String,
-            customerAcceptance: LocalDate,
-            contractEffective: LocalDate
+            newTermStartDate: LocalDate
            ): GuardianWeeklyRenewalDataExtensionRow = {
 
 
@@ -339,8 +338,8 @@ object GuardianWeeklyRenewalDataExtensionRow {
       title = contact.title.flatMap(Title.fromString),
       firstName = contact.firstName.getOrElse(""),
       lastName = contact.lastName,
-      startDate = contractEffective,
-      firstPaymentDate = customerAcceptance,
+      startDate = newTermStartDate,
+      firstPaymentDate = newTermStartDate,
       planName = planName,
       subscriptionName = subscriptionName,
       paymentMethod = paymentMethod,

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -310,20 +310,12 @@ class CheckoutService(identityService: IdentityService,
       }
     }
 
-<<<<<<< HEAD
     val currentVersionExpired = subscription.termEndDate.isBefore(now).withContextLogging("currentVersionExpired")
-    // For a renewal, all dates should be identical. If the sub has expired, this date should be fast-forwarded to the next available paper date
-    val startDateForRenewal = {
-      if (currentVersionExpired) CheckoutService.determineFirstAvailablePaperDate(now) else subscription.termEndDate
-    }.withContextLogging("startDateForRenewal")
-    val contractEffective = startDateForRenewal
-    val customerAcceptance = startDateForRenewal
-=======
-    val currentVersionExpired = subscription.termEndDate.isBefore(now)
 
     // For a renewal, all dates should be identical. If the sub has expired, this date should be fast-forwarded to the next available paper date
-    val newTermStartDate = if (currentVersionExpired) CheckoutService.determineFirstAvailablePaperDate(now) else subscription.termEndDate
->>>>>>> 69bfd1f... Committing for backup
+    val newTermStartDate = {
+      if (currentVersionExpired) CheckoutService.determineFirstAvailablePaperDate(now) else subscription.termEndDate
+    }.withContextLogging("startDateForRenewal")
 
     def constructRenewCommand(contact: Contact): Future[Renew] = Future {
       val newRatePlan = RatePlan(renewal.plan.id.get, None)

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -1,5 +1,6 @@
 package services
 
+import com.github.nscala_time.time.OrderingImplicits.LocalDateOrdering
 import com.gu.config.DiscountRatePlanIds
 import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, CountryGroup}
@@ -76,7 +77,7 @@ class CheckoutService(identityService: IdentityService,
 
   // This method is not genericised because the '6' is not stored in the association.
   def processSixWeekIntroductoryPeriod(daysUntilFirstIssue: Days, originalCommand: Subscribe): Subscribe = {
-    val maybeSixWeekAssociation = allSixWeekAssociations.find(_._1.id == originalCommand.ratePlans.head.productRatePlanId)
+    val maybeSixWeekAssociation = allSixWeekAssociations.find(_._1.id.get == originalCommand.ratePlans.head.productRatePlanId)
     val updatedCommand = maybeSixWeekAssociation.map { case (sixWeekPlan, recurringPlan) =>
       val sixWeeksPlanStartDate = originalCommand.contractEffective.plusDays(daysUntilFirstIssue.getDays)
       val replacementPlans = NonEmptyList(

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -76,9 +76,9 @@ class CheckoutService(identityService: IdentityService,
 
   // This method is not genericised because the '6' is not stored in the association.
   def processSixWeekIntroductoryPeriod(daysUntilFirstIssue: Days, originalCommand: Subscribe): Subscribe = {
-    val sixWeeksPlanStartDate = originalCommand.contractEffective.plusDays(daysUntilFirstIssue.getDays)
     val maybeSixWeekAssociation = allSixWeekAssociations.find(_._1.id == originalCommand.ratePlans.head.productRatePlanId)
     val updatedCommand = maybeSixWeekAssociation.map { case (sixWeekPlan, recurringPlan) =>
+      val sixWeeksPlanStartDate = originalCommand.contractEffective.plusDays(daysUntilFirstIssue.getDays)
       val replacementPlans = NonEmptyList(
         RatePlan(
           sixWeekPlan.id.get,

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -76,7 +76,7 @@ class CheckoutService(identityService: IdentityService,
 
   // This method is not genericised because the '6' is not stored in the association.
   def processSixWeekIntroductoryPeriod(fulfilmentDelay: Days, originalCommand: Subscribe): Subscribe = {
-    val introductoryPeriodDelayDays = Math.max(fulfilmentDelay.getDays, 0)
+    val introductoryPeriodDelayDays = fulfilmentDelay.getDays
     val sixWeeksPlanStartDate = originalCommand.contractEffective.plusDays(introductoryPeriodDelayDays)
     val maybeSixWeekAssociation = allSixWeekAssociations.find(_._1.id == originalCommand.ratePlans.head.productRatePlanId)
     val replacementPlans = maybeSixWeekAssociation.map { case (sixWeekPlan, recurringPlan) =>

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -1,11 +1,10 @@
 package services
-import com.github.nscala_time.time.Imports._
-import com.amazonaws.regions.{Region, Regions}
+
 import com.amazonaws.regions.Regions.EU_WEST_1
 import com.amazonaws.services.sqs.AmazonSQSClient
 import com.amazonaws.services.sqs.model._
+import com.github.nscala_time.time.Imports._
 import com.gu.aws.CredentialsProvider
-import com.gu.i18n.Currency
 import com.gu.lib.Retry
 import com.gu.memsub.Subscription._
 import com.gu.memsub.promo.Promotion._
@@ -24,9 +23,6 @@ import logging.ContextLogging
 import model.SubscriptionOps._
 import model.exactTarget.HolidaySuspensionBillingScheduleDataExtensionRow.constructSalutation
 import model.exactTarget._
-import model.{PaperData, PurchaserIdentifiers, Renewal, SubscribeRequest, SubscriptionOps}
-import model.SubscriptionOps._
-import org.joda.time.{DateTime, Days, LocalDate}
 import model.{PurchaserIdentifiers, Renewal, SubscribeRequest}
 import org.joda.time.{Days, LocalDate}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -199,8 +195,7 @@ class ExactTargetService(
     subscriptionDetails: String,
     contact: Contact,
     email: String,
-    customerAcceptance: LocalDate,
-    contractEffective: LocalDate): Future[Unit] = {
+    newTermStartDate: LocalDate): Future[Unit] = {
 
     implicit val context = oldSub
 
@@ -235,8 +230,7 @@ class ExactTargetService(
         contact = contact,
         paymentMethod = paymentMethod,
         email = email,
-        customerAcceptance = customerAcceptance,
-        contractEffective = contractEffective)
+        newTermStartDate = newTermStartDate)
       sendMessage <- EitherT(sendToQueue(row))
     } yield sendMessage).run
 

--- a/app/touchpoint/TouchpointBackendConfig.scala
+++ b/app/touchpoint/TouchpointBackendConfig.scala
@@ -62,6 +62,6 @@ object ZuoraProperties {
   }
 }
 case class ZuoraProperties(
-  paymentDelayInDays: Days,
+  defaultDigitalPackFreeTrialPeriod: Days,
   gracePeriodInDays: Days
 )

--- a/app/views/fragments/promotion/pricingCta.scala.html
+++ b/app/views/fragments/promotion/pricingCta.scala.html
@@ -4,12 +4,12 @@
 @import com.gu.memsub.subsv2.CatalogPlan
 @import com.gu.memsub.BillingPeriod.Month
 @import views.support.Catalog._
-@import configuration.Config.Zuora.paymentDelay
+@import configuration.Config.Zuora.defaultDigitalPackFreeTrialPeriod
 
 @(currency: Currency, plan: CatalogPlan.Digipack[Month.type], promoCode: PromoCode, promotion: AnyPromotion)
 <div class="pricing-cta">
     <div class="pricing-cta__pricing">
-        <h4 class="pricing-cta__pricing__title">Free for @promotion.asFreeTrial.fold(paymentDelay.getDays)(_.promotionType.duration.getDays) days</h4>
+        <h4 class="pricing-cta__pricing__title">Free for @promotion.asFreeTrial.fold(defaultDigitalPackFreeTrialPeriod.getDays)(_.promotionType.duration.getDays) days</h4>
         <p class="pricing-cta__pricing__value">
             @promotion.asDiscount.find(_.promotionType.durationMonths.isDefined).fold {
                 Then @formatPrice(plan, currency, promotion)/month

--- a/app/views/fragments/promotion/subscriptionTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/subscriptionTermsAndConditions.scala.html
@@ -4,14 +4,14 @@
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import views.support.Catalog._
 @import configuration.Links
-@import configuration.Config.Zuora.paymentDelay
+@import configuration.Config.Zuora.defaultDigitalPackFreeTrialPeriod
 
 @(catalog: Catalog, promotion: AnyPromotion, currency: Currency = GBP)
 @if(promotion.asDigitalPack.isDefined) {
     <h4>Digital subscription terms and conditions</h4>
     <p>
         Subscriptions available to people aged 18 and over with a valid email address. Free trial open to new digital pack subscribers only. Free trial period lasts
-        @promotion.asFreeTrial.fold(paymentDelay.getDays.toString)(_.promotionType.duration.getDays.toString)
+        @promotion.asFreeTrial.fold(defaultDigitalPackFreeTrialPeriod.getDays.toString)(_.promotionType.duration.getDays.toString)
         days from receipt of subscriber ID, up to and including the day before your first payment falls due. At the end of the free trial,
         the subscription is charged at @promotion.asIncentive.map { p => standard price (currently @formatPrice(catalog.digipack.month, currency, promotion) a month) }
         @promotion.asDiscount.map { p => the special price of @formatPrice(catalog.digipack.month, currency), promotion) a month } unless cancelled.

--- a/app/views/support/WeeklyPromotion.scala
+++ b/app/views/support/WeeklyPromotion.scala
@@ -2,13 +2,12 @@ package views.support
 
 import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.memsub.BillingPeriod._
-import com.gu.memsub.Subscription
 import com.gu.memsub.promo.Promotion.PromoWithWeeklyLandingPage
-import com.gu.memsub.subsv2.{Catalog, CatalogPlan}
+import com.gu.memsub.promo.{PromoCode, WeeklyLandingPage}
+import com.gu.memsub.subsv2.{CatalogPlan, Catalog => SubsCatalog}
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import views.support.Pricing._
-import com.gu.memsub.promo.{PromoCode, WeeklyLandingPage}
 
 object WeeklyPromotion {
   private val UK = CountryGroup.UK.countries.toSet
@@ -20,14 +19,12 @@ object WeeklyPromotion {
   private val EU = CountryGroup.Europe.countries.toSet
   private val CA = CountryGroup.Canada.countries.toSet
   private val allCountries = CountryGroup.allGroups.flatMap(_.countries).toSet
-  private val ZONEC = allCountries.toSet.diff(UK union US)
+  private val ZONEC = allCountries.diff(UK union US)
   case class DiscountedPlan(currency: Currency, pretty: String, headline: String, period: String, url: Uri, discounted: Boolean)
 
   case class DiscountedRegion(title: String, description: String, countries: Set[Country], discountedPlans: List[DiscountedPlan])
 
-  def validRegionsForPromotion(promotion: Option[PromoWithWeeklyLandingPage], promoCode: Option[PromoCode], requestCountry: Country)(implicit catalog: Catalog): Seq[DiscountedRegion] = {
-    val weekly = catalog.weekly.plans.flatten.map(_.id).toSet
-    val promotionProductRatePlanIds: Set[Subscription.ProductRatePlanId] = promotion.map(_.appliesTo.productRatePlanIds).getOrElse(weekly)
+  def validRegionsForPromotion(promotion: Option[PromoWithWeeklyLandingPage], promoCode: Option[PromoCode], requestCountry: Country)(implicit catalog: SubsCatalog): Seq[DiscountedRegion] = {
     val promotionCountries = promotion.map(_.appliesTo.countries).getOrElse(allCountries)
     val regionForZoneCCountry: Seq[DiscountedRegion] = {
       if (ZONEC.contains(requestCountry)) {
@@ -69,8 +66,8 @@ object WeeklyPromotion {
         discountedPlans = plansForPromotion(promotion, promoCode, UK, catalog.weekly.zoneA.plans,Currency.GBP)
       )
       val countries = promotionCountries intersect UK
-      val includesUKDomestic = !(countries intersect UKdomestic).isEmpty
-      val includesUKOverseas = !(countries intersect UKoverseas).isEmpty
+      val includesUKDomestic = (countries intersect UKdomestic).nonEmpty
+      val includesUKOverseas = (countries intersect UKoverseas).nonEmpty
       if(includesUKDomestic && includesUKOverseas){
         Set(all)
       } else if (includesUKDomestic) {
@@ -116,20 +113,17 @@ object WeeklyPromotion {
     regions.filter(_.discountedPlans.nonEmpty)
   }
 
-  private val currencyFor = CountryGroup.availableCurrency(Currency.all.toSet) _
-
-  def plansForPromotion(maybePromotion: Option[PromoWithWeeklyLandingPage], promoCode: Option[PromoCode], countries: Set[Country], catalogPlans: Seq[CatalogPlan.Paid], currency: Currency)(implicit catalog: Catalog): List[DiscountedPlan] = {
+  def plansForPromotion(maybePromotion: Option[PromoWithWeeklyLandingPage], promoCode: Option[PromoCode], countries: Set[Country], catalogPlans: Seq[CatalogPlan.Paid], currency: Currency)(implicit catalog: SubsCatalog): List[DiscountedPlan] = {
 
     def isSixWeek(catalogPlan: CatalogPlan.Paid): Boolean =
       catalogPlan.charges.billingPeriod match {
         case SixWeeks => true
         case _ => false
       }
-    val displaySixForSix: Boolean = maybePromotion.map(promo =>
-      catalogPlans.filter{plan =>
+    val displaySixForSix: Boolean = maybePromotion.exists(promo =>
+      catalogPlans.filter { plan =>
         promo.appliesTo.productRatePlanIds.contains(plan.id)
       }.exists(isSixWeek))
-      .getOrElse(false)
 
     val plans: List[CatalogPlan.Paid] = {
       if (displaySixForSix) catalogPlans
@@ -141,7 +135,7 @@ object WeeklyPromotion {
 
     for {
       plan <- plans
-      sixOrDiscount = isSixWeek(plan) || maybePromotion.map(_.appliesTo.productRatePlanIds.contains(plan.id)).getOrElse(false)
+      sixOrDiscount = isSixWeek(plan) || maybePromotion.exists(_.appliesTo.productRatePlanIds.contains(plan.id))
       pretty = maybePromotion.filter(_.appliesTo.productRatePlanIds.contains(plan.id)).flatMap(_.asDiscount)
         .map { discountPromo => plan.charges.prettyPricingForDiscountedPeriod[scalaz.Id.Id, WeeklyLandingPage](discountPromo, currency) }
         .getOrElse(plan.charges.billingPeriod match {

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.381-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.381",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.380",
+    "com.gu" %% "membership-common" % "0.381-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/test/services/CheckoutServiceTest.scala
+++ b/test/services/CheckoutServiceTest.scala
@@ -1,7 +1,7 @@
 package services
 import com.gu.memsub.Benefit._
 import com.gu.memsub.Product.{Delivery, ZDigipack}
-import com.gu.memsub.Subscription.ProductRatePlanId
+import com.gu.memsub.Subscription.{ProductRatePlanChargeId, ProductRatePlanId}
 import com.gu.memsub._
 import com.gu.memsub.subsv2._
 import model.{DigipackData, PaperData}
@@ -29,13 +29,13 @@ class CheckoutServiceTest extends Specification {
     id = ProductRatePlanId("p"),
     name = "name",
     description = "desc",
-    charges = PaidCharge(Digipack, BillingPeriod.Month, PricingSummary(Map.empty)),
+    charges = PaidCharge(Digipack, BillingPeriod.Month, PricingSummary(Map.empty), ProductRatePlanChargeId("foo")),
     product = Product.Digipack,
     saving = None,
     s = Status.current
   )
 
-  val zuora = ZuoraProperties(paymentDelayInDays = Days.days(14), gracePeriodInDays = Days.days(2))
+  val zuora = ZuoraProperties(defaultDigitalPackFreeTrialPeriod = Days.days(14), gracePeriodInDays = Days.days(2))
   val paperData = Left(PaperData(new LocalDate("2016-07-30"), address, None, paperPlan))
   val digipackData = Right(DigipackData(digiPlan))
 


### PR DESCRIPTION
Use new membership-common API to alter the start date of the 6-for-6 rate plan charge in a different way, such that the contract effective date can be set to 'now' and be consistent with all other subs. Also the + - one day (aka 'starting the six for six on a Thursday') is no longer necessary as the fulfilment scripts can now dedupe.

Requires: https://github.com/guardian/membership-common/pull/450

https://trello.com/c/RETXPNdh/169-bug-six-weeks-rate-plans-use-the-contract-effective-date-incorrectly

cc @jacobwinch @johnduffell @pvighi @AWare @svillafe 
