### PR TITLE
Strip leading zeros from the Subscriber IDs provided by customers in /manage

### DIFF
--- a/app/forms/AccountManagementLoginForm.scala
+++ b/app/forms/AccountManagementLoginForm.scala
@@ -3,7 +3,9 @@ package forms
 import play.api.data.Form
 import play.api.data.Forms._
 
-case class AccountManagementLoginRequest(subscriptionId: String, lastname: String, promoCode: Option[String])
+case class AccountManagementLoginRequest(unsanitisedSubscriptionId: String, lastname: String, promoCode: Option[String]) {
+  val subscriptionId = unsanitisedSubscriptionId.replaceFirst("^0+", "");
+}
 
 object AccountManagementLoginForm {
 


### PR DESCRIPTION
Strip leading zeros from the Subscriber IDs provided by customers in the /manage page, before looking up in Zuora. This is because a lot of our migrated subscribers have paperwork which contains these leading zeros back when they were managed by a third party, and are getting confused when using this page, and calling up the call centre.

https://trello.com/c/m9kKA4fQ/174-strip-leading-zeros-from-manage-page-sub-id-before-authenticating-with-zuora

cc @johnduffell @AWare @jacobwinch @pvighi @lmath 