### PR TITLE
Show the sold-to address's title in the Guardian Weekly My Account page

### DIFF
--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -22,7 +22,7 @@
     @maybeContact.map { contact =>
         <dt class="mma-section__list--title">Delivery details</dt>
         <dd class="mma-section__list--content">
-            <div>@contact.firstName @contact.lastName</div>
+            <div>@contact.title.map(_.title) @contact.firstName @contact.lastName</div>
             <div>@{
                 def opt(string: Option[String]) = string.map(_.trim).filter(_.nonEmpty)
                 List(

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.423-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.424",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.423",
+    "com.gu" %% "membership-common" % "0.423-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
Show the sold-to address's title in the Guardian Weekly My Account page, as per example:

![screen shot 2017-06-21 at 16 27 13](https://user-images.githubusercontent.com/1515970/27393018-1086f53e-56a0-11e7-905e-ce11b5e551db.png)

Requires: https://github.com/guardian/membership-common/pull/496

cc @AWare