### PR TITLE
Allow six for six promotions to be entered organically (a fix for six)

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -76,7 +76,7 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
         val buyablePlans = plans.filter(_.availableForCheckout)
         val plansInPriceOrder = buyablePlans.sortBy(_.charges.gbpPrice.amount)
         val selectedPlan = plansInPriceOrder.find(_.slug == forThisPlan)
-        selectedPlan.map(PlanList(associations,_,plans))
+        selectedPlan.map(PlanList(associations,_,buyablePlans))
       }
         case _ => None
       }.headOption

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -70,20 +70,16 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
       ) ++ testOnlyPlans
 
       val contentSubscriptionPlans = productsWithoutIntroductoryPlans ++ productsWithIntroductoryPlans
-
-      contentSubscriptionPlans.map {
-        case PlansWithIntroductory(plans, associations) =>
-          val buyablePlans = plans.filter(_.availableForCheckout)
-          val plansInPriceOrder = buyablePlans.sortBy(_.charges.gbpPrice.amount)
-          val slugPlanAndBetter = plansInPriceOrder.dropWhile(_.slug != forThisPlan)
-          slugPlanAndBetter match {
-            case planFromSlug :: otherPlans =>
-              val betterPlansInProduct = getBetterPlans(planFromSlug, otherPlans)
-              Some(PlanList(associations, planFromSlug, betterPlansInProduct: _*))
-            case Nil => None // didn't find slug
-          }
-      }.find(_.isDefined).flatten
-
+      contentSubscriptionPlans.flatMap {
+        case PlansWithIntroductory(plans, associations)
+          if (plans.exists(_.slug == forThisPlan)) => {
+        val buyablePlans = plans.filter(_.availableForCheckout)
+        val plansInPriceOrder = buyablePlans.sortBy(_.charges.gbpPrice.amount)
+        val selectedPlan = plansInPriceOrder.find(_.slug == forThisPlan)
+        selectedPlan.map(PlanList(associations,_,plans))
+      }
+        case _ => None
+      }.headOption
     }
 
     val idUser = (for {

--- a/app/controllers/Promotion.scala
+++ b/app/controllers/Promotion.scala
@@ -35,7 +35,7 @@ object Promotion extends Controller with LazyLogging with CatalogProvider {
         .filter(plan => promo.appliesTo.productRatePlanIds contains plan.id)
         .filter(plan => plan.charges.currencies contains currency)
         .map(plan => RatePlanPrice(plan.id, plan.charges)).map { ratePlanPrice =>
-          ratePlanPrice.ratePlanId.get -> ratePlanPrice.chargeList.prettyPricingForDiscountedPeriod(discountPromo, currency) //TODO: make this return adjusted rateplans if we're not changing them
+          ratePlanPrice.ratePlanId.get -> ratePlanPrice.chargeList.prettyPricingForDiscountedPeriod(discountPromo, currency)
       }.toMap
     }
   }

--- a/app/controllers/Promotion.scala
+++ b/app/controllers/Promotion.scala
@@ -35,7 +35,7 @@ object Promotion extends Controller with LazyLogging with CatalogProvider {
         .filter(plan => promo.appliesTo.productRatePlanIds contains plan.id)
         .filter(plan => plan.charges.currencies contains currency)
         .map(plan => RatePlanPrice(plan.id, plan.charges)).map { ratePlanPrice =>
-          ratePlanPrice.ratePlanId.get -> ratePlanPrice.chargeList.prettyPricingForDiscountedPeriod(discountPromo, currency)
+          ratePlanPrice.ratePlanId.get -> ratePlanPrice.chargeList.prettyPricingForDiscountedPeriod(discountPromo, currency) //TODO: make this return adjusted rateplans if we're not changing them
       }.toMap
     }
   }

--- a/app/model/ContentSubscriptionPlanOps.scala
+++ b/app/model/ContentSubscriptionPlanOps.scala
@@ -52,7 +52,6 @@ object ContentSubscriptionPlanOps {
 
     def availableForCheckout: Boolean = in.charges.billingPeriod.isRecurring || in.charges.billingPeriod == SixWeeks
     def availableForRenewal: Boolean = in.charges.billingPeriod == Quarter || in.charges.billingPeriod == OneYear
-
   }
 
 }

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -30,7 +30,9 @@
     }
 }
 @priceOption(plan: CatalogPlan.Paid, currency: Currency, associatedPlan: Option[CatalogPlan.Paid]) = {
-    <label class="option" data-currency="@currency">
+    <label class="option" data-currency="@currency"
+@if(plan.promotionalOnly && plan != productData.plans.default){hidden="true"}
+        >
         <span class="option__input">
             <input
             type="radio" name="ratePlanId"

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -30,7 +30,7 @@
     }
 }
 @priceOption(plan: CatalogPlan.Paid, currency: Currency, associatedPlan: Option[CatalogPlan.Paid]) = {
-    <label class="option" data-currency="@currency"
+    <label class="option @if(plan.promotionalOnly){js-promotional-plan}" data-currency="@currency"
 @if(plan.promotionalOnly && plan != productData.plans.default){hidden="true"}
         >
         <span class="option__input">

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -30,7 +30,7 @@
     }
 }
 @priceOption(plan: CatalogPlan.Paid, currency: Currency, associatedPlan: Option[CatalogPlan.Paid]) = {
-    <label class="option @if(plan.promotionalOnly){js-promotional-plan}" data-currency="@currency"
+    <label class="option" data-currency="@currency"
 @if(plan.promotionalOnly && plan != productData.plans.default){hidden="true"}
         >
         <span class="option__input">
@@ -45,7 +45,10 @@
             data-currency="@currency"
             data-promotional-plan="@plan.promotionalOnly"
             value="@plan.id.get"
-            @if(plan == productData.plans.default && currency == countryAndCurrencySettings.defaultCurrency){ checked="checked" }
+            @if(plan == productData.plans.default && currency == countryAndCurrencySettings.defaultCurrency) {
+                checked="checked"
+                data-is-default-plan="true"
+            }
             >
         </span>
         <span class="option__label" id="label-for-@plan.id.get-@currency">@plan.prettyName(currency) @andThenPricing(currency, associatedPlan)</span>

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -43,6 +43,7 @@
             data-option-mirror-package="@plan.packageName"
             data-name="@plan.name"
             data-currency="@currency"
+            data-promotional-plan="@plan.promotionalOnly"
             value="@plan.id.get"
             @if(plan == productData.plans.default && currency == countryAndCurrencySettings.defaultCurrency){ checked="checked" }
             >

--- a/app/views/fragments/checkout/noticesDirectDebit.scala.html
+++ b/app/views/fragments/checkout/noticesDirectDebit.scala.html
@@ -1,6 +1,5 @@
 @import controllers.CachedAssets.hashedPathFor
 @import views.support.PlanOps._
-@import views.support.PlanList
 @import com.gu.memsub.subsv2.CatalogPlan
 @(plan: CatalogPlan.Paid)
 

--- a/app/views/fragments/checkout/promoCode.scala.html
+++ b/app/views/fragments/checkout/promoCode.scala.html
@@ -1,7 +1,7 @@
 @import com.gu.memsub.promo.PromoCode
 @(promoCode: Option[PromoCode])(implicit r: RequestHeader)
 @helper.javascriptRouter("jsRoutes")(
-    routes.javascript.Promotion.validateForProductRatePlan
+    routes.javascript.Promotion.validate
 )
 <div class="checkout-promo-code js-promo-code">
     <label class="label" for="promo-code">Promo code</label>

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -7,6 +7,9 @@ import com.gu.memsub.images.{ResponsiveImage, ResponsiveImageGenerator, Responsi
 import com.gu.memsub.subsv2.{CatalogPlan, Plan, SubscriptionPlan}
 import com.netaporter.uri.dsl._
 import configuration.Links
+import model.BillingPeriodOps._
+import com.gu.memsub.BillingPeriod.{OneYear, Quarter, SixWeeks}
+
 
 import scala.reflect.internal.util.StringOps
 import scalaz.syntax.std.boolean._
@@ -31,7 +34,7 @@ object PlanOps {
     }
   }
 
-  implicit class PrettyPlan[+A <: CatalogPlan.AnyPlan](in: A) {
+  implicit class PrettyPlan[+A <: CatalogPlan.Paid](in: A) {
 
     def packImage: ResponsiveImageGroup = in.charges.benefits.list match {
       case Digipack :: Nil =>
@@ -55,6 +58,8 @@ object PlanOps {
       case Digipack :: Nil | Weekly :: Nil=> "Change payment frequency"
       case _ => "Add more"
     }
+
+    def promotionalOnly: Boolean = in.charges.billingPeriod == SixWeeks
 
     def isHomeDelivery: Boolean = in.product == Delivery
 

--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -81,7 +81,7 @@ object Pricing {
 
     def prefix = in.charges.benefits.list match {
       case Digipack :: Nil => ""
-      case _ => s"${in.packageName} - "
+      case b => if (b.contains(Weekly)) "" else s"${in.packageName} - "
     }
 
     def prettyName(currency: Currency): String = in.charges.benefits.list match {

--- a/app/views/support/ProductPopulationData.scala
+++ b/app/views/support/ProductPopulationData.scala
@@ -4,9 +4,7 @@ import com.gu.memsub.subsv2.CatalogPlan
 import com.gu.memsub.subsv2.CatalogPlan.{ContentSubscription, RecurringPlan}
 
 
-case class PlanList[+A](associations: List[(ContentSubscription, ContentSubscription)], default: A, others: A*) {
-  def map[B](f: A => B): PlanList[B] = PlanList(associations, f(default), others.map(f):_*)
-  def list = Seq(default) ++ others
+case class PlanList[+A](associations: List[(ContentSubscription, ContentSubscription)], default: A, list: List[A]) {
   def associationFor(p: ContentSubscription) =
     associations.toMap.get(p)
 }

--- a/assets/javascripts/modules/checkout/promoCode.js
+++ b/assets/javascripts/modules/checkout/promoCode.js
@@ -11,6 +11,7 @@ define([
 
     var $inputBox         = formElements.$PROMO_CODE;
     var $ratePlanFields   = $('input[name="ratePlanId"]');
+    //This doesn't include promotional rate plans as they're hidden
     var $promoCodeSnippet = $('.js-promo-code-snippet');
     var $promoCodeTsAndCs = $('.js-promo-code-tsandcs');
     var $promoCodeError   = $('.js-promo-code .js-error-message');
@@ -26,6 +27,39 @@ define([
     $ratePlanFields.each(function(el){
        ratePlans[el.value] = true;
     });
+
+    function showPromotionalPlans(productRatePlanIds){
+        var selected = ratePlanChoice.getSelectedRatePlanId();
+        var backupSelect = selected;
+        var select;
+        $ratePlanFields.each(function(plan){
+            console.log(plan);
+            var ratePlanId = plan.value;
+            var parent = plan.parentNode.parentNode;
+            if (productRatePlanIds.indexOf(ratePlanId)!==-1) {
+                parent.removeAttribute('hidden');
+                backupSelect = ratePlanId;
+                if(ratePlanId === selected){
+                    select = ratePlanId;
+                }
+            } else {
+                parent.hidden = true;
+            }
+        });
+
+        $promotionalPlans.each(function(el){
+            var ratePlanId = el.querySelector('input').value;
+            if (productRatePlanIds.indexOf(ratePlanId)!==-1) {
+                el.removeAttribute('hidden');
+                select = ratePlanId;
+            }
+        });
+
+        if(select == null){
+            select = backupSelect;
+        }
+        if (select) {selectRatePlan(select);}
+    }
 
     function selectRatePlan(ratePlanId){
         var currency = ratePlanChoice.getSelectedOptionData().currency;
@@ -91,14 +125,19 @@ define([
         $promoRenew.hide();
         toggleError($promoCodeError.parent(), false);
         var selected = ratePlanChoice.getSelectedRatePlanId()
-        $promotionalPlans.each(function(el){
+        $ratePlanFields.each(function (plan) {
+            var parent = plan.parentNode.parentNode;
+            parent.removeAttribute('hidden');
+        });
+        $promotionalPlans.each(function (el) {
             var $plan = $(el);
-            $plan.attr('hidden',true);
+            $plan.attr('hidden', true);
             var ratePlanId = el.querySelector('input').value;
-            if(ratePlanId===selected){
+            if (ratePlanId === selected) {
                 selectRatePlan(selectedPlan);
             }
         });
+
 
         $promotionalPlans.attr('hidden',true);
         removePromotionFromRatePlans();
@@ -122,13 +161,7 @@ define([
         $promoCodeApplied.show();
         $promoCodeSnippet.html(response.promotion.description);
         $promoCodeTsAndCs.attr('href', '/p/' + promoCode + '/terms');
-        $promotionalPlans.each(function(el){
-            var ratePlanId = el.querySelector('input').value;
-            if (response.promotion.appliesTo.productRatePlanIds.indexOf(ratePlanId)!==-1) {
-                el.removeAttribute('hidden');
-                selectRatePlan(ratePlanId);
-            }
-        });
+        showPromotionalPlans(response.promotion.appliesTo.productRatePlanIds);
         applyPromotionToRatePlans(response.adjustedRatePlans);
     }
 


### PR DESCRIPTION
- [x] Allow users to select any plan for the product they are buying.
- [x] Hide promotional only plans by default.
- [x] Show promotional plans when they are the default plan (via URL path) for the checkout page.
- [x] Show promotional plans when the user types in a promotion or it's included in the URL query.

Eventually we'll migrate 6-for-6 promotions to not be Tracking type. See https://github.com/guardian/membership-common/pull/455

cc @jacobwinch @pvighi 
