### PR TITLE
Configure Prout to add Sentry Releases

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -11,5 +11,8 @@
                 }
             }
         }
+    },
+    "sentry": {
+      "projects": ["subscriptions", "subscriptions-client-side"]
     }
 }


### PR DESCRIPTION
Sentry recently released some [interesting functionality around tracking issues related to specific code-changes](https://blog.sentry.io/2017/05/01/release-commits.html), and Prout now has some [basic support](https://github.com/guardian/prout/issues/47#issuecomment-302468156) for this.

![image](https://docs.sentry.io/_images/releases-overview.png)

To activate Prout's support, you just need to ensure Sentry has 'connected' to your GitHub repo in https://sentry.io/organizations/the-guardian/repos/, and then add a 'sentry' stanza to your `.prout.json`, corresponding to the Sentry projects used with this stack:

* https://sentry.io/the-guardian/subscriptions/
* https://sentry.io/the-guardian/subscriptions-client-side/
