### PR TITLE
Fixed bug causing appnexus conversion pixel not to show

### DIFF
--- a/assets/javascripts/modules/analytics/appnexus.js
+++ b/assets/javascripts/modules/analytics/appnexus.js
@@ -26,14 +26,15 @@ define([
         if (!(guardian && guardian.pageInfo && guardian.pageInfo.productData && guardian.pageInfo.productData.productSegment)) { return; }
 
         var productSegment = guardian.pageInfo.productData.productSegment;
-        var pixelPath = (productSegment === 'Thankyou') ? 'px' : 'seg';
-        var parameterName = (productSegment === 'Thankyou') ? 'id' : 'add';
 
         var pageCodes = segmentedPageCodes[productSegment];
         if (!pageCodes) { return; }
 
         var pageType = guardian.pageInfo.pageType;
         if (!pageType) { return; }
+
+        var pixelPath = (pageType === 'Thankyou') ? 'px' : 'seg';
+        var parameterName = (pageType === 'Thankyou') ? 'id' : 'add';
 
         var parameterValue = pageCodes[pageType];
 


### PR DESCRIPTION
Fixed bug where I was inspecting the wrong variable to determine whether to show the conversion or segmentation pixel. My testing on Friday picked up a false-positive when it only tested that the segmentation pixel showed correctly.

cc @jacobwinch @johnduffell @AWare @pvighi @lmath 