### PR TITLE
Only allow renewal promotions when renewing 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,7 +131,7 @@ module.exports = function(grunt) {
             options: {
                 map: isDev ? true : false,
                 processors: [
-                    require('autoprefixer-core')({browsers: ['> 5%', 'last 2 versions', 'IE 8', 'IE 9', 'Safari 6']}),
+                    require('autoprefixer-core')({browsers: ['> 5%', 'last 2 versions']}),
                     require('postcss-object-fit-images')
                 ]
             },

--- a/assets/javascripts/modules/promoCode.es6
+++ b/assets/javascripts/modules/promoCode.es6
@@ -9,7 +9,6 @@ export function validatePromoCode(promoCode, country, currency){
             method: route.method,
             url: route.url
         }).then((r)=>{
-            console.log('r',r);
             resolve(r);
         },(f,a)=>{
             console.log('f',f,a);
@@ -18,7 +17,7 @@ export function validatePromoCode(promoCode, country, currency){
     })
 }
 
-export function validatePromotionForPlans(promotion, plans) {
+export function combinePromotionAndPlans(promotion, plans) {
     let newPlans = promotion.adjustedRatePlans;
     if (newPlans == null){
         return plans;

--- a/assets/javascripts/modules/react/promoCode.jsx
+++ b/assets/javascripts/modules/react/promoCode.jsx
@@ -17,6 +17,7 @@ render(){
             <PromoField value={this.props.value} handler={this.props.handler} />
             <PromoButton status={this.props.status} onClick={this.props.send} />
             {this.props.status == status.VALID && <div className="u-note">{this.props.copy}</div>}
+            {this.props.status == status.INVALID && <div className="u-error">{this.props.copy}</div>}
         </dd>
     </div>
 }

--- a/assets/javascripts/modules/react/weeklyRenew.jsx
+++ b/assets/javascripts/modules/react/weeklyRenew.jsx
@@ -121,7 +121,7 @@ class WeeklyRenew extends React.Component {
                 let price = this.getPrice(this.getPlan(this.props.plans));
                 //It's a good promotion, but it's not a weekly one
                 this.setState({
-                    promotionDescription: 'The promotion you have entered is not currently valid for any of the available billing periods.',
+                    promotionDescription: 'The promotion you have entered is not currently valid to renew your subscription.',
                     promoStatus: status.INVALID,
                     plans: this.props.plans,
                     displayedPrice: price

--- a/assets/javascripts/modules/react/weeklyRenew.jsx
+++ b/assets/javascripts/modules/react/weeklyRenew.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom';
 import {DirectDebit} from 'modules/react/directDebit'
 import {PromoCode, status} from 'modules/react/promoCode'
-import {validatePromoCode, validatePromotionForPlans} from '../promoCode';
+import {validatePromoCode, combinePromotionAndPlans} from '../promoCode';
 import {
     SortCode,
     validAccount,
@@ -106,14 +106,9 @@ class WeeklyRenew extends React.Component {
         });
 
         validatePromoCode(this.state.promoCode, this.props.country, this.props.currency).then((response) => {
-            let newPlans = validatePromotionForPlans(response, this.state.plans);
-            let tracking = response.promotion.promotionType.name === 'tracking' || response.promotion.promotionType.name === 'retention';
-            let update = tracking || newPlans.map((plan) => {
-                return 'promotionalPrice' in plan
-            }).reduce((a, b) => {
-                return !!(a || b)
-            }, false);
-            if (update) {
+            let newPlans = combinePromotionAndPlans(response, this.state.plans);
+            let valid = response.promotion.promotionType.name === 'retention' || (response.promotion.promotionType.name === 'double' && ( response.promotion.promotionType.a.name === 'retention' || response.promotion.promotionType.b.name === 'retention'));
+            if (valid) {
                 let price = this.getPrice(this.getPlan(newPlans));
                 //This is a weekly promotion
                 this.setState({
@@ -134,9 +129,16 @@ class WeeklyRenew extends React.Component {
             }
         }).catch((payload) => {
             let price = this.getPrice(this.getPlan(this.props.plans));
-            let response = JSON.parse(payload.response);
+            let error = "Invalid Promotion";
+            if("response" in payload){
+              try{
+                  error = JSON.parse(payload.response).errorMessage;
+              } catch(e){
+                  console.error(e);
+              }
+            }
             this.setState({
-                promotionDescription: response.errorMessage,
+                promotionDescription: error,
                 promoStatus: status.INVALID,
                 plans: this.props.plans,
                 displayedPrice: price


### PR DESCRIPTION
- Changes invalid promotion copy for renew. (Better copy would be good)
- **Shows** invalid promotion copy for renew.
- Removes ancient browsers from autoprefixer.

![image](https://cloud.githubusercontent.com/assets/2670496/25183824/956cbcf0-2510-11e7-972b-8d366284a7f2.png)
