### PR TITLE
Add PROD/UAT marker to context logging

### DIFF
--- a/app/logging/ContextLogging.scala
+++ b/app/logging/ContextLogging.scala
@@ -2,33 +2,44 @@ package logging
 
 import com.gu.memsub.subsv2.Subscription
 import com.gu.memsub.subsv2.SubscriptionPlan.AnyPlan
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.StrictLogging
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import scala.concurrent.Future
+import services.TouchpointBackend
 
-trait ContextLogging extends LazyLogging {
+import scala.concurrent.Future
+import scala.language.implicitConversions
+
+case class Context(
+  sub: Subscription[AnyPlan],
+  environmentName: String
+)
+
+trait ContextLogging extends StrictLogging {
+
+  implicit def makeContext(implicit sub: Subscription[AnyPlan], resolution: TouchpointBackend.Resolution) = Context(sub, resolution.backend.environmentName)
+  implicit def makeContextFromSub(sub: Subscription[AnyPlan])(implicit resolution: TouchpointBackend.Resolution) = makeContext(sub, resolution)
 
   // as long as there's an implicit subscription context available, log will output the subscription name automatically
-  def info[P <: AnyPlan : Subscription](message: String): Unit = {
-    val context = implicitly[Subscription[P]]
-    logger.info(s"{sub: ${context.name.get}} $message")
+  def info(message: String)(implicit context: Context) = log(logger.info(_), message, context)
+
+  def error(message: String)(implicit context: Context) = log(logger.error(_), message, context)
+
+  private def log(log: String => Unit, message: String, context: Context): Unit = {
+    log(s"{${context.environmentName} sub: ${context.sub.name.get}} $message")
   }
 
-  def error[P <: AnyPlan : Subscription](message: String): Unit = {
-    val context = implicitly[Subscription[P]]
-    logger.error(s"{sub: ${context.name.get}} $message")
-  }
-
+  // you can even run an extractor on the value in a future
   implicit class FutureContextLoggable[T](future: Future[T]) {
-    def withContextLogging[P <: AnyPlan : Subscription](message: String, extractor: T => Any = identity): Future[T] = {
+    def withContextLogging(message: String, extractor: T => Any = identity)(implicit context: Context): Future[T] = {
       future.foreach(any => info(s"$message {${extractor(any)}}"))
       future
     }
 
   }
 
+  // if you do context logging on a future it will wait for the success and show the value
   implicit class ContextLoggable[T](t: T) {
-    def withContextLogging[P <: AnyPlan : Subscription](message: String): T = {
+    def withContextLogging(message: String)(implicit context: Context): T = {
       t match {
         case future: Future[_] => future.foreach(any => info(s"$message {$any}"))
         case any => info(s"$message {$any}")

--- a/app/model/SubscriptionOps.scala
+++ b/app/model/SubscriptionOps.scala
@@ -8,7 +8,7 @@ import com.gu.memsub._
 import com.gu.memsub.subsv2.SubscriptionPlan.{Paid, PaperPlan, WeeklyPlan}
 import com.gu.memsub.subsv2.{PaidCharge, PaidSubscriptionPlan, Subscription}
 import com.typesafe.scalalogging.LazyLogging
-import logging.ContextLogging
+import logging.{Context, ContextLogging}
 import model.BillingPeriodOps._
 import org.joda.time.LocalDate.now
 import PartialFunction.cond
@@ -67,8 +67,7 @@ object SubscriptionOps extends LazyLogging {
   }
 
   implicit class EnrichedPaperSubscription[P <: PaperPlan](subscription: Subscription[P]) extends ContextLogging {
-    implicit val subContext = subscription
-    val renewable = {
+    def renewable(implicit context: Context) = {
       val wontAutoRenew = !subscription.autoRenew
       val startedAlready = !subscription.termStartDate.isAfter(now)
       info(s"testing if renewable - wontAutoRenew: $wontAutoRenew, startedAlready: $startedAlready")
@@ -77,7 +76,7 @@ object SubscriptionOps extends LazyLogging {
   }
 
   implicit class EnrichedWeeklySubscription[P <: WeeklyPlan](subscription: Subscription[P]) {
-    def asRenewable = if (subscription.renewable) Some(subscription.asInstanceOf[Subscription[WeeklyPlanOneOff]]) else None
+    def asRenewable(implicit context: Context) = if (subscription.renewable) Some(subscription.asInstanceOf[Subscription[WeeklyPlanOneOff]]) else None
     def secondPaymentDate = if (subscription.hasIntroductoryPeriod) subscription.acceptanceDate else subscription.acceptanceDate plusMonths subscription.plan.charges.billingPeriod.monthsInPeriod
 
   }

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -19,7 +19,7 @@ import com.gu.zuora.soap.models.Commands.{Account, PaymentMethod, RatePlan, Subs
 import com.gu.zuora.soap.models.Queries
 import com.gu.zuora.soap.models.Results.SubscribeResult
 import com.gu.zuora.soap.models.errors._
-import logging.ContextLogging
+import logging.{Context, ContextLogging}
 import model.BillingPeriodOps._
 import model.SubscriptionOps._
 import model.error.CheckoutService._
@@ -307,9 +307,11 @@ class CheckoutService(
   }
 
   def renewSubscription(subscription: Subscription[WeeklyPlanOneOff], renewal: model.Renewal)
-    (implicit p: PromotionApplicator[com.gu.memsub.promo.Renewal, Renew], zuoraRestService: ZuoraRestService[Future]) = {
-
-    implicit val context = subscription
+    (implicit
+      p: PromotionApplicator[com.gu.memsub.promo.Renewal, Renew],
+      zuoraRestService: ZuoraRestService[Future],
+      context: Context
+    ) = {
 
     def getPayment(contact: Contact, billto: Queries.Contact): PaymentService#Payment = {
       val idMinimalUser = IdMinimalUser(contact.identityId, None)

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -20,7 +20,7 @@ import com.gu.zuora.api.ZuoraService
 import com.gu.zuora.soap.models.Results.SubscribeResult
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
-import logging.ContextLogging
+import logging.{Context, ContextLogging}
 import model.SubscriptionOps._
 import model.exactTarget.HolidaySuspensionBillingScheduleDataExtensionRow.constructSalutation
 import model.exactTarget._
@@ -202,9 +202,7 @@ class ExactTargetService(
     subscriptionDetails: String,
     contact: Contact,
     email: String,
-    newTermStartDate: LocalDate): Future[Unit] = {
-
-    implicit val context = oldSub
+    newTermStartDate: LocalDate)(implicit context: Context): Future[Unit] = {
 
     sealed trait Error {
       def msg: String


### PR DESCRIPTION
Previously we logged the subscription when you used the info or the withContextLogging calls.  This could get confusing when things happened on a subscription, but that one was actually in UAT.

This change adds logging of the env and sub.
```
2017-04-10 10:43:38,821 model.SubscriptionOps$EnrichedPaperSubscription[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} testing if renewable - wontAutoRenew: true, startedAlready: true
2017-04-10 10:43:38,821 controllers.ManageWeekly$[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} sub is renewable - showing weeklyRenew page
2017-04-10 10:44:10,133 model.SubscriptionOps$EnrichedPaperSubscription[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} testing if renewable - wontAutoRenew: true, startedAlready: true
2017-04-10 10:44:10,154 controllers.ManageWeekly$[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} Attempting to renew onto Guardian Weekly Quarterly with promo code: None
2017-04-10 10:44:10,260 services.CheckoutService[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} currentVersionExpired {false}
2017-04-10 10:44:10,261 services.CheckoutService[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} startDateForRenewal {2018-04-01}
2017-04-10 10:44:10,593 services.CheckoutService[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} zuoraAccount {2c92c0f859b047b70159bc8dcc901253}
2017-04-10 10:44:10,925 services.CheckoutService[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} zuora bill to {2c92c0f859b047b70159bc8dcc971254}
2017-04-10 10:44:11,082 services.CheckoutService[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} promo code from client {None}
2017-04-10 10:44:11,086 services.CheckoutService[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} Subscription price: {£30 every 3 months}
2017-04-10 10:44:11,087 services.CheckoutService[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} sfContact {003g000001Kb4m3AAB}
2017-04-10 10:44:13,286 services.CheckoutService[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} createPaymentMethod {2c92c0f859b047b70159bc8dcc901253}
2017-04-10 10:44:13,293 services.CheckoutService[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} No promotion to apply, keeping basicRenewCommand
2017-04-10 10:44:13,293 services.CheckoutService[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} final renew command {Renew(2c92c0f95b42451c015b573eeaf32fbd,2017-04-01,2018-04-01,2c92c0f95b42451c015b573eeb0a2fc2,NonEmptyList(RatePlan(2c92c0f9574ee3d80157514ee1c36a8e,None,List())),2018-04-01,None,true,false)}
2017-04-10 10:44:16,573 services.CheckoutService[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} email submitted on backend but not updated: Direct, Some(john@guardian.co.uk)
2017-04-10 10:44:18,107 services.ExactTargetService[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} Successfully enqueued guardian weekly renewal email.
2017-04-10 10:44:18,107 controllers.ManageWeekly$[ContextLogging.scala:26] INFO: {UAT sub: A-S00068891} Successfully processed renewal onto Guardian Weekly Quarterly
```

It does this by adding a context to wrap the subscription and the environment name.  This is grabbed implicitly, so it will find the sub and backend automatically, and later calls just need to pull in the Context implicitly to be able to log things also.

The downside is that the Context is a concrete class, so there's no way to have a context that only includes some of the information, or perhaps more information in later times.  We can visit that when it becomes useful.  The other downside is the number of implicits used.  I'm not keen on implicits, but using the Reader monad seems to be the functional way to do it and we all know how much boilerplate that causes!

@jacobwinch @paulbrown1982 @lmath @pvighi any thoughts?