### PR TITLE
Fix manage page for subscribers with < 5 character subscriber ID

### DIFF
--- a/app/forms/AccountManagementLoginForm.scala
+++ b/app/forms/AccountManagementLoginForm.scala
@@ -8,7 +8,7 @@ case class AccountManagementLoginRequest(subscriptionId: String, lastname: Strin
 object AccountManagementLoginForm {
 
   val mappings = Form(mapping(
-    "subscriptionId" -> text(minLength = 5, maxLength = 50),
+    "subscriptionId" -> text(minLength = 1, maxLength = 50),
     "lastname" -> text(minLength = 1, maxLength = 50),
     "promoCode" -> optional(text(minLength = 1, maxLength = 50))
   )(AccountManagementLoginRequest.apply)(AccountManagementLoginRequest.unapply))


### PR DESCRIPTION
Some migrated Guardian Weekly Subscriber IDs are 4 characters long, and they're not able to log in to the /manage page. I'm setting the validation to 1 in case there are other sneaky Subscriber IDs.

cc @jacobwinch @pvighi @johnduffell @AWare 