### PR TITLE
Show the 'Pay in £GBP' checkbox for all currencies on Zone C

### DIFF
--- a/app/model/PaymentValidation.scala
+++ b/app/model/PaymentValidation.scala
@@ -18,7 +18,7 @@ object PaymentValidation {
   def validateCurrency(currency: Currency, settings: CountryWithCurrency, plan: CatalogPlan.ContentSubscription): Boolean = {
 
     def isValidCurrencyOverride = plan.product match {
-      case Product.WeeklyZoneC => currency == GBP && settings.currency == USD && settings.country != Country.US
+      case Product.WeeklyZoneC => currency == GBP && settings.country != Country.US && settings.country != Country.UK
       case _ => false
     }
 

--- a/assets/javascripts/modules/checkout/fieldSwitcher.js
+++ b/assets/javascripts/modules/checkout/fieldSwitcher.js
@@ -112,13 +112,12 @@ define([
 
     var redrawCurrencyOverride = function (selectedCurrency) {
         var currencySelector = $('.js-checkout-currency-override');
-
-        if (selectedCurrency == 'USD') {
-            formElements.$CURRENCY_OVERRIDE_CHECKBOX.removeClass('js-ignore');
-            currencySelector.show();
-        } else {
+        if (selectedCurrency === 'GBP') {
             formElements.$CURRENCY_OVERRIDE_CHECKBOX.addClass('js-ignore');
             currencySelector.hide();
+        } else {
+            formElements.$CURRENCY_OVERRIDE_CHECKBOX.removeClass('js-ignore');
+            currencySelector.show();
         }
     };
 


### PR DESCRIPTION
Show the 'Pay in £GBP' checkbox for all currencies on Zone C not just when picking a USD country.

The backend validation basically checks that the currency override is only GBP (as all plans have a GPB price) and it is only provided when in Zone C.

Landing on an Australian checkout:

![picture 97](https://cloud.githubusercontent.com/assets/1515970/25891758/1dd0fef8-356a-11e7-8d19-c458ed886c04.png)
![picture 98](https://cloud.githubusercontent.com/assets/1515970/25891755/1dced498-356a-11e7-98a6-3d930caa25ef.png)

And then when changing country to an Euros country:

![picture 101](https://cloud.githubusercontent.com/assets/1515970/25891757/1dd04a26-356a-11e7-8ec0-82049cfa5536.png)
![picture 99](https://cloud.githubusercontent.com/assets/1515970/25891760/1dd8cc3c-356a-11e7-839a-3e5e5cb75188.png)

See: https://trello.com/c/3ynoNDSG/153-allow-gbp-payment-option-for-all-zone-c-purchases-not-just-usd

cc @pvighi 