### PR TITLE
Ensure we set the full name country in Salesforce

### DIFF
--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -1,7 +1,6 @@
 package services
 
 import com.gu.identity.play.IdMinimalUser
-import com.gu.memsub.Address
 import com.gu.salesforce.ContactDeserializer.Keys
 import com.gu.salesforce._
 import com.typesafe.scalalogging.LazyLogging
@@ -31,7 +30,7 @@ object SalesforceService {
     Keys.BILLING_STREET -> personalData.address.line,
     Keys.BILLING_CITY -> personalData.address.town,
     Keys.BILLING_POSTCODE -> personalData.address.postCode,
-    Keys.BILLING_COUNTRY -> personalData.address.countryName,
+    Keys.BILLING_COUNTRY -> personalData.address.country.map(_.name).getOrElse(personalData.address.countryName),
     Keys.BILLING_STATE -> personalData.address.countyOrState,
     Keys.ALLOW_GU_RELATED_MAIL -> personalData.receiveGnmMarketing
   ) ++ personalData.title.fold(Json.obj())(title => Json.obj(
@@ -41,7 +40,7 @@ object SalesforceService {
     Keys.MAILING_CITY -> addr.town,
     Keys.MAILING_POSTCODE -> addr.postCode,
     Keys.MAILING_STATE -> addr.countyOrState,
-    Keys.MAILING_COUNTRY -> addr.countryName
+    Keys.MAILING_COUNTRY -> addr.country.map(_.name).getOrElse(addr.countryName)
   ) ++ paperData.flatMap(_.deliveryInstructions).fold(Json.obj())(instrs => Json.obj(
     Keys.DELIVERY_INSTRUCTIONS -> instrs
   )))

--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -30,7 +30,7 @@ object SalesforceService {
     Keys.BILLING_STREET -> personalData.address.line,
     Keys.BILLING_CITY -> personalData.address.town,
     Keys.BILLING_POSTCODE -> personalData.address.postCode,
-    Keys.BILLING_COUNTRY -> personalData.address.country.map(_.name).getOrElse(personalData.address.countryName),
+    Keys.BILLING_COUNTRY -> personalData.address.country.fold(personalData.address.countryName)(_.name),
     Keys.BILLING_STATE -> personalData.address.countyOrState,
     Keys.ALLOW_GU_RELATED_MAIL -> personalData.receiveGnmMarketing
   ) ++ personalData.title.fold(Json.obj())(title => Json.obj(
@@ -40,7 +40,7 @@ object SalesforceService {
     Keys.MAILING_CITY -> addr.town,
     Keys.MAILING_POSTCODE -> addr.postCode,
     Keys.MAILING_STATE -> addr.countyOrState,
-    Keys.MAILING_COUNTRY -> addr.country.map(_.name).getOrElse(addr.countryName)
+    Keys.MAILING_COUNTRY -> addr.country.fold(addr.countryName)(_.name)
   ) ++ paperData.flatMap(_.deliveryInstructions).fold(Json.obj())(instrs => Json.obj(
     Keys.DELIVERY_INSTRUCTIONS -> instrs
   )))


### PR DESCRIPTION
Ensure we use the full name for countries in Salesforce to make all subs consistent with each other, irrespective of what Membership or Identity may have done to the account prior. This mitigates the risk of breaking international paper deliveries if a member goes on to become a subscriber.

There is a more significant related change in Membership-frontend: https://github.com/guardian/membership-frontend/pull/1595

cc @jacobwinch @pvighi @lmath @AWare 