### PR TITLE
use the suspension service call to get the unfinished suspensions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.390-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.390",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.389",
+    "com.gu" %% "membership-common" % "0.390-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
If people have broken holidays in the past, we don't want to deal with them in case they are broken in some way (finish before they start) This filters them before they can cause an issue.

@paulbrown1982 @jacobwinch @pvighi @lmath 