### PR TITLE
Remove the promotions from the subs front page

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -23,7 +23,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DNAVUK1", None).url?edition=@UK.id" data-test-id="subscriptions-uk-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DHOMEUK1", None).url?edition=@UK.id" data-test-id="subscriptions-uk-digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper-digital">

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -15,45 +15,43 @@
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">14-day free trial of our digital pack</li>
-                        <li class="block__list-item"><strong>Plus, save 50% for the first 3 months</strong></li>
-                        @UK.digitalPackSaving.map { saving => <li class="block__list-item">Save up to @saving% on the app store price</li> }
+                        @UK.digitalPackSaving.map { saving => <li class="block__list-item"><strong>Save up to @saving% on the app store price</strong></li> }
                         <li class="block__list-item">Access to the Daily Edition and the advert-free Guardian App Premium Tier</li>
+                        <li class="block__list-item">All supplements Monday to Sunday</li>
                         <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
                         <li class="block__list-item">Use on up to 10 devices</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DBH80X", None).url?edition=@UK.id" data-test-id="subscriptions-uk-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DNAVUK1", None).url?edition=@UK.id" data-test-id="subscriptions-uk-digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper-digital">
                 <h2 class="block__title">Paper + digital</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item"><strong>Subscribe today to save an extra 50% on the first 3 months</strong></li>
-                        <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
-                        <li class="block__list-item">Pick the package you want: Everyday+, Sixday+, Weekend+ and Sunday+</li>
+                        <li class="block__list-item">Year-round savings of up to 36% off the retail price</li>
+                        <li class="block__list-item">Pick the package you want: Everyday+, Sixday+, Weekend+ and The Observer+</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
-                        <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
+                        <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBG80F", None).url" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("NHOMEUKD", None).url" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper">
                 <h2 class="block__title">Paper</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item"><strong>Subscribe today to save an extra 50% on the first 3 months</strong></li>
-                        <li class="block__list-item">Year-round savings on the retail price</li>
-                        <li class="block__list-item">Pick the package you want: Everyday, Sixday, Weekend and Sunday</li>
+                        <li class="block__list-item">Year-round savings of up to 31% off the retail price</li>
+                        <li class="block__list-item">Pick the package you want: Everyday, Sixday, Weekend and The Observer</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
                         <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBG80X", None).url" data-test-id="subscriptions-uk-paper">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("NHOMEUKP", None).url" data-test-id="subscriptions-uk-paper">Subscribe now</a>
                 </div>
             </div>
         </div>

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -15,8 +15,7 @@
             <div class="block__info">
                 <ul class="block__list">
                     <li class="block__list-item">14-day free trial</li>
-                    <li class="block__list-item"><strong>Plus, save 50% for the first 3 months</strong></li>
-                    @edition.digitalPackSaving.map {saving => <li class="block__list-item">Save up to @{saving}% on the app store price</li>}
+                    @edition.digitalPackSaving.map {saving => <li class="block__list-item"><strong>Save up to @{saving}% on the app store price</strong></li>}
                     <li class="block__list-item">Access to the Daily Edition, the digital version of the UK Guardian newspaper</li>
                     <li class="block__list-item">Access to the advert-free Guardian App Premium Tier</li>
                     <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
@@ -24,7 +23,7 @@
                 </ul>
             </div>
             <div class="block__footer">
-                <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render(s"DBH80X", None).url?edition=@edition.id" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
+                <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render(s"DHOME${edition.id.toUpperCase}", None).url?edition=@edition.id" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
             </div>
         </div>
         <div class="row__item block block--primary block--weekly">

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -23,7 +23,7 @@
                 </ul>
             </div>
             <div class="block__footer">
-                <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render(s"DHOME${edition.id.toUpperCase}", None).url?edition=@edition.id" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
+                <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render(s"DHOME${edition.id.toUpperCase}1", None).url?edition=@edition.id" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
             </div>
         </div>
         <div class="row__item block block--primary block--weekly">

--- a/app/views/offers/offers_international.scala.html
+++ b/app/views/offers/offers_international.scala.html
@@ -15,8 +15,7 @@
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">14-day free trial</li>
-                        <li class="block__list-item"><strong>Plus, save 50% for the first 3 months</strong></li>
-                        @edition.digitalPackSaving.map {saving => <li class="block__list-item">Save up to @{saving}% on the app store price</li>}
+                        @edition.digitalPackSaving.map {saving => <li class="block__list-item"><strong>Save up to @{saving}% on the app store price</strong></li>}
                         <li class="block__list-item">Access to the Daily Edition, the digital version of the UK Guardian newspaper</li>
                         <li class="block__list-item">Access to the advert-free Guardian App Premium Tier</li>
                         <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
@@ -24,7 +23,7 @@
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render("DBH41F", edition.countryGroup.defaultCountry).url">Subscribe now</a>
+                    <a class="button button--large button--primary button--arrow" href="@routes.PromoLandingPage.render(s"DOFF${edition.id.toUpperCase}1", edition.countryGroup.defaultCountry).url">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--weekly">

--- a/app/views/offers/offers_uk.scala.html
+++ b/app/views/offers/offers_uk.scala.html
@@ -15,45 +15,43 @@
                 <div class="block__info">
                     <ul class="block__list">
                         <li class="block__list-item">14-day free trial of our digital pack</li>
-                        <li class="block__list-item"><strong>Plus, save 50% for the first 3 months</strong></li>
-                        @UK.digitalPackSaving.map { saving => <li class="block__list-item">Save up to @saving% on the app store price</li> }
+                        @UK.digitalPackSaving.map { saving => <li class="block__list-item"><strong>Save up to @saving% on the app store price</strong></li> }
                         <li class="block__list-item">Access to the Daily Edition and the advert-free Guardian App Premium Tier</li>
+                        <li class="block__list-item">All supplements Monday to Sunday</li>
                         <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
                         <li class="block__list-item">Use on up to 10 devices</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DBH41F", UK.countryGroup.defaultCountry).url">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DOFFUK1", UK.countryGroup.defaultCountry).url">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper-digital">
                 <h2 class="block__title">Paper + digital</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item"><strong>Subscribe today to save an extra 50% on the first 3 months</strong></li>
-                        <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
-                        <li class="block__list-item">Pick the package you want: Everyday+, Sixday+, Weekend+ and Sunday+</li>
+                        <li class="block__list-item">Year-round savings of up to 36% off the retail price</li>
+                        <li class="block__list-item">Pick the package you want: Everyday+, Sixday+, Weekend+ and The Observer+</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
-                        <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
+                        <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBG41G", None).url">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("NOFFUKD", None).url">Subscribe now</a>
                 </div>
             </div>
             <div class="row__item block block--primary block--paper">
                 <h2 class="block__title">Paper</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item"><strong>Subscribe today to save an extra 50% on the first 3 months</strong></li>
-                        <li class="block__list-item">Year-round savings on the retail price</li>
-                        <li class="block__list-item">Pick the package you want: Everyday, Sixday, Weekend and Sunday</li>
+                        <li class="block__list-item">Year-round savings of up to 31% off the retail price</li>
+                        <li class="block__list-item">Pick the package you want: Everyday, Sixday, Weekend and The Observer</li>
                         <li class="block__list-item">All supplements Monday to Sunday</li>
                         <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
                     </ul>
                 </div>
                 <div class="block__footer">
-                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("GBG41F", None).url">Subscribe now</a>
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("NOFFUKP", None).url">Subscribe now</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Remove the promotions from the subs front page. This needs to be merged between 00:00:01 and 10:00:00 on Friday 16 June 2018.

https://trello.com/c/8LhD5wSg/208-remove-election-promotions-from-subs-frontend

cc @AWare @jacobwinch @johnduffell @pvighi @lmath 