### PR TITLE
try read subs using rest again with optional contact fields

### DIFF
--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -257,7 +257,8 @@ class CheckoutService(
       soldToContact = soldToContact.map(address => SoldToContact(
         name = personalData,        // TODO once we have gifting change this to the Giftee's name
         address = address,
-        email = personalData.email  // TODO once we have gifting change this to the Giftee's email address
+        email = personalData.email,  // TODO once we have gifting change this to the Giftee's email address
+        phone = personalData.telephoneNumber
       )),
       contractEffective = acquisitionDate,
       contractAcceptance = firstPaymentDate,
@@ -269,7 +270,6 @@ class CheckoutService(
   private def createSubscription(
       subscribe: Subscribe,
       purchaserIds: PurchaserIdentifiers): Future[NonEmptyList[SubsError] \/ SubscribeResult] = {
-
     zuoraService.createSubscription(subscribe).map(\/.right).recover {
       case e: PaymentGatewayError => \/.left(NonEmptyList(CheckoutZuoraPaymentGatewayError(
         purchaserIds,

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -3,7 +3,8 @@
 @import com.gu.memsub.promo.PromoCode
 @(
     subscriberId: Option[String],
-    promoCode: Option[PromoCode]
+    promoCode: Option[PromoCode],
+    message: Option[String]= None
 )(implicit request: RequestHeader, flash: Flash, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Manage your subscription | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
@@ -79,6 +80,9 @@
                                 }
                                 @if(flash.get("error").isDefined) {
                                     <div class="form-field__error-message-visible">@flash.get("error")</div>
+                                }
+                                @message.map { message =>
+                                    <div class="form-field__error-message-visible">@message</div>
                                 }
                                 <button type="submit" class="js-suspend-submit button button--primary button--large u-margin-bottom">
                                     Continue

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -24,7 +24,7 @@
         <dd class="mma-section__list--content">
             <div>@contact.firstName @contact.lastName</div>
             <div>@{
-                def opt(string: String) = Some(string.trim).filter(_.nonEmpty)
+                def opt(string: Option[String]) = string.map(_.trim).filter(_.nonEmpty)
                 List(
                     opt(contact.address1),
                     opt(contact.address2),

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -5,7 +5,8 @@
 @import com.gu.salesforce.Contact
 @import model.SubscriptionOps._
 
-@(chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[Contact] = None, subscription: Subscription[SubscriptionPlan.ContentSubscription])(extra: Html = Html(""))
+@import com.gu.zuora.ZuoraRestService.SoldToContact
+@(chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[SoldToContact] = None, subscription: Subscription[SubscriptionPlan.ContentSubscription])(extra: Html = Html(""))
 <dl class="mma-section__list">
     <dt class="mma-section__list--title">Subscriber ID</dt>
     <dd class="mma-section__list--content">@{subscription.name.get}</dd>
@@ -23,12 +24,14 @@
         <dd class="mma-section__list--content">
             <div>@contact.firstName @contact.lastName</div>
             <div>@{
+                def opt(string: String) = Some(string.trim).filter(_.nonEmpty)
                 List(
-                    contact.mailingStreet,
-                    contact.mailingCity,
-                    contact.mailingState,
-                    contact.mailingPostcode,
-                    contact.mailingCountry
+                    opt(contact.address1),
+                    opt(contact.address2),
+                    opt(contact.city),
+                    opt(contact.state),
+                    opt(contact.postCode),
+                    contact.country.map(_.name)
                 ).flatten.mkString(", ")}</div>
         </dd>
     }

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -5,8 +5,9 @@
 @import com.gu.salesforce.Contact
 @import model.SubscriptionOps._
 @import org.joda.time.LocalDate.now
+@import com.gu.zuora.ZuoraRestService.SoldToContact
 @(
-    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: Option[BillingSchedule], contact: Contact
+    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: Option[BillingSchedule], contact: SoldToContact
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -14,8 +14,9 @@
 @import com.gu.memsub.promo.PromoCode
 @import org.joda.time.LocalDate.now
 @import com.gu.memsub.subsv2.ReaderType
+@import com.gu.zuora.ZuoraRestService.SoldToContact
 @(
-    subscription: Subscription[WeeklyPlanOneOff], contact: Contact, email: Option[String], billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
+    subscription: Subscription[WeeklyPlanOneOff], contact: SoldToContact, email: Option[String], billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
 @main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {
@@ -62,7 +63,7 @@
                 data-billing-country="@billToCountry.alpha2"
                 data-promo-code="@promoCode.map(_.get)"
                 data-currency="@currency.iso"
-                data-delivery-country="@contact.mailingCountryParsed.map(_.alpha2).getOrElse(billToCountry.alpha2)"
+                data-delivery-country="@contact.country.map(_.alpha2).getOrElse(billToCountry.alpha2)"
                 data-direct-debit-logo="@hashedPathFor("images/direct-debit-black.png")"
                 data-weekly-terms-conditions-href="@Links.weeklyTerms.href"
                 data-weekly-terms-conditions-title="@Links.weeklyTerms.title"

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.406",
+    "com.gu" %% "membership-common" % "0.407",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.404",
+    "com.gu" %% "membership-common" % "0.405",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.405",
+    "com.gu" %% "membership-common" % "0.406",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
Trying again, because after the first attempt, migrated subs with null as address2 were failing to let people manage due to a json reader error.  When we create a sub through the frontend we put in an empty string, but we can't trust migrated subs.  As a result it's better to assume they're all optional except last name, as per the [old salesforce deserialiser](https://github.com/guardian/membership-common/blob/master/src/main/scala/com/gu/salesforce/Contact.scala#L21-L25)

pulls in https://github.com/guardian/membership-common/pull/478

Also includes the changes in https://github.com/guardian/subscriptions-frontend/pull/933 due to the membership common changes being already merged.

Look at the last commit for the updates just now: https://github.com/guardian/subscriptions-frontend/commit/dc7f77496ce6e5ad6fbe8504813c81e006b4e920

@paulbrown1982 @jacobwinch 