### PR TITLE
[DO NOT MERGE TILL 10am on 3/4] Update the homepage promo links and the offers page promo links

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -76,7 +76,7 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
         val buyablePlans = plans.filter(_.availableForCheckout)
         val plansInPriceOrder = buyablePlans.sortBy(_.charges.gbpPrice.amount)
         val selectedPlan = plansInPriceOrder.find(_.slug == forThisPlan)
-        selectedPlan.map(PlanList(associations,_,buyablePlans))
+        selectedPlan.map(PlanList(associations,_,plansInPriceOrder))
       }
         case _ => None
       }.headOption

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -29,28 +29,30 @@
                 <h2 class="block__title">Paper + digital</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">Year-round savings of up to 36% off the retail price</li>
-                        <li class="block__list-item">Pick the package you want: Everyday+, Sixday+, Weekend+ and Sunday+</li>
+                        <li class="block__list-item"><strong>Subscribe today to save an extra 50% for the first month</strong></li>
+                        <li class="block__list-item">Year-round savings on the retail price</li>
+                        <li class="block__list-item">Pick the package you want: Everyday+, Sixday+, Weekend+</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
                         <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("NHOMEUKD", None).url" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBA80F", None).url" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper">
                 <h2 class="block__title">Paper</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">Year-round savings of up to 31% off the price of your paper</li>
+                        <li class="block__list-item"><strong>Subscribe today to save an extra 50% for the first month</strong></li>
+                        <li class="block__list-item">Year-round savings on the retail price</li>
                         <li class="block__list-item">Pick the package you want: Everyday, Sixday and Weekend</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
                         <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("NHOMEUKP", None).url" data-test-id="subscriptions-uk-paper">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBA80X", None).url" data-test-id="subscriptions-uk-paper">Subscribe now</a>
                 </div>
             </div>
         </div>

--- a/app/views/offers/offers_international.scala.html
+++ b/app/views/offers/offers_international.scala.html
@@ -15,14 +15,14 @@
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">14-day free trial</li>
-                        <li class="block__list-item"><strong>Subscribe today and save an additional 50% off the subscription price for 3 months</strong></li>
+                        <li class="block__list-item"><strong>Save up to 75% on the app store price</strong></li>
                         <li class="block__list-item">Access to the Daily Edition, the digital version of the UK Guardian newspaper</li>
                         <li class="block__list-item">Access to the Guardian App Premium Tier, an advert-free experience</li>
                         <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render("DAJ41X", edition.countryGroup.defaultCountry).url">Subscribe now</a>
+                    <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render("DOFFINT", edition.countryGroup.defaultCountry).url">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--weekly">

--- a/app/views/offers/offers_uk.scala.html
+++ b/app/views/offers/offers_uk.scala.html
@@ -1,7 +1,8 @@
 @import model.DigitalEdition.UK
+@import org.joda.time.LocalDate
 @import views.support.DigitalEdition._
 @()
-
+@isEasterWeekend = @{LocalDate.now.isAfter(LocalDate.parse("2017-04-13")) && LocalDate.now.isBefore(LocalDate.parse("2017-04-18"))}
 @main(
     "Subscriptions and Membership | The Guardian",
     Some("Subscribe to The Guardian & Observer. Support our independent, award-winning journalism."),
@@ -15,44 +16,60 @@
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">14-day free trial of our digital pack</li>
-                        <li class="block__list-item"><strong>Subscribe today and save an additional 50% off the subscription price for 3 months</strong></li>
+                        <li class="block__list-item"><strong>Save up to 75% on the app store price</strong></li>
                         <li class="block__list-item">Access to the Daily Edition and the advert-free Guardian App Premium Tier</li>
                         <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
                         <li class="block__list-item">Use on up to 10 devices</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DAI41X", UK.countryGroup.defaultCountry).url">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DOFFUK1", UK.countryGroup.defaultCountry).url">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper-digital">
                 <h2 class="block__title">Paper + digital</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">Year-round savings of up to 36% off the retail price</li>
-                        <li class="block__list-item"><strong>Subscribe today and save an additional 30% off the subscription price for 3 months</strong></li>
+                        <li class="block__list-item">
+                            <strong>
+                            @if(isEasterWeekend) {
+                                Subscribe this weekend to save an extra 50% on the first 3 months
+                            } else {
+                                Subscribe today to save an extra 50% for the first month
+                            }
+                            </strong>
+                        </li>
+                        <li class="block__list-item">Year-round savings on the retail price</li>
                         <li class="block__list-item">Pick the package you want: Everyday+, Sixday+ and Weekend+</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
                         <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GAH41G", None).url">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render(if(isEasterWeekend) "GBB41G" else "GBA41G", None).url">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper">
                 <h2 class="block__title">Paper</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">Year-round savings of up to 31% off the price of your paper</li>
-                        <li class="block__list-item"><strong>Subscribe today and save an additional 30% off the subscription price for 3 months</strong></li>
+                        <li class="block__list-item">
+                            <strong>
+                            @if(isEasterWeekend) {
+                                Subscribe this weekend to save an extra 50% on the first 3 months
+                            } else {
+                                Subscribe today to save an extra 50% for the first month
+                            }
+                            </strong>
+                        </li>
+                        <li class="block__list-item">Year-round savings on the retail price</li>
                         <li class="block__list-item">Pick the package you want: Everyday, Sixday and Weekend</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
                         <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GAH41F", None).url">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render(if(isEasterWeekend) "GBB41F" else "GBA41F", None).url">Subscribe now</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Update the homepage promo links and the offers page promo links. As per https://trello.com/c/Ypxi5kap/70-timebound-subs-promotion-changes-for-3-4 and https://trello.com/c/GWjFwapn/71-timebound-subs-promotion-changes-for-14-4-17-4 

Before:
![picture 64](https://cloud.githubusercontent.com/assets/1515970/24516028/3ce31df8-1571-11e7-994d-1ee981cc1f65.png)

After:
![picture 65](https://cloud.githubusercontent.com/assets/1515970/24516075/6038453a-1571-11e7-9a1b-7744a4d24290.png)
and (during 14th-17th) on offer page only
![picture 66](https://cloud.githubusercontent.com/assets/1515970/24543443/a34f3794-15f7-11e7-9052-3949fd41d692.png)

cc @jacobwinch @AWare @pvighi @johnduffell