### PR TITLE
Use px not seg for appnexus conversion code

### DIFF
--- a/assets/javascripts/modules/analytics/appnexus.js
+++ b/assets/javascripts/modules/analytics/appnexus.js
@@ -26,6 +26,8 @@ define([
         if (!(guardian && guardian.pageInfo && guardian.pageInfo.productData && guardian.pageInfo.productData.productSegment)) { return; }
 
         var productSegment = guardian.pageInfo.productData.productSegment;
+        var pixelPath = (productSegment === 'Thankyou') ? 'px' : 'seg';
+        var parameterName = (productSegment === 'Thankyou') ? 'id' : 'add';
 
         var pageCodes = segmentedPageCodes[productSegment];
         if (!pageCodes) { return; }
@@ -33,11 +35,7 @@ define([
         var pageType = guardian.pageInfo.pageType;
         if (!pageType) { return; }
 
-        var parameterName = (productSegment === 'Thankyou') ? 'id' : 'add';
-
         var parameterValue = pageCodes[pageType];
-
-        var pixelPath = (productSegment === 'Thankyou') ? 'px' : 'seg';
 
         var oImg = document.createElement('img');
         oImg.setAttribute('src', 'https://secure.adnxs.com/' + pixelPath + '?t=2&' + parameterName + '=' + parameterValue);

--- a/assets/javascripts/modules/analytics/appnexus.js
+++ b/assets/javascripts/modules/analytics/appnexus.js
@@ -25,14 +25,18 @@ define([
     function init() {
         if (!(guardian && guardian.pageInfo && guardian.pageInfo.productData && guardian.pageInfo.productData.productSegment)) { return; }
 
-        var pageCodes = segmentedPageCodes[guardian.pageInfo.productData.productSegment];
+        var productSegment = guardian.pageInfo.productData.productSegment;
+
+        var pageCodes = segmentedPageCodes[productSegment];
         if (!pageCodes) { return; }
 
         var pageType = guardian.pageInfo.pageType;
         if (!pageType) { return; }
 
+        var pixelType = (productSegment === 'Thankyou') ? 'px' : 'seg';
+
         var oImg = document.createElement('img');
-        oImg.setAttribute('src', 'https://secure.adnxs.com/seg?t=2&add=' + pageCodes[pageType]);
+        oImg.setAttribute('src', 'https://secure.adnxs.com/' + pixelType + '?t=2&add=' + pageCodes[pageType]);
         oImg.setAttribute('alt', 'AppNexus pixel');
         oImg.setAttribute('height', '0');
         oImg.setAttribute('width', '0');

--- a/assets/javascripts/modules/analytics/appnexus.js
+++ b/assets/javascripts/modules/analytics/appnexus.js
@@ -33,10 +33,14 @@ define([
         var pageType = guardian.pageInfo.pageType;
         if (!pageType) { return; }
 
-        var pixelType = (productSegment === 'Thankyou') ? 'px' : 'seg';
+        var parameterName = (productSegment === 'Thankyou') ? 'id' : 'add';
+
+        var parameterValue = pageCodes[pageType];
+
+        var pixelPath = (productSegment === 'Thankyou') ? 'px' : 'seg';
 
         var oImg = document.createElement('img');
-        oImg.setAttribute('src', 'https://secure.adnxs.com/' + pixelType + '?t=2&add=' + pageCodes[pageType]);
+        oImg.setAttribute('src', 'https://secure.adnxs.com/' + pixelPath + '?t=2&' + parameterName + '=' + parameterValue);
         oImg.setAttribute('alt', 'AppNexus pixel');
         oImg.setAttribute('height', '0');
         oImg.setAttribute('width', '0');


### PR DESCRIPTION
Fixed mistake where I did not notice that the appnexus pixel should have different path and parameter names when conversion vs segment type.

cc @jacobwinch @pvighi @lmath @johnduffell @AWare 