### PR TITLE
update membership common version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.385",
+    "com.gu" %% "membership-common" % "0.387",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
## Why are you doing this?
updating membership common version to include special [armed forces states](https://github.com/guardian/membership-common/pull/457)

## Trello card: [Here](https://trello.com/c/nryweB6d/60-us-military-state-codes-are-not-included-in-our-drop-down-list-this-prevents-their-employees-from-supporting-the-guardian)

## Changes
* Us Armed forces states are now available in the state drop down list

@paulbrown1982 @jacobwinch 