### PR TITLE
load the delivery address from zuora via rest

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -4,11 +4,8 @@ import _root_.services.AuthenticationService._
 import _root_.services.TouchpointBackend
 import _root_.services.TouchpointBackend.Resolution
 import actions.CommonActions._
-import com.github.nscala_time.time.OrderingImplicits.LocalDateOrdering
-import com.gu.memsub.BillingPeriod.SixWeeks
 import com.gu.memsub.Subscription.{Name, ProductRatePlanId}
 import com.gu.memsub.promo.{NormalisedPromoCode, PromoCode}
-import com.gu.memsub.services.GetSalesforceContactForSub
 import com.gu.memsub.subsv2.SubscriptionPlan._
 import com.gu.memsub.subsv2._
 import com.gu.memsub.{BillingSchedule, Product}
@@ -16,25 +13,25 @@ import com.gu.subscriptions.suspendresume.SuspensionService
 import com.gu.subscriptions.suspendresume.SuspensionService.{BadZuoraJson, ErrNel, HolidayRefund, PaymentHoliday}
 import com.gu.zuora.ZuoraRestService
 import com.gu.zuora.soap.models.Queries.Contact
-import com.typesafe.scalalogging.LazyLogging
 import configuration.{Config, ProfileLinks}
 import forms._
 import logging.ContextLogging
+import model.ContentSubscriptionPlanOps._
 import model.SubscriptionOps._
 import model.{Renewal, RenewalReads}
 import org.joda.time.LocalDate.now
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
 import play.api.mvc._
 import utils.TestUsers.PreSigninTestCookie
 import views.html.account.thankYouRenew
-import views.support.Pricing._
 import views.support.Dates._
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import views.support.Pricing._
+
 import scala.concurrent.Future
 import scalaz.std.scalaFuture._
 import scalaz.syntax.std.option._
 import scalaz.{-\/, EitherT, OptionT, \/, \/-}
-import model.ContentSubscriptionPlanOps._
 // this handles putting subscriptions in and out of the session
 object SessionSubscription {
 
@@ -155,8 +152,8 @@ object ManageWeekly extends ContextLogging {
 
   object WeeklyPlanInfo {
 
-    import play.api.libs.json._
     import play.api.libs.functional.syntax._
+    import play.api.libs.json._
 
     implicit def writer: Writes[WeeklyPlanInfo] =
       (
@@ -199,9 +196,9 @@ object ManageWeekly extends ContextLogging {
             }).right.map(r => (existingCurrency, r))
           }
           weeklyPlanInfo match {
-            case Left(error) =>
-              info(s"couldn't get new rate/currency for renewal: $error")
-              Ok(views.html.account.details(None, promoCode))
+            case Left(errorMessage) =>
+              error(s"couldn't get new rate/currency for renewal: $errorMessage")
+              Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but can't renew it via the web, please contact customer services for help.")))
             case Right((existingCurrency, weeklyPlanInfoList)) =>
               Ok(weeklySubscription.asRenewable.map { renewableSub =>
                 info(s"sub is renewable - showing weeklyRenew page")
@@ -212,16 +209,16 @@ object ManageWeekly extends ContextLogging {
               })
           }
         }.getOrElse {
-          info(s"no valid bill to country for account")
-          Ok(views.html.account.details(None, promoCode))
+          error(s"no valid bill to country for account")
+          Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but can't manage it via the web, please contact customer services for help.")))
         }
-      }.run.map(_.fold({ error =>
-        info(s"problem getting account: $error")
-        Ok(views.html.account.details(None, promoCode))
+      }.run.map(_.fold({ errorMessage =>
+        error(s"problem getting account: $errorMessage")
+        Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but can't manage it via the web, please contact customer services for help.")))
       }, identity))
     } else {
       info(s"don't support agents, can't manage sub")
-      Future.successful(Ok(views.html.account.details(None, promoCode))) // don't support gifts (yet) as they have related contacts in salesforce of unknown structure
+      Future.successful(Ok(views.html.account.details(None, promoCode, Some("You subscribe via an agent, at present you can't manage it via the web, please contact customer services for help.")))) // don't support gifts (yet) as they have related contacts in salesforce of unknown structure
     }
   }
 
@@ -335,12 +332,12 @@ object AccountManagement extends Controller with ContextLogging with CatalogProv
       }
       maybeFutureManagePage.getOrElse {
         // the product type didn't have the right charges
-        Future.successful(Ok(views.html.account.details(None, promoCode)))
+        Future.successful(Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but can't manage it via the web, please contact customer services for help."))))
       }
     }
 
     futureMaybeFutureManagePage.getOrElse {
-      // not a valid AS number or some unnamed problem getting the details
+      // not a valid AS number or some unnamed problem getting the details or no sub details in the session yet
       Future.successful(Ok(views.html.account.details(subscriberId, promoCode)))
     }.flatMap(identity)
   }

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -3,7 +3,8 @@
 @import com.gu.memsub.promo.PromoCode
 @(
     subscriberId: Option[String],
-    promoCode: Option[PromoCode]
+    promoCode: Option[PromoCode],
+    message: Option[String]= None
 )(implicit request: RequestHeader, flash: Flash, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Manage your subscription | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
@@ -79,6 +80,9 @@
                                 }
                                 @if(flash.get("error").isDefined) {
                                     <div class="form-field__error-message-visible">@flash.get("error")</div>
+                                }
+                                @message.map { message =>
+                                    <div class="form-field__error-message-visible">@message</div>
                                 }
                                 <button type="submit" class="js-suspend-submit button button--primary button--large u-margin-bottom">
                                     Continue

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -24,7 +24,7 @@
         <dd class="mma-section__list--content">
             <div>@contact.firstName @contact.lastName</div>
             <div>@{
-                def opt(string: String) = Some(string).filter(_.trim.nonEmpty)
+                def opt(string: String) = Some(string.trim).filter(_.nonEmpty)
                 List(
                     opt(contact.address1),
                     opt(contact.address2),

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -5,7 +5,8 @@
 @import com.gu.salesforce.Contact
 @import model.SubscriptionOps._
 
-@(chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[Contact] = None, subscription: Subscription[SubscriptionPlan.ContentSubscription])(extra: Html = Html(""))
+@import com.gu.zuora.ZuoraRestService.SoldToContact
+@(chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[SoldToContact] = None, subscription: Subscription[SubscriptionPlan.ContentSubscription])(extra: Html = Html(""))
 <dl class="mma-section__list">
     <dt class="mma-section__list--title">Subscriber ID</dt>
     <dd class="mma-section__list--content">@{subscription.name.get}</dd>
@@ -23,12 +24,14 @@
         <dd class="mma-section__list--content">
             <div>@contact.firstName @contact.lastName</div>
             <div>@{
+                def opt(string: String) = Some(string).filter(_.trim.nonEmpty)
                 List(
-                    contact.mailingStreet,
-                    contact.mailingCity,
-                    contact.mailingState,
-                    contact.mailingPostcode,
-                    contact.mailingCountry
+                    opt(contact.address1),
+                    opt(contact.address2),
+                    opt(contact.city),
+                    opt(contact.state),
+                    opt(contact.postCode),
+                    contact.country.map(_.name)
                 ).flatten.mkString(", ")}</div>
         </dd>
     }

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -5,8 +5,9 @@
 @import com.gu.salesforce.Contact
 @import model.SubscriptionOps._
 @import org.joda.time.LocalDate.now
+@import com.gu.zuora.ZuoraRestService.SoldToContact
 @(
-    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: Option[BillingSchedule], contact: Contact
+    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: Option[BillingSchedule], contact: SoldToContact
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -14,8 +14,9 @@
 @import com.gu.memsub.promo.PromoCode
 @import org.joda.time.LocalDate.now
 @import com.gu.memsub.subsv2.ReaderType
+@import com.gu.zuora.ZuoraRestService.SoldToContact
 @(
-    subscription: Subscription[WeeklyPlanOneOff], contact: Contact, email: Option[String], billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
+    subscription: Subscription[WeeklyPlanOneOff], contact: SoldToContact, email: Option[String], billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {
@@ -62,7 +63,7 @@
                 data-billing-country="@billToCountry.alpha2"
                 data-promo-code="@promoCode.map(_.get)"
                 data-currency="@currency.iso"
-                data-delivery-country="@contact.mailingCountryParsed.map(_.alpha2).getOrElse(billToCountry.alpha2)"
+                data-delivery-country="@contact.country.map(_.alpha2).getOrElse(billToCountry.alpha2)"
                 data-direct-debit-logo="@hashedPathFor("images/direct-debit-black.png")"
                 data-weekly-terms-conditions-href="@Links.weeklyTerms.href"
                 data-weekly-terms-conditions-title="@Links.weeklyTerms.title"

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.405-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.405",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.404",
+    "com.gu" %% "membership-common" % "0.405-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
Previously we called zuora 3 times to get the sub, account, and billto address, then salesforce to get the delivery address for guardian weekly.
Now I changed it to call zuora twice to get the sub, and account via rest, which automatically pulls in the addresses.
This saves us 2 calls on log in to manage, and means we don't depend on salesforce as much.
@jacobwinch @paulbrown1982 @lmath 