### PR TITLE
Make identity check more robust 

### DIFF
--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -27,7 +27,7 @@ class IdentityService(identityApiClient: => IdentityApiClient) extends LazyLoggi
   def doesUserExist(email: String): Future[Boolean] =
     identityApiClient.userLookupByEmail(email).map { response =>
       response.status match {
-        case status if status == Status.OK =>  (response.json \ "user" \ "id").asOpt[String].isDefined
+        case status if status == Status.OK =>  true
         case status if status == Status.NOT_FOUND => false
         case status => {
           logger.error(s"ID API failed on email check with HTTP status $status")

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -26,7 +26,14 @@ class IdentityService(identityApiClient: => IdentityApiClient) extends LazyLoggi
 
   def doesUserExist(email: String): Future[Boolean] =
     identityApiClient.userLookupByEmail(email).map { response =>
-      (response.json \ "user" \ "id").asOpt[String].isDefined
+      response.status match {
+        case status if status == Status.OK =>  (response.json \ "user" \ "id").asOpt[String].isDefined
+        case status => {
+          logger.error(s"ID API failed on email check with HTTP status $status")
+          false
+        }
+      }
+
     }
 
   def userLookupByCredentials(accessCredentials: AccessCredentials): Future[Option[IdUser]] = accessCredentials match {

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -28,6 +28,7 @@ class IdentityService(identityApiClient: => IdentityApiClient) extends LazyLoggi
     identityApiClient.userLookupByEmail(email).map { response =>
       response.status match {
         case status if status == Status.OK =>  (response.json \ "user" \ "id").asOpt[String].isDefined
+        case status if status == Status.NOT_FOUND => false
         case status => {
           logger.error(s"ID API failed on email check with HTTP status $status")
           false

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -27,8 +27,8 @@ class IdentityService(identityApiClient: => IdentityApiClient) extends LazyLoggi
   def doesUserExist(email: String): Future[Boolean] =
     identityApiClient.userLookupByEmail(email).map { response =>
       response.status match {
-        case status if status == Status.OK =>  true
-        case status if status == Status.NOT_FOUND => false
+        case Status.OK =>  true
+        case Status.NOT_FOUND => false
         case status => {
           logger.error(s"ID API failed on email check with HTTP status $status")
           false


### PR DESCRIPTION
Reverts guardian/subscriptions-frontend#954

Not forgetting that identity returns a 404 for not found.