### PR TITLE
Updated copy and the promotion codes on subs landing and offer pages

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -15,36 +15,37 @@
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">14-day free trial of our digital pack</li>
-                        @UK.digitalPackSaving.map { saving => <li class="block__list-item"><strong>Save up to @saving% on the app store price</strong></li> }
+                        <li class="block__list-item"><strong>Plus, subscribe today and save an extra 50% on the first 3 months</strong></li>
+                        @UK.digitalPackSaving.map { saving => <li class="block__list-item">Save up to @saving% on the app store price</li> }
                         <li class="block__list-item">Access to the Daily Edition and the advert-free Guardian App Premium Tier</li>
                         <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
                         <li class="block__list-item">Use on up to 10 devices</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DHOMEUK1", None).url?edition=@UK.id" data-test-id="subscriptions-uk-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DBH80X", None).url?edition=@UK.id" data-test-id="subscriptions-uk-digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper-digital">
                 <h2 class="block__title">Paper + digital</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item"><strong>Subscribe today to save an extra 50% for the first month</strong></li>
-                        <li class="block__list-item">Year-round savings on the retail price</li>
+                        <li class="block__list-item"><strong>Subscribe today to save an extra 50% on the first 3 months</strong></li>
+                        <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
                         <li class="block__list-item">Pick the package you want: Everyday+, Sixday+, Weekend+ and Sunday+</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
-                        <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
+                        <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBA80F", None).url" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBG80F", None).url" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper">
                 <h2 class="block__title">Paper</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item"><strong>Subscribe today to save an extra 50% for the first month</strong></li>
+                        <li class="block__list-item"><strong>Subscribe today to save an extra 50% on the first 3 months</strong></li>
                         <li class="block__list-item">Year-round savings on the retail price</li>
                         <li class="block__list-item">Pick the package you want: Everyday, Sixday, Weekend and Sunday</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
@@ -52,7 +53,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBA80X", None).url" data-test-id="subscriptions-uk-paper">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBG80X", None).url" data-test-id="subscriptions-uk-paper">Subscribe now</a>
                 </div>
             </div>
         </div>

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -18,7 +18,7 @@
                     <li class="block__list-item"><strong>Plus, subscribe today and save an extra 50% on the first 3 months</strong></li>
                     @edition.digitalPackSaving.map {saving => <li class="block__list-item">Save up to @{saving}% on the app store price</li>}
                     <li class="block__list-item">Access to the Daily Edition, the digital version of the UK Guardian newspaper</li>
-                    <li class="block__list-item">Access to the and the advert-free Guardian App Premium Tier</li>
+                    <li class="block__list-item">Access to the advert-free Guardian App Premium Tier</li>
                     <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
                     <li class="block__list-item">Use on up to 10 devices</li>
                 </ul>

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -14,15 +14,17 @@
             <h2 class="block__title">Subscribe to the Guardian <span class="break-tablet">digital pack</span></h2>
             <div class="block__info">
                 <ul class="block__list">
-                    <li class="block__list-item">Access to the Daily Edition, the digital version of the UK Guardian newspaper</li>
-                    <li class="block__list-item">Access to the Guardian App Premium Tier, an advert-free experience</li>
-                    <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
-                    @edition.digitalPackSaving.map {saving => <li class="block__list-item"><strong>Save up to @{saving}% on the app store price</strong></li>}
                     <li class="block__list-item">14-day free trial</li>
+                    <li class="block__list-item"><strong>Plus, subscribe today and save an extra 50% on the first 3 months</strong></li>
+                    @edition.digitalPackSaving.map {saving => <li class="block__list-item">Save up to @{saving}% on the app store price</li>}
+                    <li class="block__list-item">Access to the Daily Edition, the digital version of the UK Guardian newspaper</li>
+                    <li class="block__list-item">Access to the and the advert-free Guardian App Premium Tier</li>
+                    <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
+                    <li class="block__list-item">Use on up to 10 devices</li>
                 </ul>
             </div>
             <div class="block__footer">
-                <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render(s"DHOME${edition.id.toUpperCase}1", None).url?edition=@edition.id" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
+                <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render(s"DBH80X", None).url?edition=@edition.id" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
             </div>
         </div>
         <div class="row__item block block--primary block--weekly">

--- a/app/views/offers/offers_international.scala.html
+++ b/app/views/offers/offers_international.scala.html
@@ -18,7 +18,7 @@
                         <li class="block__list-item"><strong>Plus, subscribe today and save an extra 50% on the first 3 months</strong></li>
                         @edition.digitalPackSaving.map {saving => <li class="block__list-item">Save up to @{saving}% on the app store price</li>}
                         <li class="block__list-item">Access to the Daily Edition, the digital version of the UK Guardian newspaper</li>
-                        <li class="block__list-item">Access to the and the advert-free Guardian App Premium Tier</li>
+                        <li class="block__list-item">Access to the advert-free Guardian App Premium Tier</li>
                         <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
                         <li class="block__list-item">Use on up to 10 devices</li>
                     </ul>

--- a/app/views/offers/offers_international.scala.html
+++ b/app/views/offers/offers_international.scala.html
@@ -3,26 +3,28 @@
 
 @(edition: DigitalEdition)
 
-@main(s"${edition.name} | Subscriptions and Membership | The Guardian",
+@main(s"${edition.name} | Subscriptions | The Guardian",
     Some("Subscribe to The Guardian. Support our independent, award-winning journalism."),
     edition = edition) {
 
     <main class="page-container gs-container">
-        @fragments.page.header("Subscriptions and Membership", Some("Select your preferred package"))
+        @fragments.page.header("Subscription offers", Some("Select your preferred package"))
         <div class="row row--items-2">
             <div class="row__item block block--primary block--digital">
                 <h2 class="block__title">Subscribe to the Guardian <span class="break-tablet">digital pack</span></h2>
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">14-day free trial</li>
-                        <li class="block__list-item"><strong>Save up to 75% on the app store price</strong></li>
+                        <li class="block__list-item"><strong>Plus, subscribe today and save an extra 50% on the first 3 months</strong></li>
+                        @edition.digitalPackSaving.map {saving => <li class="block__list-item">Save up to @{saving}% on the app store price</li>}
                         <li class="block__list-item">Access to the Daily Edition, the digital version of the UK Guardian newspaper</li>
-                        <li class="block__list-item">Access to the Guardian App Premium Tier, an advert-free experience</li>
+                        <li class="block__list-item">Access to the and the advert-free Guardian App Premium Tier</li>
                         <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
+                        <li class="block__list-item">Use on up to 10 devices</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render("DOFFINT", edition.countryGroup.defaultCountry).url">Subscribe now</a>
+                    <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render("DBH41F", edition.countryGroup.defaultCountry).url">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--weekly">
@@ -36,7 +38,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("WAL41X", None).url">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("WAL41X", edition.countryGroup.defaultCountry).url">Subscribe now</a>
                 </div>
             </div>
         </div>

--- a/app/views/offers/offers_uk.scala.html
+++ b/app/views/offers/offers_uk.scala.html
@@ -1,63 +1,51 @@
 @import model.DigitalEdition.UK
-@import org.joda.time.DateTime
 @import views.support.DigitalEdition._
 @()
-@isEasterWeekend = @{DateTime.now.isAfter(DateTime.parse("2017-04-13T13:00:00Z")) && DateTime.now.isBefore(DateTime.parse("2017-04-17T23:00:00Z"))}
+
 @main(
-    "Subscriptions and Membership | The Guardian",
+    "Subscriptions | The Guardian",
     Some("Subscribe to The Guardian & Observer. Support our independent, award-winning journalism."),
     edition = UK) {
 
     <main class="page-container gs-container">
-        @fragments.page.header("Subscriptions and Membership")
+        @fragments.page.header("Subscription offers")
         <div class="row row--items-3">
             <div class="row__item block block--primary block--digital">
                 <h2 class="block__title">Digital</h2>
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">14-day free trial of our digital pack</li>
-                        <li class="block__list-item"><strong>Save up to 75% on the app store price</strong></li>
+                        <li class="block__list-item"><strong>Plus, subscribe today and save an extra 50% on the first 3 months</strong></li>
+                        @UK.digitalPackSaving.map { saving => <li class="block__list-item">Save up to @saving% on the app store price</li> }
                         <li class="block__list-item">Access to the Daily Edition and the advert-free Guardian App Premium Tier</li>
                         <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
                         <li class="block__list-item">Use on up to 10 devices</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DOFFUK1", UK.countryGroup.defaultCountry).url">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DBH41F", UK.countryGroup.defaultCountry).url">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper-digital">
                 <h2 class="block__title">Paper + digital</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">
-                        @if(isEasterWeekend) {
-                            <strong>Subscribe this weekend to save an extra 50% on the first 3 months</strong>
-                        } else {
-                            <strong>Subscribe today to save an extra 50% for the first month</strong>
-                        }
-                        </li>
-                        <li class="block__list-item">Year-round savings on the retail price</li>
+                        <li class="block__list-item"><strong>Subscribe today to save an extra 50% on the first 3 months</strong></li>
+                        <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
                         <li class="block__list-item">Pick the package you want: Everyday+, Sixday+, Weekend+ and Sunday+</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
-                        <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
+                        <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render(if(isEasterWeekend) "GBB41G" else "GBA41G", None).url">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBG41F", None).url">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper">
                 <h2 class="block__title">Paper</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">
-                        @if(isEasterWeekend) {
-                            <strong>Subscribe this weekend to save an extra 50% on the first 3 months</strong>
-                        } else {
-                            <strong>Subscribe today to save an extra 50% for the first month</strong>
-                        }
-                        </li>
+                        <li class="block__list-item"><strong>Subscribe today to save an extra 50% on the first 3 months</strong></li>
                         <li class="block__list-item">Year-round savings on the retail price</li>
                         <li class="block__list-item">Pick the package you want: Everyday, Sixday, Weekend and Sunday</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
@@ -65,11 +53,11 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render(if(isEasterWeekend) "GBB41F" else "GBA41F", None).url">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBG41G", None).url">Subscribe now</a>
                 </div>
             </div>
         </div>
-        <div class="row row--items-3">
+        <div class="row row--items-1">
             <div class="row__item block block--primary block--weekly">
                 <h2 class="block__title">Subscribe to the Guardian Weekly</h2>
                 <div class="block__info">
@@ -81,7 +69,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("WAL41X", None).url">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("WAL41X", UK.countryGroup.defaultCountry).url">Subscribe now</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
See: https://trello.com/c/hejW5quO/158-subs-election-promotions-campaign-request-1

I've also made a couple of my own small tweaks to the offer page title (removed Membership) and moved around the bullet points of the Paper + digital section on the UK landing and offer pages.

Should not be merged until Thursday 12 May 2017.

cc @lmath @AWare @johnduffell @jacobwinch @pvighi 