### PR TITLE
Add the tracking codes to the navbar links

### DIFF
--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -88,7 +88,7 @@ object PromoLandingPage extends Controller {
 
   private def redirectToBrochurePage(promotion: AnyPromotion, country: Country)(implicit promoCode: PromoCode, request: Request[AnyContent]): Option[Result] = {
     getBrochureRouteForPromotion(promotion, country) map { route =>
-      val result = Redirect(route.url, request.queryString)
+      val result = Redirect(route.url, request.queryString - "country")
       if (promotion.promotionType == Tracking) {
         result.withSession(request.session.data.toSeq ++ Seq(PromotionTrackingCode -> promoCode.get) :_*)
       } else {

--- a/app/views/fragments/global/navigation.scala.html
+++ b/app/views/fragments/global/navigation.scala.html
@@ -1,20 +1,18 @@
 @import model.DigitalEdition
-@import views.support.DigitalEdition._
-
 @import model.DigitalEdition.UK
 @(edition: DigitalEdition, managementPage: Boolean)
 <nav class="global-nav">
     <div class="global-nav__inner gs-container">
-        <a href="/?INTCMP=GU_SUBSCRIPTIONS_NAV" class="global-nav__link">home</a>
-        <a href="/@edition.id/digital" class="global-nav__link">digital</a>
+        <a href="/" class="global-nav__link">home</a>
+        <a href="@routes.PromoLandingPage.render(s"DNAV${edition.id.toUpperCase}1", None).url?edition=@edition.id" class="global-nav__link">digital</a>
         @if(edition == UK) {
-            <a href="/collection/paper" class="global-nav__link">paper</a>
+            <a href="@routes.PromoLandingPage.render(s"NNAV${edition.id.toUpperCase}P", None).url" class="global-nav__link">paper</a>
         }
-        <a href="/weekly?INTCMP=GU_SUBSCRIPTIONS_NAV" class="global-nav__link">weekly</a>
+        <a href="@routes.PromoLandingPage.render(s"WNAV${edition.id.toUpperCase}", edition.countryGroup.defaultCountry).url" class="global-nav__link">weekly</a>
         @if(managementPage) {
             <a href="@routes.AccountManagement.logout" class="global-nav__link global-nav__link--right">sign out</a>
         } else {
-            <a href="/manage?INTCMP=GU_SUBSCRIPTIONS_NAV" class="global-nav__link global-nav__link--right">manage</a>
+            <a href="/manage" class="global-nav__link global-nav__link--right">manage</a>
         }
     </div>
 </nav>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -71,7 +71,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("WHOMEUK", None)" data-test-id="subscriptions-uk-guardian-weekly">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("WHOMEUK", UK.countryGroup.defaultCountry)" data-test-id="subscriptions-uk-guardian-weekly">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block">

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -22,7 +22,7 @@
                 </ul>
             </div>
             <div class="block__footer">
-                <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render("DHOMEINT", None).url?edition=@edition.id" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
+                <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render(s"DHOME${edition.id.toUpperCase}1", None).url?edition=@edition.id" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
             </div>
         </div>
         <div class="row__item block block--primary block--weekly">
@@ -36,7 +36,7 @@
                 </ul>
             </div>
             <div class="block__footer">
-                <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("WHOMEINT", None).url" data-test-id="subscriptions-@edition.id-guardian-weekly">Subscribe now</a>
+                <a class="button button--large button--primary" href="@routes.PromoLandingPage.render(s"WHOME${edition.id.toUpperCase}", edition.countryGroup.defaultCountry).url" data-test-id="subscriptions-@edition.id-guardian-weekly">Subscribe now</a>
             </div>
         </div>
     </div>

--- a/app/views/promotion/weeklyLandingPage.scala.html
+++ b/app/views/promotion/weeklyLandingPage.scala.html
@@ -3,6 +3,7 @@
 @import com.gu.memsub.promo.Promotion.asAnyPromotion
 @import views.support.LandingPageOps._
 @import configuration.Links
+@import model.DigitalEdition
 @import views.support.CommaSplit
 @import views.support.{MarkdownRenderer}
 @import com.gu.memsub.subsv2.Catalog
@@ -38,7 +39,8 @@
         title = s"$title | The Guardian",
         bodyClasses = List("is-wide"),
         product = Some(WeeklyZoneA),// don't specifically need zone a, any weekly is fine
-        hreflangs = Some(hreflangs)
+        hreflangs = Some(hreflangs),
+        edition = DigitalEdition.getForCountry(Some(country))
     ) {
 
         @fragments.heroBanner(promotion.flatMap(_.landingPage.image).getOrElse(defaultImage)){


### PR DESCRIPTION
- Add the tracking code to the navbar links, attributing that 'widget' as a source of a the transaction if a customer comes via it.
- Tidied up the international homepages so  they link through to a consistent Guardian Weekly landing page (e.g. /au homepage links through to /weekly/AU).
- Removed ugly 'country' query parameter from promo code redirect to a brochure page, it is not needed as no brochure page understands that parameter.

cc @jacobwinch @pvighi @AWare 