### PR TITLE
Renewal fixes

### DIFF
--- a/app/logging/ContextLogging.scala
+++ b/app/logging/ContextLogging.scala
@@ -24,6 +24,8 @@ trait ContextLogging extends StrictLogging {
 
   def error(message: String)(implicit context: Context) = log(logger.error(_), message, context)
 
+  def error(message: String, cause: Throwable)(implicit context: Context) = log(logger.error(_, cause), message, context)
+
   private def log(log: String => Unit, message: String, context: Context): Unit = {
     log(s"{${context.environmentName} sub: ${context.sub.name.get}} $message")
   }

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -310,11 +310,11 @@ class CheckoutService(
   }
 
   def renewSubscription(subscription: Subscription[WeeklyPlanOneOff], renewal: model.Renewal)
-                       (implicit
-                        p: PromotionApplicator[com.gu.memsub.promo.Renewal, Renew],
-                        zuoraRestService: ZuoraRestService[Future],
-                        context: Context
-                       ): Future[\/[String, Any]] = {
+    (implicit
+      p: PromotionApplicator[com.gu.memsub.promo.Renewal, Renew],
+      zuoraRestService: ZuoraRestService[Future],
+      context: Context
+    ): Future[\/[String, Any]] = {
 
     def getPayment(contact: Contact, billto: Queries.Contact): PaymentService#Payment = {
       val idMinimalUser = IdMinimalUser(contact.identityId, None)
@@ -348,7 +348,6 @@ class CheckoutService(
       val finalRenewCommand = applyPromoIfNecessary(maybeValidPromo, basicRenewCommand)
       finalRenewCommand.withContextLogging("final renew command")
     }
-
 
     def getValidPromotion(code: PromoCode, addressCountry: Option[Country]): \/[String, ValidPromotion[com.gu.memsub.promo.Renewal]] = for {
       country <- addressCountry.withContextLogging("country client").toRightDisjunction("No country in contact!")

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -201,9 +201,7 @@ class ExactTargetService(
     renewal: Renewal,
     subscriptionDetails: String,
     contact: Contact,
-    email: String,
     newTermStartDate: LocalDate)(implicit context: Context): Future[Unit] = {
-
     sealed trait Error {
       def msg: String
       def code: String
@@ -234,7 +232,7 @@ class ExactTargetService(
         planName = renewal.plan.name,
         contact = contact,
         paymentMethod = paymentMethod,
-        email = email,
+        email = renewal.email,
         newTermStartDate = newTermStartDate)
       sendMessage <- EitherT(sendToQueue(row))
     } yield sendMessage).run

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -35,7 +35,6 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 import scalaz.Scalaz._
 import scalaz.{-\/, EitherT, \/, \/-}
-
 /**
   * Sends welcome email message to Amazon SQS queue which is consumed by membership-workflow.
   *
@@ -240,8 +239,8 @@ class ExactTargetService(
     sentMessage.map {
       case \/-(sendMsgResult) => info(s"Successfully enqueued guardian weekly renewal email.")
       case -\/(se@SimpleError(_)) => error(se.fullDescription)
-      case -\/(et@ExceptionThrown(_,exception)) => logger.error(et.fullDescription, exception)
-    }
+      case -\/(et@ExceptionThrown(_, exception)) => error(et.fullDescription, exception)
+    }.recover { case e: Exception => error(e.getMessage, e) }
   }
 }
 
@@ -253,6 +252,7 @@ object SqsClient extends LazyLogging {
 
   def sendDataExtensionToQueue(queueName: String, row: DataExtensionRow): Future[Try[SendMessageResult]] = {
     Future {
+      throw new Exception("exeception inside the thing!")
       val payload = Json.obj(
         "To" -> Json.obj(
           "Address" -> row.email,

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -252,7 +252,6 @@ object SqsClient extends LazyLogging {
 
   def sendDataExtensionToQueue(queueName: String, row: DataExtensionRow): Future[Try[SendMessageResult]] = {
     Future {
-      throw new Exception("exeception inside the thing!")
       val payload = Json.obj(
         "To" -> Json.obj(
           "Address" -> row.email,


### PR DESCRIPTION
problems with renewals fixed:
- promotion validation used Zuora Country for the ajax check and salesforce for the server side check
- server side promotion validation didn't cause an error it just didn't apply the promotion and continued with the renewal
- exceptions being thrown in the steps after the zuora amendments were executed resulted in an error telling the customer that the sub was not renewed when it fact it was.  