### PR TITLE
 adds delivery instructions to the account object in zuora instead of the soldtocontact

### DIFF
--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -118,8 +118,7 @@ class CheckoutService(
         name = personalData, // TODO once we have gifting change this to the Giftee's name
         address = paperData.deliveryAddress,
         email = personalData.email, // TODO once we have gifting change this to the Giftee's email address
-        phone = personalData.telephoneNumber,
-        deliveryInstructions = paperData.deliveryInstructions
+        phone = personalData.telephoneNumber
       ))
       case _ => None
     }
@@ -307,17 +306,22 @@ class CheckoutService(
 
   private def createPaymentType(purchaserIds: PurchaserIdentifiers, subscriptionData: SubscribeRequest): Future[NonEmptyList[SubsError] \/ PaymentService#Payment] = {
 
+    val deliveryInstructions: Option[String] = subscriptionData.productData match {
+      case Left(paperData) => paperData.deliveryInstructions
+      case _ => None
+    }
+
     try {
       val payment = subscriptionData.genericData.paymentData match {
         case paymentData@DirectDebitData(_, _, _) =>
           val personalData = subscriptionData.genericData.personalData
           require(personalData.address.country.contains(Country.UK), "Direct Debit payment only works in the UK right now")
-          paymentService.makeDirectDebitPayment(paymentData, personalData.first, personalData.last, purchaserIds)
+          paymentService.makeDirectDebitPayment(paymentData, personalData.first, personalData.last, purchaserIds, deliveryInstructions)
         case paymentData@CreditCardData(_) =>
           val plan = subscriptionData.productData.fold(_.plan, _.plan)
           val desiredCurrency = subscriptionData.genericData.currency
           val currency = if (plan.charges.price.currencies.contains(desiredCurrency)) desiredCurrency else GBP
-          paymentService.makeCreditCardPayment(paymentData, currency, purchaserIds)
+          paymentService.makeCreditCardPayment(paymentData, currency, purchaserIds, deliveryInstructions)
       }
       Future.successful(\/.right(payment))
     } catch {
@@ -340,8 +344,8 @@ class CheckoutService(
       val idMinimalUser = IdMinimalUser(contact.identityId, None)
       val purchaserIds = PurchaserIdentifiers(contact, Some(idMinimalUser))
       renewal.paymentData match {
-        case cd: CreditCardData => paymentService.makeCreditCardPayment(cd, subscription.currency, purchaserIds)
-        case dd: DirectDebitData => paymentService.makeDirectDebitPayment(dd, billto.firstName, billto.lastName, purchaserIds)
+        case cd: CreditCardData => paymentService.makeCreditCardPayment(cd, subscription.currency, purchaserIds, None)
+        case dd: DirectDebitData => paymentService.makeDirectDebitPayment(dd, billto.firstName, billto.lastName, purchaserIds, None)
       }
     }
 

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -316,12 +316,12 @@ class CheckoutService(
         case paymentData@DirectDebitData(_, _, _) =>
           val personalData = subscriptionData.genericData.personalData
           require(personalData.address.country.contains(Country.UK), "Direct Debit payment only works in the UK right now")
-          paymentService.makeDirectDebitPayment(paymentData, personalData.first, personalData.last, purchaserIds, deliveryInstructions)
+          paymentService.makeZuoraAccountWithDirectDebit(paymentData, personalData.first, personalData.last, purchaserIds, deliveryInstructions)
         case paymentData@CreditCardData(_) =>
           val plan = subscriptionData.productData.fold(_.plan, _.plan)
           val desiredCurrency = subscriptionData.genericData.currency
           val currency = if (plan.charges.price.currencies.contains(desiredCurrency)) desiredCurrency else GBP
-          paymentService.makeCreditCardPayment(paymentData, currency, purchaserIds, deliveryInstructions)
+          paymentService.makeZuoraAccountWithCreditCard(paymentData, currency, purchaserIds, deliveryInstructions)
       }
       Future.successful(\/.right(payment))
     } catch {
@@ -344,8 +344,8 @@ class CheckoutService(
       val idMinimalUser = IdMinimalUser(contact.identityId, None)
       val purchaserIds = PurchaserIdentifiers(contact, Some(idMinimalUser))
       renewal.paymentData match {
-        case cd: CreditCardData => paymentService.makeCreditCardPayment(cd, subscription.currency, purchaserIds, None)
-        case dd: DirectDebitData => paymentService.makeDirectDebitPayment(dd, billto.firstName, billto.lastName, purchaserIds, None)
+        case cd: CreditCardData => paymentService.makeZuoraAccountWithCreditCard(cd, subscription.currency, purchaserIds, None)
+        case dd: DirectDebitData => paymentService.makeZuoraAccountWithDirectDebit(dd, billto.firstName, billto.lastName, purchaserIds, None)
       }
     }
 

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -243,7 +243,7 @@ class CheckoutService(
     }
   }
 
-  private def attachPaymentMethodToStripeCustomer(payment: PaymentService#Payment, purchaserIds: PurchaserIdentifiers): Future[NonEmptyList[SubsError] \/ PaymentMethod] =
+  private def attachPaymentMethodToStripeCustomer(payment: PaymentService#AccountAndPayment, purchaserIds: PurchaserIdentifiers): Future[NonEmptyList[SubsError] \/ PaymentMethod] =
     payment.makePaymentMethod.map(\/.right).recover {
         case e: Stripe.Error =>
           \/.left(NonEmptyList(CheckoutStripeError(
@@ -304,7 +304,7 @@ class CheckoutService(
     }
   }
 
-  private def createPaymentType(purchaserIds: PurchaserIdentifiers, subscriptionData: SubscribeRequest): Future[NonEmptyList[SubsError] \/ PaymentService#Payment] = {
+  private def createPaymentType(purchaserIds: PurchaserIdentifiers, subscriptionData: SubscribeRequest): Future[NonEmptyList[SubsError] \/ PaymentService#AccountAndPayment] = {
 
     val deliveryInstructions: Option[String] = subscriptionData.productData match {
       case Left(paperData) => paperData.deliveryInstructions
@@ -340,7 +340,7 @@ class CheckoutService(
       context: Context
     ): Future[\/[String, Any]] = {
 
-    def getPayment(contact: Contact, billto: Queries.Contact): PaymentService#Payment = {
+    def getPayment(contact: Contact, billto: Queries.Contact): PaymentService#AccountAndPayment = {
       val idMinimalUser = IdMinimalUser(contact.identityId, None)
       val purchaserIds = PurchaserIdentifiers(contact, Some(idMinimalUser))
       renewal.paymentData match {

--- a/app/services/PaymentService.scala
+++ b/app/services/PaymentService.scala
@@ -57,14 +57,14 @@ class PaymentService(val stripeService: StripeService) {
     }
   }
 
-  def makeDirectDebitPayment(
+  def makeZuoraAccountWithDirectDebit(
       paymentData: DirectDebitData,
       firstName: String,
       lastName: String,
       purchaserIds: PurchaserIdentifiers,
       deliveryInstructions: Option[String]) = ZuoraAccountDirectDebit(paymentData, firstName,lastName, purchaserIds, deliveryInstructions)
 
-  def makeCreditCardPayment(
+  def makeZuoraAccountWithCreditCard(
      paymentData: CreditCardData,
      currency: Currency,
      purchaserIds: PurchaserIdentifiers,

--- a/app/services/PaymentService.scala
+++ b/app/services/PaymentService.scala
@@ -13,12 +13,12 @@ import model._
 
 class PaymentService(val stripeService: StripeService) {
 
-  sealed trait Payment {
+  sealed trait AccountAndPayment {
     def makeAccount: Account
     def makePaymentMethod: Future[PaymentMethod]
   }
 
-  case class DirectDebitPayment(paymentData: DirectDebitData, firstName: String, lastName: String, purchaserIds: PurchaserIdentifiers, deliveryInstructions: Option[String]) extends Payment {
+  case class ZuoraAccountDirectDebit(paymentData: DirectDebitData, firstName: String, lastName: String, purchaserIds: PurchaserIdentifiers, deliveryInstructions: Option[String]) extends AccountAndPayment {
 
     override def makeAccount = Account(purchaserIds.contactId, identityIdForAccount(purchaserIds), GBP, autopay = true, GoCardless, deliveryInstructions = deliveryInstructions)
 
@@ -33,7 +33,7 @@ class PaymentService(val stripeService: StripeService) {
       ))
   }
 
-  class CreditCardPayment(val paymentData: CreditCardData, val currency: Currency, val purchaserIds: PurchaserIdentifiers, val deliveryInstructions: Option[String]) extends Payment {
+  class ZuoraAccountCreditCard(val paymentData: CreditCardData, val currency: Currency, val purchaserIds: PurchaserIdentifiers, val deliveryInstructions: Option[String]) extends AccountAndPayment {
     override def makeAccount = Account(purchaserIds.contactId, identityIdForAccount(purchaserIds), currency, autopay = true, Stripe, deliveryInstructions)
 
     override def makePaymentMethod = {
@@ -62,12 +62,12 @@ class PaymentService(val stripeService: StripeService) {
       firstName: String,
       lastName: String,
       purchaserIds: PurchaserIdentifiers,
-      deliveryInstructions: Option[String]) = DirectDebitPayment(paymentData, firstName,lastName, purchaserIds, deliveryInstructions)
+      deliveryInstructions: Option[String]) = ZuoraAccountDirectDebit(paymentData, firstName,lastName, purchaserIds, deliveryInstructions)
 
   def makeCreditCardPayment(
      paymentData: CreditCardData,
      currency: Currency,
      purchaserIds: PurchaserIdentifiers,
-     deliveryInstructions: Option[String]) = new CreditCardPayment(paymentData, currency, purchaserIds, deliveryInstructions )
+     deliveryInstructions: Option[String]) = new ZuoraAccountCreditCard(paymentData, currency, purchaserIds, deliveryInstructions )
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.424",
+    "com.gu" %% "membership-common" % "0.426-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.426-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.426",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.426",
+    "com.gu" %% "membership-common" % "0.427",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
Updates membership common and adds delivery instructions to the account object in zuora instead of the soldtocontact

there's an informal 1:1 rel here so this is okay


https://github.com/guardian/membership-common/pull/500