### PR TITLE
Wrong codes

### DIFF
--- a/app/views/offers/offers_uk.scala.html
+++ b/app/views/offers/offers_uk.scala.html
@@ -38,7 +38,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBG41F", None).url">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBG41G", None).url">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper">
@@ -53,7 +53,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBG41G", None).url">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBG41F", None).url">Subscribe now</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
There was a typo and these codes should have been the other way round. It was decided to switch the codes on the site rather than the products behind the codes in the promo tool.

@AWare @jacobwinch @johnduffell @lmath @pvighi 