### PR TITLE
write the phone number to zuora on subscribe

### DIFF
--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -257,7 +257,8 @@ class CheckoutService(
       soldToContact = soldToContact.map(address => SoldToContact(
         name = personalData,        // TODO once we have gifting change this to the Giftee's name
         address = address,
-        email = personalData.email  // TODO once we have gifting change this to the Giftee's email address
+        email = personalData.email,  // TODO once we have gifting change this to the Giftee's email address
+        phone = personalData.telephoneNumber
       )),
       contractEffective = acquisitionDate,
       contractAcceptance = firstPaymentDate,
@@ -269,7 +270,6 @@ class CheckoutService(
   private def createSubscription(
       subscribe: Subscribe,
       purchaserIds: PurchaserIdentifiers): Future[NonEmptyList[SubsError] \/ SubscribeResult] = {
-
     zuoraService.createSubscription(subscribe).map(\/.right).recover {
       case e: PaymentGatewayError => \/.left(NonEmptyList(CheckoutZuoraPaymentGatewayError(
         purchaserIds,

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.406-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.406",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.404",
+    "com.gu" %% "membership-common" % "0.406-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
based on https://github.com/guardian/membership-common/pull/477
Now we will write the phone number to zuora so that it's there from subscription start rather than getting sent by the triggers at some point later.
__snippet of account json follows:__
```json

  "soldToContact": {
    "id": "2c92c0f95bf63407015bf895a28a22ac",
    "firstName": "dsfkjhs",
    "lastName": "bloggs",
    "address1": "dsfkjhkjh",
    "address2": "",
    "city": "kjh",
    "county": null,
    "state": "",
    "zipCode": "N1 9GU",
    "country": "United Kingdom",
    "workEmail": "aaskjfdhsdakjf@gu.com",
    "workPhone": "B01234",
    "taxRegion": null,
    "fax": null,
    "SpecialDeliveryInstructions__c": null
  },
```

@paulbrown1982 @pvighi @AWare @jacobwinch 
