### PR TITLE
Do not allow managing cancelled subs

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -27,7 +27,7 @@ import play.api.mvc._
 import utils.TestUsers.PreSigninTestCookie
 import views.html.account.thankYouRenew
 import views.support.Pricing._
-
+import views.support.Dates._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 import scalaz.std.scalaFuture._
@@ -357,7 +357,7 @@ object AccountManagement extends Controller with ContextLogging with CatalogProv
       "error" -> errorMessage
     )
     subscriptionFromUserDetails(loginRequest).map {
-        case Some(sub) if (sub.isCancelled) =>  loginError(s"Your subscription is cancelled as of ${sub.termEndDate}, please contact customer services.")
+        case Some(sub) if (sub.isCancelled) =>  loginError(s"Your subscription is cancelled as of ${sub.termEndDate.pretty}, please contact customer services.")
         case Some(sub) => SessionSubscription.set(Redirect(routes.AccountManagement.manage(None, None, promoCode)), sub)
         case _ => loginError("Unable to verify your details.")
     }

--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -303,7 +303,7 @@ object AccountManagement extends Controller with ContextLogging with CatalogProv
     loginRequestOpt.map { loginRequest =>
       (for {
         zuoraSubscription <- OptionT(tpBackend.subscriptionService.get[ContentSubscription](Name(loginRequest.subscriptionId))).filter(sub => !sub.isCancelled)
-        result <- OptionT(subscriptionDetailsMatch(loginRequest, zuoraSubscription).map(matches => if (matches)  Some(zuoraSubscription) else None))
+        result <- OptionT(subscriptionDetailsMatch(loginRequest, zuoraSubscription).map(matches => if (matches) Some(zuoraSubscription) else None))
       } yield result).run
     }.getOrElse(Future.successful(None))
 

--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -302,8 +302,8 @@ object AccountManagement extends Controller with ContextLogging with CatalogProv
 
     loginRequestOpt.map { loginRequest =>
       (for {
-        zuoraSubscription <- OptionT(tpBackend.subscriptionService.get[ContentSubscription](Name(loginRequest.subscriptionId)))
-        result <- OptionT(subscriptionDetailsMatch(loginRequest, zuoraSubscription).map(matches => if (matches) Some(zuoraSubscription) else None))
+        zuoraSubscription <- OptionT(tpBackend.subscriptionService.get[ContentSubscription](Name(loginRequest.subscriptionId))).filter(sub => !sub.isCancelled)
+        result <- OptionT(subscriptionDetailsMatch(loginRequest, zuoraSubscription).map(matches => if (matches)  Some(zuoraSubscription) else None))
       } yield result).run
     }.getOrElse(Future.successful(None))
 


### PR DESCRIPTION
Logging in to /manage with a cancelled home delivery sub causes a 500 error.  [trello card](https://trello.com/c/KFnLL0AM/50-improve-handling-of-cancelled-subs-who-try-to-access-manage)

@jacobwinch  mentioned that there are similar problems with other types of subs, for example attempting to renew a cancelled subscription.

This change filters out cancelled subs so the user would get an "Unable to verify your details" error when trying to log in.

@johnduffell @jacobwinch @paulbrown1982 