### PR TITLE
Update membership common to remove delivery instructions for now.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.422",
+    "com.gu" %% "membership-common" % "0.423",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
@paulbrown1982 
Zuora sets a max of 100chars on description, will see if appropriate or use another field. 