### PR TITLE
Improve logging for Guardian Weekly renewals

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -247,7 +247,7 @@ object ManageWeekly extends ContextLogging {
         }.recover{
             case e: Throwable =>
               val errorMessage = "Unexpected error while renewing subscription"
-              error(errorMessage)
+              error(s"${errorMessage}: $e")
               InternalServerError(jsonError(errorMessage))
         }
       }

--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -240,14 +240,16 @@ object ManageWeekly extends ContextLogging {
         renewableSub <- weeklySub.asRenewable.toRightDisjunction("subscription is not renewable")
         renew <- parseRenewalRequest(request, tpBackend.catalogService.unsafeCatalog)
       } yield {
-        info(s"Attempting to renew ${renew.plan.name} for ${renewableSub.id} with promo code: ${renew.promoCode}")(sub)
-        tpBackend.checkoutService.renewSubscription(renewableSub, renew).map(_ => Ok(Json.obj("redirect" -> routes.AccountManagement.renewThankYou().url)))
-          .recover{
+        info(s"Attempting to renew onto ${renew.plan.name} with promo code: ${renew.promoCode}")(sub)
+        tpBackend.checkoutService.renewSubscription(renewableSub, renew).map { _ =>
+          info(s"Successfully processed renewal onto ${renew.plan.name}")
+          Ok(Json.obj("redirect" -> routes.AccountManagement.renewThankYou().url))
+        }.recover{
             case e: Throwable =>
               val errorMessage = "Unexpected error while renewing subscription"
-              logger.error(errorMessage, e)
+              error(errorMessage)
               InternalServerError(jsonError(errorMessage))
-          }
+        }
       }
       response.valueOr(error => Future(BadRequest(jsonError(error))))
     }

--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -242,12 +242,12 @@ object ManageWeekly extends ContextLogging {
       } yield {
         info(s"Attempting to renew onto ${renew.plan.name} with promo code: ${renew.promoCode}")(sub)
         tpBackend.checkoutService.renewSubscription(renewableSub, renew).map { _ =>
-          info(s"Successfully processed renewal onto ${renew.plan.name}")
+          info(s"Successfully processed renewal onto ${renew.plan.name}")(sub)
           Ok(Json.obj("redirect" -> routes.AccountManagement.renewThankYou().url))
         }.recover{
             case e: Throwable =>
               val errorMessage = "Unexpected error while renewing subscription"
-              error(s"${errorMessage}: $e")
+              error(s"${errorMessage}: $e")(sub)
               InternalServerError(jsonError(errorMessage))
         }
       }

--- a/app/logging/ContextLogging.scala
+++ b/app/logging/ContextLogging.scala
@@ -16,7 +16,7 @@ trait ContextLogging extends LazyLogging {
 
   def error[P <: AnyPlan : Subscription](message: String): Unit = {
     val context = implicitly[Subscription[P]]
-    logger.info(s"{sub: ${context.name.get}} $message")
+    logger.error(s"{sub: ${context.name.get}} $message")
   }
 
   implicit class FutureContextLoggable[T](future: Future[T]) {


### PR DESCRIPTION
If we use Context Logging throughout it makes debugging a particular user's journey through the flow much easier:

```
33007:logs jacob_winch$ less subscriptions-frontend.log | grep "sub: A-S00068432"
2017-03-22 14:38:04,128 controllers.ManageWeekly$[ContextLogging.scala:14] INFO: {sub: A-S00068432} sub is renewable - showing weeklyRenew page
2017-03-22 14:38:23,070 model.SubscriptionOps$EnrichedPaperSubscription[ContextLogging.scala:14] INFO: {sub: A-S00068432} testing if renewable - wontAutoRenew: true, startedAlready: true
2017-03-22 14:38:23,085 controllers.ManageWeekly$[ContextLogging.scala:14] INFO: {sub: A-S00068432} Attempting to renew onto Guardian Weekly 1 Year with promo code: None
2017-03-22 14:38:23,171 services.CheckoutService[ContextLogging.scala:14] INFO: {sub: A-S00068432} currentVersionExpired {false}
2017-03-22 14:38:23,172 services.CheckoutService[ContextLogging.scala:14] INFO: {sub: A-S00068432} startDateForRenewal {2017-04-13}
2017-03-22 14:38:23,498 services.CheckoutService[ContextLogging.scala:14] INFO: {sub: A-S00068432} zuoraAccount {2c92c0f85ad595bc015ad6b6d0ce7c4f}
2017-03-22 14:38:23,821 services.CheckoutService[ContextLogging.scala:14] INFO: {sub: A-S00068432} zuora bill to {2c92c0f85ad595bc015ad6b6d0d67c50}
2017-03-22 14:38:24,005 services.CheckoutService[ContextLogging.scala:14] INFO: {sub: A-S00068432} sfContact {003g000001U4gHYAAZ}
2017-03-22 14:38:24,006 services.CheckoutService[ContextLogging.scala:14] INFO: {sub: A-S00068432} promo code from client {None}
2017-03-22 14:38:24,007 services.CheckoutService[ContextLogging.scala:14] INFO: {sub: A-S00068432} Subscription price: {£120 for 1 year}
2017-03-22 14:38:24,008 controllers.ManageWeekly$[ContextLogging.scala:19] ERROR: {sub: A-S00068432} Unexpected error while renewing subscription: java.util.NoSuchElementException: Future.filter predicate is not satisfied
```