### PR TITLE
allow manage of recurring 6 months weekly

### DIFF
--- a/app/views/support/BillingPeriod.scala
+++ b/app/views/support/BillingPeriod.scala
@@ -8,6 +8,7 @@ object BillingPeriod {
       case Month => "every month"
       case Quarter => "every 3 months"
       case Year => "every 12 months"
+      case SixMonthsRecurring => "every six months"
       case period: OneOffPeriod => s"for ${period.noun}"
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.403",
+    "com.gu" %% "membership-common" % "0.404",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
This follows on from allowing manage six months one off, so people can renew.  This one will allow people who are on recurring to get in, this is because some people are on recurring plans in a non renewing sub for some reason.
@jacobwinch @paulbrown1982 @lmath 