### PR TITLE
Added the promo code as a Google Analytics dimension

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -77,6 +77,7 @@
     guardian.pageInfo.productData.initialProduct = '@{productData.plans.default.name}';
     guardian.pageInfo.productData.productPurchasing = '@{productData.plans.default.name}';
     guardian.pageInfo.productData.productType = '@{productData.plans.default.product.productType}';
+    guardian.pageInfo.productData.promoCode = '@{promoCode.map(_.get)}';
 </script>
 
 <main class="page-container gs-container">

--- a/assets/javascripts/modules/analytics/ga.js
+++ b/assets/javascripts/modules/analytics/ga.js
@@ -27,7 +27,6 @@ define(['modules/analytics/analyticsEnabled',
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
         /*eslint-enable */
 
-        // Ours
         ga('create', {
             'trackingId': guardian.googleAnalytics.trackingId,
             'name': 'membershipPropertyTracker',
@@ -54,6 +53,9 @@ define(['modules/analytics/analyticsEnabled',
             if (productData.productPurchased) {
                 ga('membershipPropertyTracker.set', 'dimension11', productData.productType + ' - ' + productData.productPurchased);  // productPurchased
             }
+            if (productData.promoCode) {
+                ga('membershipPropertyTracker.set', 'dimension19', productData.promoCode);  // promoCode
+            }
         }
 
         if (intcmp && intcmp[1]) {
@@ -76,14 +78,6 @@ define(['modules/analytics/analyticsEnabled',
 
         ga('membershipPropertyTracker.send', 'pageview');
 
-        // JellyFish
-        ga('create', {
-            'trackingId': 'UA-44575989-1',
-            'name': 'jellyfishGA',
-            'cookieDomain': 'auto'
-        });
-        ga('jellyfishGA.send', 'pageview');
-
         flushEventQueue();
     }
 
@@ -104,6 +98,9 @@ define(['modules/analytics/analyticsEnabled',
                 metric2: obj.elapsedTime,
                 metric10: converted
             };
+            if (guardian.pageInfo.productData.promoCode) {
+                event.dimension19 = guardian.pageInfo.productData.promoCode;
+            }
             if (guardian.experience){
                 event.dimension16 = guardian.experience;
             }

--- a/assets/javascripts/modules/checkout/eventTracking.js
+++ b/assets/javascripts/modules/checkout/eventTracking.js
@@ -29,6 +29,7 @@ define(['modules/analytics/ga', 'modules/checkout/ratePlanChoice'], function (ga
         completedPaymentDetails: trackEvent('Payment details'),
         completedReviewDetails: trackEvent('Review and confirm'),
         completedDeliveryDetails: trackEvent('Delivery address'),
+        enteredPromoCode: trackEvent('Promo code'),
         init: function () {
             ratePlanChoice.registerOnChangeAction(trackRatePlanChange);
 

--- a/assets/javascripts/modules/checkout/ratePlanChoice.js
+++ b/assets/javascripts/modules/checkout/ratePlanChoice.js
@@ -44,8 +44,9 @@ define(['$', 'bean'], function ($, bean) {
 
     function selectRatePlanForIdAndCurrency(ratePlanId, currency) {
         forEveryPlanOption(function(option) {
-            if ($(option).val() === ratePlanId && $(option).attr('data-currency') === currency) {
-                $(option).attr('checked', 'checked');
+            var $option = $(option);
+            if ($option.val() === ratePlanId && $option.attr('data-currency') === currency && !$option.attr('checked')) {
+                $option.attr('checked', 'checked');
                 bean.fire(option, 'change');
             }
         });


### PR DESCRIPTION
[Added the promo code to Google Analytics](https://trello.com/c/dKpUZJTk/173-put-promo-code-into-a-ga-dimension) as [dimension19](https://docs.google.com/spreadsheets/d/1MmWHNeeiQE_dzekImIP9Tv4beLx_8JzWx3rOtCp4PGg/edit#gid=1460779756). It's a session based variable, so in theory it only needs setting once, and left absent after that. The 'last click' also wins in this scenario.

See: ```el "Promo code"``` and ```cd19 "DIYZZJZSL"``` on this custom event beacon.

<img width="843" alt="picture 105" src="https://cloud.githubusercontent.com/assets/1515970/26099415/81859eba-3a22-11e7-97d6-c0ff80f46778.png">

I also removed the old JellyFish analytics tag, and fixed 2 bugs where (1) the Rate plan change tracking event was firing too many times, and (2) an already validated and displayed promo code was being revalidated and redisplayed when on-bluring from the promo code field.

cc @AWare @pvighi @jacobwinch @johnduffell @lmath @michaelwmcnamara 