### PR TITLE
Manually fulfilling today due to Easter bank holiday

### DIFF
--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -50,9 +50,12 @@ object CheckoutService {
     case weekend => d.plusWeeks(1).withDayOfWeek(DateTimeConstants.FRIDAY)
   }
 
-  def determineFirstAvailableWeeklyDate(now: LocalDate): LocalDate =
-    nextFriday(now plusWeeks 1)
+  val manualFulfilmentOverride = new LocalDate("2017-04-28")
 
+  def determineFirstAvailableWeeklyDate(now: LocalDate): LocalDate = {
+    val nextAvailableDate = nextFriday(now plusWeeks 1)
+    Seq(manualFulfilmentOverride, nextAvailableDate).max
+  }
 }
 
 class CheckoutService(

--- a/assets/javascripts/modules/checkout/deliveryFields.jsx
+++ b/assets/javascripts/modules/checkout/deliveryFields.jsx
@@ -13,10 +13,10 @@ require('react-datepicker/dist/react-datepicker.css');
 const MAX_WEEKS_AVAILABLE = 4;
 
 function getFirstSelectableDate(filterFn) {
-    let weekly = formElements.$DELIVERED_PRODUCT_TYPE.val() === 'weekly';
-    let firstWeekly = moment('20170414','YYYYMMDD');
-    let NUMBER_OF_DAYS_IN_ADVANCE = weekly?7:3;
-    var firstSelectableDate = moment().add(NUMBER_OF_DAYS_IN_ADVANCE, 'days');
+    const weekly = formElements.$DELIVERED_PRODUCT_TYPE.val() === 'weekly';
+    const firstWeekly = moment('20170428','YYYYMMDD');
+    const NUMBER_OF_DAYS_IN_ADVANCE = weekly ? 7 : 3;
+    const firstSelectableDate = moment().add(NUMBER_OF_DAYS_IN_ADVANCE, 'days');
     while (filterFn && !filterFn(firstSelectableDate)) {
         firstSelectableDate.add(1, 'day');
     }
@@ -27,7 +27,7 @@ function getFirstSelectableDate(filterFn) {
 }
 
 function getLastSelectableDate(firstSelectableDate) {
-    var startDate = firstSelectableDate || moment();
+    const startDate = firstSelectableDate || moment();
     return moment(startDate).add(MAX_WEEKS_AVAILABLE, 'weeks');
 }
 

--- a/test/services/CheckoutServiceTest.scala
+++ b/test/services/CheckoutServiceTest.scala
@@ -50,16 +50,23 @@ class CheckoutServiceTest extends Specification {
     }
   }
 
+    "Calculate the next available Friday correctly (if overridden)" in {
+      CheckoutService.determineFirstAvailableWeeklyDate(new LocalDate("2017-04-13")) mustEqual new LocalDate("2017-04-28")
+      CheckoutService.determineFirstAvailableWeeklyDate(new LocalDate("2017-04-21")) mustEqual new LocalDate("2017-04-28")
+      CheckoutService.determineFirstAvailableWeeklyDate(new LocalDate("2017-04-22")) mustEqual new LocalDate("2017-05-05")
+    }
+
+    // Uses default algorithm after override date that
     "Calculate the next available Friday correctly (if today is a Monday)" in {
-       CheckoutService.determineFirstAvailableWeeklyDate(new LocalDate("2017-03-06")) mustEqual(new LocalDate("2017-03-17"))
+      CheckoutService.determineFirstAvailableWeeklyDate(new LocalDate("2017-04-24")) mustEqual new LocalDate("2017-05-05")
     }
 
     "Calculate the next available Friday correctly (if today is a Friday)" in {
-      CheckoutService.determineFirstAvailableWeeklyDate(new LocalDate("2017-03-10")) mustEqual(new LocalDate("2017-03-17"))
+      CheckoutService.determineFirstAvailableWeeklyDate(new LocalDate("2017-05-05")) mustEqual new LocalDate("2017-05-12")
     }
 
     "Calculate the next available Friday correctly (if today is a Sunday)" in {
-      CheckoutService.determineFirstAvailableWeeklyDate(new LocalDate("2017-03-12")) mustEqual(new LocalDate("2017-03-24"))
+      CheckoutService.determineFirstAvailableWeeklyDate(new LocalDate("2017-05-14")) mustEqual new LocalDate("2017-05-26")
     }
 
 }


### PR DESCRIPTION
Manually fulfilling on Thursday this week due to Monday being Easter Bank Holiday. I've updated tests accordingly to cover this week, and then the normal algorithm beyond.

Before:
![picture 70](https://cloud.githubusercontent.com/assets/1515970/24996782/24de1404-202c-11e7-8257-cee9dabf86c3.png)

After:
![picture 69](https://cloud.githubusercontent.com/assets/1515970/24996757/0a2edefe-202c-11e7-8be9-69b07633e1d2.png)

cc @jacobwinch 

Also (fulfilling is the only word where it has two Ls): http://dictionary.cambridge.org/dictionary/english/fulfilling 😛 

