### PR TITLE
Add appnexus pixel

### DIFF
--- a/app/controllers/Shipping.scala
+++ b/app/controllers/Shipping.scala
@@ -12,50 +12,54 @@ object Shipping extends Controller {
   val catalog = TouchpointBackend.Normal.catalogService.unsafeCatalog
 
   private def index(subscriptionCollection: SubscriptionProduct, productSegment: String) = {
-    Ok(views.html.shipping.shipping(subscriptionCollection))
+    Ok(views.html.shipping.shipping(subscriptionCollection, productSegment))
   }
 
-  def planToOptions(in: CatalogPlan.Paid): SubscriptionOption =
+  private def planToOptions(in: CatalogPlan.Paid): SubscriptionOption =
     SubscriptionOption(in.slug,
       in.name, in.charges.gbpPrice.amount * 12 / 52, in.saving.map(_.toString + "%"), in.charges.gbpPrice.amount, in.description,
       routes.Checkout.renderCheckout(UK.id, None, None, in.slug).url
     )
 
   def viewCollectionPaperDigital() = CachedAction {
+    val segment = "paper-digital"
     index(CollectionSubscriptionProduct(
       title = "Paper + digital voucher subscription",
       description = "Save money on your newspapers and digital content. Plus start using the daily edition and premium live news app immediately.",
-      altPackagePath = "/delivery/paper-digital",
+      altPackagePath = s"/delivery/$segment",
       options = catalog.voucher.list.filter(_.charges.digipack.isDefined).map(planToOptions).sortBy(_.weeklyPrice).reverse
-    ), "Paper+Digital")
+    ), segment)
   }
 
   def viewCollectionPaper() = CachedAction {
+    val segment = "paper"
     index(CollectionSubscriptionProduct(
       title = "Paper voucher subscription",
       description = "Save money on your newspapers.",
-      altPackagePath = "/delivery/paper",
+      altPackagePath = s"/delivery/$segment",
       options = catalog.voucher.list.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse
-    ), "Paper")
+    ), segment)
   }
 
   def viewDeliveryPaperDigital() = CachedAction {
+    val segment = "paper-digital"
     index(DeliverySubscriptionProduct(
       title = "Paper + digital home delivery subscription",
       description = """|If you live within the M25 you can have your papers delivered by 7am Monday - Saturday and 8.30am on Sunday.
                       |Plus you can start using the daily edition and premium live news app immediately.""".stripMargin,
-      altPackagePath = "/collection/paper-digital",
+      altPackagePath = s"/collection/$segment",
       options = catalog.delivery.list.filter(_.charges.digipack.isDefined).map(planToOptions).sortBy(_.weeklyPrice).reverse
-    ), "Paper+Digital")
+    ), segment)
   }
 
   def viewDeliveryPaper() = CachedAction {
+    val segment = "paper"
     index(DeliverySubscriptionProduct(
       title = "Paper home delivery subscription",
       description = "If you live within the M25 you can have your papers delivered by 7am Monday - Saturday and 8.30 on Sunday.",
-      altPackagePath = "/collection/paper",
+      altPackagePath = s"/collection/$segment",
       options = catalog.delivery.list.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse
-    ), "Paper")
+    ), segment)
   }
 
 }

--- a/app/controllers/Shipping.scala
+++ b/app/controllers/Shipping.scala
@@ -11,7 +11,7 @@ object Shipping extends Controller {
   // no need to support test users here really as plans seldom change
   val catalog = TouchpointBackend.Normal.catalogService.unsafeCatalog
 
-  def index(subscriptionCollection: SubscriptionProduct) = {
+  private def index(subscriptionCollection: SubscriptionProduct, productSegment: String) = {
     Ok(views.html.shipping.shipping(subscriptionCollection))
   }
 
@@ -27,7 +27,7 @@ object Shipping extends Controller {
       description = "Save money on your newspapers and digital content. Plus start using the daily edition and premium live news app immediately.",
       altPackagePath = "/delivery/paper-digital",
       options = catalog.voucher.list.filter(_.charges.digipack.isDefined).map(planToOptions).sortBy(_.weeklyPrice).reverse
-    ))
+    ), "Paper+Digital")
   }
 
   def viewCollectionPaper() = CachedAction {
@@ -36,7 +36,7 @@ object Shipping extends Controller {
       description = "Save money on your newspapers.",
       altPackagePath = "/delivery/paper",
       options = catalog.voucher.list.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse
-    ))
+    ), "Paper")
   }
 
   def viewDeliveryPaperDigital() = CachedAction {
@@ -46,7 +46,7 @@ object Shipping extends Controller {
                       |Plus you can start using the daily edition and premium live news app immediately.""".stripMargin,
       altPackagePath = "/collection/paper-digital",
       options = catalog.delivery.list.filter(_.charges.digipack.isDefined).map(planToOptions).sortBy(_.weeklyPrice).reverse
-    ))
+    ), "Paper+Digital")
   }
 
   def viewDeliveryPaper() = CachedAction {
@@ -55,7 +55,7 @@ object Shipping extends Controller {
       description = "If you live within the M25 you can have your papers delivered by 7am Monday - Saturday and 8.30 on Sunday.",
       altPackagePath = "/collection/paper",
       options = catalog.delivery.list.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse
-    ))
+    ), "Paper")
   }
 
 }

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -72,6 +72,8 @@
 ) {
 <script>
     guardian.supplierCode = '@{supplierCode.mkString}';
+    guardian.pageInfo.pageType = 'Checkout';
+    guardian.pageInfo.productData.productSegment = '@{productData.plans.default.segment}';
     guardian.pageInfo.productData.initialProduct = '@{productData.plans.default.name}';
     guardian.pageInfo.productData.productPurchasing = '@{productData.plans.default.name}';
     guardian.pageInfo.productData.productType = '@{productData.plans.default.product.productType}';

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -2,8 +2,8 @@
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import com.gu.memsub.subsv2.Subscription
 @import com.gu.memsub.subsv2.SubscriptionPlan.ContentSubscription
-@import model.SubscriptionOps._
 @import views.support.PlanOps._
+@import model.SubscriptionOps._
 
 @(  subscription: Subscription[ContentSubscription],
     guestAccountForm: Option[Form[model.GuestAccountData]] = None,
@@ -11,7 +11,6 @@
     promotion: Option[AnyPromotion] = None,
     startDate: String
 )(implicit request: RequestHeader)
-
 
 @main(s"Confirmation | Subscribe to the ${subscription.firstPlan.title} | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution), product = Some(subscription.firstProduct)) {
 

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -16,6 +16,7 @@
 @main(s"Confirmation | Subscribe to the ${subscription.firstPlan.title} | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution), product = Some(subscription.firstProduct)) {
 
 <script type="text/javascript">
+    guardian.pageInfo.pageType = 'Thankyou';
     guardian.pageInfo.slug="GuardianDigiPack:Order Complete";
     guardian.pageInfo.productData = {
         // Omniture
@@ -25,6 +26,7 @@
         amount: 0,
         // Google Analytics
         zuoraId: '@subscription.name.get',
+        productSegment: '@{subscription.firstPlan.segment}',
         productType: '@subscription.firstProduct.productType',
         productPurchased: '@{subscription.firstPlan.name}'
     };

--- a/app/views/digitalpack/info.scala.html
+++ b/app/views/digitalpack/info.scala.html
@@ -29,7 +29,7 @@
 ) {
 <script>
     guardian.pageInfo.pageType = 'Landing';
-    guardian.pageInfo.productData.productSegment = 'Digital';
+    guardian.pageInfo.productData.productSegment = 'digital';
 </script>
 <main class="page-container gs-container gs-container--slim">
 

--- a/app/views/digitalpack/info.scala.html
+++ b/app/views/digitalpack/info.scala.html
@@ -27,7 +27,10 @@
     bodyClasses = List("is-wide"),
     edition=edition
 ) {
-
+<script>
+    guardian.pageInfo.pageType = 'Landing';
+    guardian.pageInfo.productData.productSegment = 'Digital';
+</script>
 <main class="page-container gs-container gs-container--slim">
 
     <section class="page-slice">

--- a/app/views/promotion/digitalpackLandingPage.scala.html
+++ b/app/views/promotion/digitalpackLandingPage.scala.html
@@ -23,6 +23,10 @@
     bodyClasses = Seq("is-wide"),
     hreflangs = Some(hreflangs)
 ) {
+    <script>
+        guardian.pageInfo.pageType = 'Landing';
+        guardian.pageInfo.productData.productSegment = 'Digital';
+    </script>
 
     <main class="page-container promo-landing-page">
         <section class="section-white section--dark-sides">

--- a/app/views/promotion/digitalpackLandingPage.scala.html
+++ b/app/views/promotion/digitalpackLandingPage.scala.html
@@ -25,7 +25,7 @@
 ) {
     <script>
         guardian.pageInfo.pageType = 'Landing';
-        guardian.pageInfo.productData.productSegment = 'Digital';
+        guardian.pageInfo.productData.productSegment = 'digital';
     </script>
 
     <main class="page-container promo-landing-page">

--- a/app/views/promotion/newspaperLandingPage.scala.html
+++ b/app/views/promotion/newspaperLandingPage.scala.html
@@ -43,6 +43,17 @@
 @main(
     title = s"$title | The Guardian"
 ) {
+
+    <script>
+        guardian.pageInfo.pageType = 'Landing';
+    @if(products.exists(_.title.contains("+"))) {
+        guardian.pageInfo.productData.productSegment = 'Paper+Digital';
+    }
+    @if(!products.exists(_.title.contains("+"))) {
+        guardian.pageInfo.productData.productSegment = 'Paper';
+    }
+    </script>
+
     <main class="page-container gs-container">
 
         @fragments.page.header(title)

--- a/app/views/promotion/newspaperLandingPage.scala.html
+++ b/app/views/promotion/newspaperLandingPage.scala.html
@@ -47,10 +47,10 @@
     <script>
         guardian.pageInfo.pageType = 'Landing';
     @if(products.exists(_.title.contains("+"))) {
-        guardian.pageInfo.productData.productSegment = 'Paper+Digital';
+        guardian.pageInfo.productData.productSegment = 'paper-digital';
     }
     @if(!products.exists(_.title.contains("+"))) {
-        guardian.pageInfo.productData.productSegment = 'Paper';
+        guardian.pageInfo.productData.productSegment = 'paper';
     }
     </script>
 

--- a/app/views/promotion/weeklyLandingPage.scala.html
+++ b/app/views/promotion/weeklyLandingPage.scala.html
@@ -45,7 +45,7 @@
 
         <script>
             guardian.pageInfo.pageType = 'Landing';
-            guardian.pageInfo.productData.productSegment = 'Weekly';
+            guardian.pageInfo.productData.productSegment = 'weekly';
         </script>
 
         @fragments.heroBanner(promotion.flatMap(_.landingPage.image).getOrElse(defaultImage)){

--- a/app/views/promotion/weeklyLandingPage.scala.html
+++ b/app/views/promotion/weeklyLandingPage.scala.html
@@ -43,6 +43,11 @@
         edition = DigitalEdition.getForCountry(Some(country))
     ) {
 
+        <script>
+            guardian.pageInfo.pageType = 'Landing';
+            guardian.pageInfo.productData.productSegment = 'Weekly';
+        </script>
+
         @fragments.heroBanner(promotion.flatMap(_.landingPage.image).getOrElse(defaultImage)){
             @title
         } {

--- a/app/views/shipping/shipping.scala.html
+++ b/app/views/shipping/shipping.scala.html
@@ -1,9 +1,12 @@
 @import model.DigitalEdition.UK
-@(subscription: model.Subscriptions.SubscriptionProduct)
-
-@import utils.Prices._
+@(subscription: model.Subscriptions.SubscriptionProduct, productSegment: String)
 
 @main(s"${subscription.capitalizedTitle} | Choose a Package | Subscriptions | The Guardian", edition = UK) {
+
+    <script>
+        guardian.pageInfo.pageType = 'Landing';
+        guardian.pageInfo.productData.productSegment = '@productSegment';
+    </script>
 
     <main class="page-container gs-container">
 

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -28,6 +28,15 @@ object PlanOps {
       case Product.Digipack => Some("Daily Edition + Guardian App Premium Tier")
       case _ => StringOps.oempty(in.description).headOption
     }
+
+    def segment: String = {
+      in.product match {
+        case Product.Digipack => "digital"
+        case _: Product.Weekly=> "weekly"
+        case Product.Voucher | Product.Delivery => if (in.name.endsWith("+")) "paper-digital" else "paper"
+        case _ => ""
+      }
+    }
   }
 
   implicit class PrettyPlan[+A <: CatalogPlan.Paid](in: A) {
@@ -74,17 +83,17 @@ object PlanOps {
 
     def segment: String = {
       if (in.isDigitalPack) {
-        "Digital"
+        "digital"
       } else if (in.isHomeDelivery || in.isVoucher) {
         if (in.hasDigitalPack) {
-          "Paper+Digital"
+          "paper-digital"
         } else {
-          "Paper"
+          "paper"
         }
       } else if (in.isGuardianWeekly) {
-        "Weekly"
+        "weekly"
       } else {
-        "Subscription"
+        ""
       }
     }
   }

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -1,18 +1,14 @@
 package views.support
 
 import com.gu.memsub.Benefit._
+import com.gu.memsub.BillingPeriod.SixWeeks
 import com.gu.memsub.Product.{Delivery, Voucher}
 import com.gu.memsub._
 import com.gu.memsub.images.{ResponsiveImage, ResponsiveImageGenerator, ResponsiveImageGroup}
-import com.gu.memsub.subsv2.{CatalogPlan, Plan, SubscriptionPlan}
+import com.gu.memsub.subsv2.{CatalogPlan, Plan}
 import com.netaporter.uri.dsl._
-import configuration.Links
-import model.BillingPeriodOps._
-import com.gu.memsub.BillingPeriod.{OneYear, Quarter, SixWeeks}
-
 
 import scala.reflect.internal.util.StringOps
-import scalaz.syntax.std.boolean._
 object PlanOps {
   implicit class CommonPlanOps[+A <: Plan[_,_]](in: A) {
 
@@ -76,7 +72,21 @@ object PlanOps {
 
     def hasDigitalPack: Boolean = in.charges.benefits.list.contains(Digipack)
 
-
+    def segment: String = {
+      if (in.isDigitalPack) {
+        "Digital"
+      } else if (in.isHomeDelivery || in.isVoucher) {
+        if (in.hasDigitalPack) {
+          "Paper+Digital"
+        } else {
+          "Paper"
+        }
+      } else if (in.isGuardianWeekly) {
+        "Weekly"
+      } else {
+        "Subscription"
+      }
+    }
   }
 
   implicit class ProductOps(product: Product) {

--- a/assets/javascripts/modules/analytics/analyticsEnabled.js
+++ b/assets/javascripts/modules/analytics/analyticsEnabled.js
@@ -3,7 +3,7 @@ define([
 ], function (cookie) {
     'use strict';
 
-    var analyticsEnabled = (
+    var analyticsEnabled = true || (
         window.guardian.analyticsEnabled &&
         !cookie.getCookie('ANALYTICS_OFF_KEY') &&
         !window.guardian.isDev

--- a/assets/javascripts/modules/analytics/analyticsEnabled.js
+++ b/assets/javascripts/modules/analytics/analyticsEnabled.js
@@ -3,7 +3,7 @@ define([
 ], function (cookie) {
     'use strict';
 
-    var analyticsEnabled = true || (
+    var analyticsEnabled = (
         window.guardian.analyticsEnabled &&
         !cookie.getCookie('ANALYTICS_OFF_KEY') &&
         !window.guardian.isDev

--- a/assets/javascripts/modules/analytics/appnexus.js
+++ b/assets/javascripts/modules/analytics/appnexus.js
@@ -1,0 +1,45 @@
+define([
+    'modules/analytics/analyticsEnabled',
+    'modules/analytics/dntEnabled'
+], function (analyticsEnabled, dntEnabled) {
+    'use strict';
+
+    var segmentedPageCodes = {
+        'Digital': {
+            'Landing': '8326260',
+            'Checkout': '8326264',
+            'Thankyou': '836984'
+        },
+        'Paper+Digital': {
+            'Landing': '8326267',
+            'Checkout': '8326269',
+            'Thankyou': '836986'
+        },
+        'Paper': {
+            'Landing': '8326272',
+            'Checkout': '8326273',
+            'Thankyou': '836985'
+        }
+    };
+
+    function init() {
+        if (!(guardian && guardian.pageInfo && guardian.pageInfo.productData && guardian.pageInfo.productData.productSegment)) { return; }
+
+        var pageCodes = segmentedPageCodes[guardian.pageInfo.productData.productSegment];
+        if (!pageType) { return; }
+
+        var pageType = guardian.pageInfo.pageType;
+        if (!pageType) { return; }
+
+        var oImg = document.createElement('img');
+        oImg.setAttribute('src', 'https://secure.adnxs.com/seg?t=2&add=' + pageCodes[pageType]);
+        oImg.setAttribute('alt', 'AppNexus pixel');
+        oImg.setAttribute('height', '1');
+        oImg.setAttribute('width', '1');
+        document.body.appendChild(oImg);
+    }
+
+    return {
+        init: analyticsEnabled(dntEnabled(init))
+    };
+});

--- a/assets/javascripts/modules/analytics/appnexus.js
+++ b/assets/javascripts/modules/analytics/appnexus.js
@@ -5,17 +5,17 @@ define([
     'use strict';
 
     var segmentedPageCodes = {
-        'Digital': {
+        'digital': {
             'Landing': '8326260',
             'Checkout': '8326264',
             'Thankyou': '836984'
         },
-        'Paper+Digital': {
+        'paper-digital': {
             'Landing': '8326267',
             'Checkout': '8326269',
             'Thankyou': '836986'
         },
-        'Paper': {
+        'paper': {
             'Landing': '8326272',
             'Checkout': '8326273',
             'Thankyou': '836985'
@@ -26,7 +26,7 @@ define([
         if (!(guardian && guardian.pageInfo && guardian.pageInfo.productData && guardian.pageInfo.productData.productSegment)) { return; }
 
         var pageCodes = segmentedPageCodes[guardian.pageInfo.productData.productSegment];
-        if (!pageType) { return; }
+        if (!pageCodes) { return; }
 
         var pageType = guardian.pageInfo.pageType;
         if (!pageType) { return; }
@@ -34,8 +34,8 @@ define([
         var oImg = document.createElement('img');
         oImg.setAttribute('src', 'https://secure.adnxs.com/seg?t=2&add=' + pageCodes[pageType]);
         oImg.setAttribute('alt', 'AppNexus pixel');
-        oImg.setAttribute('height', '1');
-        oImg.setAttribute('width', '1');
+        oImg.setAttribute('height', '0');
+        oImg.setAttribute('width', '0');
         document.body.appendChild(oImg);
     }
 

--- a/assets/javascripts/modules/analytics/facebook.js
+++ b/assets/javascripts/modules/analytics/facebook.js
@@ -22,11 +22,18 @@ define([
         var productData = guardian.pageInfo ? guardian.pageInfo.productData : {};
 
         if (productData) {
+            var parameters = {
+                currency: 'GBP',
+                value: '0',
+                content_type: productData.productType
+            };
             if (productData.productPurchasing) {
-                fbq('track', 'InitiateCheckout');
+                parameters.content_name = productData.productPurchasing;
+                fbq('track', 'InitiateCheckout', parameters);
             }
             if (productData.productPurchased) {
-                fbq('track', 'Purchase');
+                parameters.content_name = productData.productPurchased;
+                fbq('track', 'Purchase', parameters);
             }
         }
     }

--- a/assets/javascripts/modules/analytics/setup.js
+++ b/assets/javascripts/modules/analytics/setup.js
@@ -9,6 +9,7 @@ define(['modules/analytics/ga',
              remarketing,
              krux,
              facebook,
+             appnexus,
              affectv) {
     'use strict';
 
@@ -19,6 +20,7 @@ define(['modules/analytics/ga',
         remarketing.init();
         krux.init();
         facebook.init();
+        appnexus.init();
         affectv.init();
     }
 

--- a/assets/javascripts/modules/analytics/setup.js
+++ b/assets/javascripts/modules/analytics/setup.js
@@ -3,6 +3,7 @@ define(['modules/analytics/ga',
         'modules/analytics/remarketing',
         'modules/analytics/krux',
         'modules/analytics/facebook',
+        'modules/analytics/appnexus',
         'modules/analytics/affectv'
 ], function (ga,
              ophan,


### PR DESCRIPTION
Add the AppNexus tracking pixel with the various IDs representing the stage of the conversion funnel. Note, the Acquisitions team have not set up IDs for the Guardian Weekly flow.

Also fixed the Facebook tracker which was erroring in the console.

![picture 71](https://cloud.githubusercontent.com/assets/1515970/25007899/e7584068-2059-11e7-9d82-635ea285a939.png)

cc @AWare @jacobwinch @pvighi @lmath 