### PR TITLE
Remove the focus halo's from .button

### DIFF
--- a/assets/stylesheets/modules/_buttons.scss
+++ b/assets/stylesheets/modules/_buttons.scss
@@ -152,3 +152,9 @@
         border-color: $c-neutral2;
     }
 }
+
+.button:focus, .button:active, .button.active, .button:focus:active {
+    background-image: none;
+    outline: none;
+    box-shadow: none;
+}


### PR DESCRIPTION
Source:   http://stackoverflow.com/questions/24222798/how-to-remove-the-blue-box-shadow-border-in-button-if-clicked/24222873#24222873