### PR TITLE
Revert "load the delivery address from zuora via rest"

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -4,8 +4,11 @@ import _root_.services.AuthenticationService._
 import _root_.services.TouchpointBackend
 import _root_.services.TouchpointBackend.Resolution
 import actions.CommonActions._
+import com.github.nscala_time.time.OrderingImplicits.LocalDateOrdering
+import com.gu.memsub.BillingPeriod.SixWeeks
 import com.gu.memsub.Subscription.{Name, ProductRatePlanId}
 import com.gu.memsub.promo.{NormalisedPromoCode, PromoCode}
+import com.gu.memsub.services.GetSalesforceContactForSub
 import com.gu.memsub.subsv2.SubscriptionPlan._
 import com.gu.memsub.subsv2._
 import com.gu.memsub.{BillingSchedule, Product}
@@ -13,25 +16,25 @@ import com.gu.subscriptions.suspendresume.SuspensionService
 import com.gu.subscriptions.suspendresume.SuspensionService.{BadZuoraJson, ErrNel, HolidayRefund, PaymentHoliday}
 import com.gu.zuora.ZuoraRestService
 import com.gu.zuora.soap.models.Queries.Contact
+import com.typesafe.scalalogging.LazyLogging
 import configuration.{Config, ProfileLinks}
 import forms._
 import logging.ContextLogging
-import model.ContentSubscriptionPlanOps._
 import model.SubscriptionOps._
 import model.{Renewal, RenewalReads}
 import org.joda.time.LocalDate.now
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
 import play.api.mvc._
 import utils.TestUsers.PreSigninTestCookie
 import views.html.account.thankYouRenew
-import views.support.Dates._
 import views.support.Pricing._
-
+import views.support.Dates._
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 import scalaz.std.scalaFuture._
 import scalaz.syntax.std.option._
 import scalaz.{-\/, EitherT, OptionT, \/, \/-}
+import model.ContentSubscriptionPlanOps._
 // this handles putting subscriptions in and out of the session
 object SessionSubscription {
 
@@ -152,8 +155,8 @@ object ManageWeekly extends ContextLogging {
 
   object WeeklyPlanInfo {
 
-    import play.api.libs.functional.syntax._
     import play.api.libs.json._
+    import play.api.libs.functional.syntax._
 
     implicit def writer: Writes[WeeklyPlanInfo] =
       (
@@ -163,62 +166,59 @@ object ManageWeekly extends ContextLogging {
 
   }
 
-  def apply(
-    billingSchedule: Option[BillingSchedule],
-    weeklySubscription: Subscription[WeeklyPlan],
-    promoCode: Option[PromoCode]
-  )(implicit
-    request: Request[AnyContent],
-    resolution: TouchpointBackend.Resolution
-  ): Future[Result] = {
+  def apply(billingSchedule: Option[BillingSchedule], weeklySubscription: Subscription[WeeklyPlan], promoCode: Option[PromoCode])(implicit request: Request[AnyContent], resolution: TouchpointBackend.Resolution): Future[Result] = {
     implicit val tpBackend = resolution.backend
     implicit val rest = tpBackend.simpleRestClient
-    implicit val zuoraRest = new ZuoraRestService[Future]
+    implicit val zuoraRestService = new ZuoraRestService[Future]
     implicit val flash = request.flash
     implicit val subContext = weeklySubscription
     if (weeklySubscription.readerType != ReaderType.Agent) {
-      EitherT(zuoraRest.getAccount(weeklySubscription.accountId)).map { account =>
-        account.billToContact.country.map { billToCountry =>
-          val catalog = tpBackend.catalogService.unsafeCatalog
-          val weeklyPlans = weeklySubscription.planToManage.product match {
-            case Product.WeeklyZoneA => catalog.weekly.zoneA.plans
-            case Product.WeeklyZoneB => catalog.weekly.zoneB.plans
-            case Product.WeeklyZoneC => catalog.weekly.zoneC.plans
-          }
+      // go to SF to get the contact mailing information etc
+      GetSalesforceContactForSub.zuoraAccountFromSub(weeklySubscription)(tpBackend.zuoraService, tpBackend.salesforceService.repo, defaultContext).flatMap { account =>
+        val futureSfContact = GetSalesforceContactForSub.sfContactForZuoraAccount(account)(tpBackend.zuoraService, tpBackend.salesforceService.repo, defaultContext)
+        val futureZuoraBillToContact = tpBackend.zuoraService.getContact(account.billToId)
+        futureSfContact.flatMap { contact =>
+          futureZuoraBillToContact.map { zuoraContact =>
+            zuoraContact.country.map { billToCountry =>
+              val catalog = tpBackend.catalogService.unsafeCatalog
+              val weeklyPlans = weeklySubscription.planToManage.product match {
+                case Product.WeeklyZoneA => catalog.weekly.zoneA.plans
+                case Product.WeeklyZoneB => catalog.weekly.zoneB.plans
+                case Product.WeeklyZoneC => catalog.weekly.zoneC.plans
+              }
 
-          val renewalPlans = weeklyPlans.filter(_.availableForRenewal)
+              val renewalPlans = weeklyPlans.filter(_.availableForRenewal)
 
-          val currency = account.currency.toRight(s"could not deserialise currency for account ${account.id}")
-          val weeklyPlanInfo = currency.right.flatMap { existingCurrency =>
-            sequence(renewalPlans.map { plan =>
-              val price = plan.charges.price.getPrice(existingCurrency).toRight(s"could not find price in $existingCurrency for plan ${plan.id} ${plan.name}").right
-              price.map(price => WeeklyPlanInfo(plan.id, plan.charges.prettyPricing(price.currency)))
-            }).right.map(r => (existingCurrency, r))
+              val currency = account.currency.toRight(s"could not deserialise currency for account ${account.id}")
+              val weeklyPlanInfo = currency.right.flatMap { existingCurrency =>
+                sequence(renewalPlans.map { plan =>
+                  val price = plan.charges.price.getPrice(existingCurrency).toRight(s"could not find price in $existingCurrency for plan ${plan.id} ${plan.name}").right
+                  price.map(price => WeeklyPlanInfo(plan.id, plan.charges.prettyPricing(price.currency)))
+                }).right.map(r => (existingCurrency, r))
+              }
+              weeklyPlanInfo match {
+                case Left(error) =>
+                  info(s"couldn't get new rate/currency for renewal: $error")
+                  Ok(views.html.account.details(None, promoCode))
+                case Right((existingCurrency, weeklyPlanInfoList)) =>
+                  Ok(weeklySubscription.asRenewable.map { renewableSub =>
+                    info(s"sub is renewable - showing weeklyRenew page")
+                    views.html.account.weeklyRenew(renewableSub, contact, zuoraContact.email, billToCountry, weeklyPlanInfoList, existingCurrency, promoCode)
+                  } getOrElse {
+                    info(s"sub is not renewable - showing weeklyDetails page")
+                    views.html.account.weeklyDetails(weeklySubscription, billingSchedule, contact)
+                  })
+              }
+            }.getOrElse {
+              info(s"no valid bill to country for account")
+              Ok(views.html.account.details(None, promoCode))
+            }
           }
-          weeklyPlanInfo match {
-            case Left(errorMessage) =>
-              error(s"couldn't get new rate/currency for renewal: $errorMessage")
-              Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but can't renew it via the web, please contact customer services for help.")))
-            case Right((existingCurrency, weeklyPlanInfoList)) =>
-              Ok(weeklySubscription.asRenewable.map { renewableSub =>
-                info(s"sub is renewable - showing weeklyRenew page")
-                views.html.account.weeklyRenew(renewableSub, account.soldToContact, account.billToContact.email, billToCountry, weeklyPlanInfoList, existingCurrency, promoCode)
-              } getOrElse {
-                info(s"sub is not renewable - showing weeklyDetails page")
-                views.html.account.weeklyDetails(weeklySubscription, billingSchedule, account.soldToContact)
-              })
-          }
-        }.getOrElse {
-          error(s"no valid bill to country for account")
-          Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but can't manage it via the web, please contact customer services for help.")))
         }
-      }.run.map(_.fold({ errorMessage =>
-        error(s"problem getting account: $errorMessage")
-        Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but can't manage it via the web, please contact customer services for help.")))
-      }, identity))
+      }
     } else {
       info(s"don't support agents, can't manage sub")
-      Future.successful(Ok(views.html.account.details(None, promoCode, Some("You subscribe via an agent, at present you can't manage it via the web, please contact customer services for help.")))) // don't support gifts (yet) as they have related contacts in salesforce of unknown structure
+      Future.successful(Ok(views.html.account.details(None, promoCode))) // don't support gifts (yet) as they have related contacts in salesforce of unknown structure
     }
   }
 
@@ -332,12 +332,12 @@ object AccountManagement extends Controller with ContextLogging with CatalogProv
       }
       maybeFutureManagePage.getOrElse {
         // the product type didn't have the right charges
-        Future.successful(Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but can't manage it via the web, please contact customer services for help."))))
+        Future.successful(Ok(views.html.account.details(None, promoCode)))
       }
     }
 
     futureMaybeFutureManagePage.getOrElse {
-      // not a valid AS number or some unnamed problem getting the details or no sub details in the session yet
+      // not a valid AS number or some unnamed problem getting the details
       Future.successful(Ok(views.html.account.details(subscriberId, promoCode)))
     }.flatMap(identity)
   }

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -3,8 +3,7 @@
 @import com.gu.memsub.promo.PromoCode
 @(
     subscriberId: Option[String],
-    promoCode: Option[PromoCode],
-    message: Option[String]= None
+    promoCode: Option[PromoCode]
 )(implicit request: RequestHeader, flash: Flash, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Manage your subscription | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
@@ -80,9 +79,6 @@
                                 }
                                 @if(flash.get("error").isDefined) {
                                     <div class="form-field__error-message-visible">@flash.get("error")</div>
-                                }
-                                @message.map { message =>
-                                    <div class="form-field__error-message-visible">@message</div>
                                 }
                                 <button type="submit" class="js-suspend-submit button button--primary button--large u-margin-bottom">
                                     Continue

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -5,8 +5,7 @@
 @import com.gu.salesforce.Contact
 @import model.SubscriptionOps._
 
-@import com.gu.zuora.ZuoraRestService.SoldToContact
-@(chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[SoldToContact] = None, subscription: Subscription[SubscriptionPlan.ContentSubscription])(extra: Html = Html(""))
+@(chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[Contact] = None, subscription: Subscription[SubscriptionPlan.ContentSubscription])(extra: Html = Html(""))
 <dl class="mma-section__list">
     <dt class="mma-section__list--title">Subscriber ID</dt>
     <dd class="mma-section__list--content">@{subscription.name.get}</dd>
@@ -24,14 +23,12 @@
         <dd class="mma-section__list--content">
             <div>@contact.firstName @contact.lastName</div>
             <div>@{
-                def opt(string: String) = Some(string.trim).filter(_.nonEmpty)
                 List(
-                    opt(contact.address1),
-                    opt(contact.address2),
-                    opt(contact.city),
-                    opt(contact.state),
-                    opt(contact.postCode),
-                    contact.country.map(_.name)
+                    contact.mailingStreet,
+                    contact.mailingCity,
+                    contact.mailingState,
+                    contact.mailingPostcode,
+                    contact.mailingCountry
                 ).flatten.mkString(", ")}</div>
         </dd>
     }

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -5,9 +5,8 @@
 @import com.gu.salesforce.Contact
 @import model.SubscriptionOps._
 @import org.joda.time.LocalDate.now
-@import com.gu.zuora.ZuoraRestService.SoldToContact
 @(
-    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: Option[BillingSchedule], contact: SoldToContact
+    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: Option[BillingSchedule], contact: Contact
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -14,9 +14,8 @@
 @import com.gu.memsub.promo.PromoCode
 @import org.joda.time.LocalDate.now
 @import com.gu.memsub.subsv2.ReaderType
-@import com.gu.zuora.ZuoraRestService.SoldToContact
 @(
-    subscription: Subscription[WeeklyPlanOneOff], contact: SoldToContact, email: Option[String], billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
+    subscription: Subscription[WeeklyPlanOneOff], contact: Contact, email: Option[String], billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {
@@ -63,7 +62,7 @@
                 data-billing-country="@billToCountry.alpha2"
                 data-promo-code="@promoCode.map(_.get)"
                 data-currency="@currency.iso"
-                data-delivery-country="@contact.country.map(_.alpha2).getOrElse(billToCountry.alpha2)"
+                data-delivery-country="@contact.mailingCountryParsed.map(_.alpha2).getOrElse(billToCountry.alpha2)"
                 data-direct-debit-logo="@hashedPathFor("images/direct-debit-black.png")"
                 data-weekly-terms-conditions-href="@Links.weeklyTerms.href"
                 data-weekly-terms-conditions-title="@Links.weeklyTerms.title"

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.405",
+    "com.gu" %% "membership-common" % "0.404",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
Reverts guardian/subscriptions-frontend#932

it's treating address2 as a required field which isn't @paulbrown1982 