### PR TITLE
Tweaking the copy on the Digital sale section

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -15,7 +15,7 @@
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">14-day free trial of our digital pack</li>
-                        <li class="block__list-item"><strong>Plus, subscribe today and save an extra 50% on the first 3 months</strong></li>
+                        <li class="block__list-item"><strong>Plus, save 50% for the first 3 months</strong></li>
                         @UK.digitalPackSaving.map { saving => <li class="block__list-item">Save up to @saving% on the app store price</li> }
                         <li class="block__list-item">Access to the Daily Edition and the advert-free Guardian App Premium Tier</li>
                         <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -15,7 +15,7 @@
             <div class="block__info">
                 <ul class="block__list">
                     <li class="block__list-item">14-day free trial</li>
-                    <li class="block__list-item"><strong>Plus, subscribe today and save an extra 50% on the first 3 months</strong></li>
+                    <li class="block__list-item"><strong>Plus, save 50% for the first 3 months</strong></li>
                     @edition.digitalPackSaving.map {saving => <li class="block__list-item">Save up to @{saving}% on the app store price</li>}
                     <li class="block__list-item">Access to the Daily Edition, the digital version of the UK Guardian newspaper</li>
                     <li class="block__list-item">Access to the advert-free Guardian App Premium Tier</li>

--- a/app/views/offers/offers_international.scala.html
+++ b/app/views/offers/offers_international.scala.html
@@ -15,7 +15,7 @@
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">14-day free trial</li>
-                        <li class="block__list-item"><strong>Plus, subscribe today and save an extra 50% on the first 3 months</strong></li>
+                        <li class="block__list-item"><strong>Plus, save 50% for the first 3 months</strong></li>
                         @edition.digitalPackSaving.map {saving => <li class="block__list-item">Save up to @{saving}% on the app store price</li>}
                         <li class="block__list-item">Access to the Daily Edition, the digital version of the UK Guardian newspaper</li>
                         <li class="block__list-item">Access to the advert-free Guardian App Premium Tier</li>

--- a/app/views/offers/offers_uk.scala.html
+++ b/app/views/offers/offers_uk.scala.html
@@ -15,7 +15,7 @@
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">14-day free trial of our digital pack</li>
-                        <li class="block__list-item"><strong>Plus, subscribe today and save an extra 50% on the first 3 months</strong></li>
+                        <li class="block__list-item"><strong>Plus, save 50% for the first 3 months</strong></li>
                         @UK.digitalPackSaving.map { saving => <li class="block__list-item">Save up to @saving% on the app store price</li> }
                         <li class="block__list-item">Access to the Daily Edition and the advert-free Guardian App Premium Tier</li>
                         <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>


### PR DESCRIPTION
Tweaking the copy on the Digital sale section. The 'today' language conflicts with the 14-day free trial above it.

This is a request from the MMCR Acquisition team. https://trello.com/c/iyWsJBhl/187-wrong-copy-on-digital-section

Before:
<img width="312" alt="picture 106" src="https://cloud.githubusercontent.com/assets/1515970/26151169/71822466-3af9-11e7-9c15-197b0edd6f6d.png">

After:
<img width="315" alt="picture 107" src="https://cloud.githubusercontent.com/assets/1515970/26151174/7619ad00-3af9-11e7-83c6-57cbfd01f35b.png">

cc @jacobwinch @pvighi @AWare @jacobwinch @lmath 

