### PR TITLE
Use TiP to verify first production sale after deployment

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -266,7 +266,6 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
       }
 
       logger.info(s"User successfully became subscriber:\n\tUser: SF=${r.salesforceMember.salesforceContactId}\n\tPlan: ${subscribeRequest.productData.fold(_.plan, _.plan).name}\n\tSubscription: ${r.subscribeResult.subscriptionName}")
-      if (tpBackend.environmentName == "PROD") Tip.verify()
       Ok(Json.obj("redirect" -> routes.Checkout.thankYou().url)).withSession(session)
     }
 
@@ -309,6 +308,7 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
       val eventualMaybeSubscription = tpBackend.subscriptionService.get[com.gu.memsub.subsv2.SubscriptionPlan.ContentSubscription](Name(subsName))
       eventualMaybeSubscription.map { maybeSub =>
         maybeSub.map { sub =>
+          if (tpBackend.environmentName == "PROD") Tip.verify()
           Ok(view.thankyou(sub, passwordForm, resolution, promotion, startDate))
         }.getOrElse {
           Redirect(routes.Homepage.index()).withNewSession

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -10,6 +10,7 @@ import com.gu.memsub.promo.{NewUsers, NormalisedPromoCode, PromoCode}
 import com.gu.memsub.subsv2.CatalogPlan.ContentSubscription
 import com.gu.memsub.subsv2.{CatalogPlan, PlansWithIntroductory}
 import com.gu.memsub.{Product, SupplierCode}
+import com.gu.tip.Tip
 import com.gu.zuora.soap.models.errors._
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config.Identity.webAppProfileUrl
@@ -265,6 +266,7 @@ object Checkout extends Controller with LazyLogging with CatalogProvider {
       }
 
       logger.info(s"User successfully became subscriber:\n\tUser: SF=${r.salesforceMember.salesforceContactId}\n\tPlan: ${subscribeRequest.productData.fold(_.plan, _.plan).name}\n\tSubscription: ${r.subscribeResult.subscriptionName}")
+      if (tpBackend.environmentName == "PROD") Tip.verify()
       Ok(Json.obj("redirect" -> routes.Checkout.thankYou().url)).withSession(session)
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",
+    "com.gu" %% "tip" % "0.1.1",
     "com.github.nscala-time" %% "nscala-time" % "2.8.0",
     "com.getsentry.raven" % "raven-logback" % "7.8.5",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",


### PR DESCRIPTION
This PR enables us to report on the first production sale after a deploy, using:
https://github.com/guardian/tip

Note that this requires us to add a GitHub access token to our private .conf file. For the purposes of testing out TiP, I suggest that we use my personal access token for this (temporarily). 

