### PR TITLE
Remove the one-off plan check when deciding if a sub is renewable

### DIFF
--- a/app/model/SubscriptionOps.scala
+++ b/app/model/SubscriptionOps.scala
@@ -71,9 +71,8 @@ object SubscriptionOps extends LazyLogging {
     val renewable = {
       val wontAutoRenew = !subscription.autoRenew
       val startedAlready = !subscription.termStartDate.isAfter(now)
-      val isOneOffPlan = !subscription.planToManage.charges.billingPeriod.isRecurring
-      info(s"testing if renewable - wontAutoRenew: $wontAutoRenew, startedAlready: $startedAlready, isOneOffPlan: $isOneOffPlan")
-      wontAutoRenew && startedAlready && isOneOffPlan
+      info(s"testing if renewable - wontAutoRenew: $wontAutoRenew, startedAlready: $startedAlready")
+      wontAutoRenew && startedAlready
     }
   }
 


### PR DESCRIPTION
When a renewal is processed, the effective end date of any existing plan will now be set as = new term start date (before the new plan is added). Consequently, I don't think we need to check that the current plan is a one-off any more.

Related PRs:
https://github.com/guardian/membership-common/pull/452/files
https://github.com/guardian/subscriptions-frontend/pull/886

@paulbrown1982 @pvighi 