### PR TITLE
Make identity check more robust

### DIFF
--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -26,7 +26,11 @@ class IdentityService(identityApiClient: => IdentityApiClient) extends LazyLoggi
 
   def doesUserExist(email: String): Future[Boolean] =
     identityApiClient.userLookupByEmail(email).map { response =>
-      (response.json \ "user" \ "id").asOpt[String].isDefined
+      response.status match {
+        case status if status == Status.OK =>  (response.json \ "user" \ "id").asOpt[String].isDefined
+        case _ => false
+      }
+
     }
 
   def userLookupByCredentials(accessCredentials: AccessCredentials): Future[Option[IdUser]] = accessCredentials match {

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -28,7 +28,10 @@ class IdentityService(identityApiClient: => IdentityApiClient) extends LazyLoggi
     identityApiClient.userLookupByEmail(email).map { response =>
       response.status match {
         case status if status == Status.OK =>  (response.json \ "user" \ "id").asOpt[String].isDefined
-        case _ => false
+        case status => {
+          logger.error(s"ID API failed on email check with HTTP status $status")
+          false
+        }
       }
 
     }


### PR DESCRIPTION
By checking for a 200 response before attempting to parse JSON
![](https://media.giphy.com/media/TnPhv5CI8rHK8/giphy.gif)