### PR TITLE
Send phone as normalisedphonenumber

### DIFF
--- a/app/model/SubscriptionData.scala
+++ b/app/model/SubscriptionData.scala
@@ -70,6 +70,12 @@ case class PaperData(
 
 object PersonalData {
   def fromIdUser(u: IdUser) = {
+    val phoneNumber: Option[String] = for {
+      identityPhoneNumber <- u.privateFields.flatMap(_.telephoneNumber)
+      countryCode <- identityPhoneNumber.countryCode
+      localNumber <- identityPhoneNumber.localNumber
+    } yield NormalisedTelephoneNumber(countryCode, localNumber).format
+
     val personalData = PersonalData(
       title = u.privateFields.flatMap(_.title).flatMap(Title.fromString),
       first = u.privateFields.flatMap(_.firstName).getOrElse(""),
@@ -77,7 +83,7 @@ object PersonalData {
       email = u.primaryEmailAddress,
       receiveGnmMarketing = u.statusFields.flatMap(_.receiveGnmMarketing).getOrElse(false),
       address = u.billingAddress,
-      telephoneNumber = u.privateFields.flatMap(_.telephoneNumber).flatMap(_.localNumber)
+      telephoneNumber = phoneNumber
     )
     personalData
   }

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -118,7 +118,7 @@ class CheckoutService(
         name = personalData, // TODO once we have gifting change this to the Giftee's name
         address = paperData.deliveryAddress,
         email = personalData.email, // TODO once we have gifting change this to the Giftee's email address
-        phone = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country).map(n => s"${n.countryCode}${n.localNumber}")
+        phone = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country)
       ))
       case _ => None
     }
@@ -273,7 +273,6 @@ class CheckoutService(
     val fulfilmentDate = fufilmentDelay.map(delay => now.plusDays(delay.getDays)).getOrElse(acquisitionDate)
     val firstPaymentDate = paymentDelay.map(delay => now.plusDays(delay.getDays)).getOrElse(fulfilmentDate)
 
-    val maybeTelephoneNumber = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country)
     Subscribe(
       account = acc,
       paymentMethod = Some(paymentMethod),
@@ -286,7 +285,7 @@ class CheckoutService(
       contractAcceptance = firstPaymentDate,
       supplierCode = requestData.supplierCode,
       ipCountry = requestData.ipCountry,
-      phone = maybeTelephoneNumber.map(_.format)
+      phone = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country)
     )
   }
 

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -118,7 +118,7 @@ class CheckoutService(
         name = personalData, // TODO once we have gifting change this to the Giftee's name
         address = paperData.deliveryAddress,
         email = personalData.email, // TODO once we have gifting change this to the Giftee's email address
-        phone = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country)
+        phone = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, paperData.deliveryAddress.country orElse personalData.address.country)
       ))
       case _ => None
     }

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -113,12 +113,18 @@ class CheckoutService(
     def emailError: SubNel[Unit] = EitherT(Future.successful(\/.left(NonEmptyList(CheckoutIdentityFailure("Email in use")))))
 
     val idMinimalUser = authenticatedUserOpt.map(_.user)
+
+    val telephoneNumber = subscriptionData.productData match {
+      case Left(paperData) => NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, paperData.deliveryAddress.country orElse personalData.address.country)
+      case _ => NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country)
+    }
+
     val soldToContact = subscriptionData.productData match {
       case Left(paperData) => Some(SoldToContact(
         name = personalData, // TODO once we have gifting change this to the Giftee's name
         address = paperData.deliveryAddress,
         email = personalData.email, // TODO once we have gifting change this to the Giftee's email address
-        phone = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, paperData.deliveryAddress.country orElse personalData.address.country)
+        phone = telephoneNumber
       ))
       case _ => None
     }
@@ -140,7 +146,7 @@ class CheckoutService(
       paymentMethod <- EitherT(attachPaymentMethodToStripeCustomer(payment, combinedIds))
       //prepare a sub to send to zuora
       fulfilmentDelay = CheckoutService.fulfilmentDelay(subscriptionData.productData)
-      initialSubscribe = createSubscribeRequest(personalData, soldToContact, requestData, plan, combinedIds, paymentMethod, payment.makeAccount, Some(fulfilmentDelay), Some(paymentDelay))
+      initialSubscribe = createSubscribeRequest(personalData, soldToContact, requestData, plan, combinedIds, paymentMethod, payment.makeAccount, Some(fulfilmentDelay), Some(paymentDelay), telephoneNumber)
       withTrial = processSixWeekIntroductoryPeriod(fulfilmentDelay, initialSubscribe)
       //handle promotion
       validPromotion = promoCode.flatMap {
@@ -266,7 +272,8 @@ class CheckoutService(
       paymentMethod: PaymentMethod,
       acc: Account,
       fufilmentDelay: Option[Days],
-      paymentDelay: Option[Days]
+      paymentDelay: Option[Days],
+      telephoneNumber: Option[NormalisedTelephoneNumber]
                                     ): Subscribe = {
 
     val acquisitionDate = now
@@ -285,7 +292,7 @@ class CheckoutService(
       contractAcceptance = firstPaymentDate,
       supplierCode = requestData.supplierCode,
       ipCountry = requestData.ipCountry,
-      phone = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country)
+      phone = telephoneNumber
     )
   }
 

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -273,6 +273,7 @@ class CheckoutService(
     val fulfilmentDate = fufilmentDelay.map(delay => now.plusDays(delay.getDays)).getOrElse(acquisitionDate)
     val firstPaymentDate = paymentDelay.map(delay => now.plusDays(delay.getDays)).getOrElse(fulfilmentDate)
 
+    val maybeTelephoneNumber = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country)
     Subscribe(
       account = acc,
       paymentMethod = Some(paymentMethod),
@@ -285,7 +286,7 @@ class CheckoutService(
       contractAcceptance = firstPaymentDate,
       supplierCode = requestData.supplierCode,
       ipCountry = requestData.ipCountry,
-      phone = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber,personalData.address.country)
+      phone = maybeTelephoneNumber.map(_.format)
     )
   }
 

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -11,7 +11,7 @@ import com.gu.memsub.promo.{Renewal, ValidPromotion, _}
 import com.gu.memsub.services.{GetSalesforceContactForSub, PromoService, PaymentService => CommonPaymentService}
 import com.gu.memsub.subsv2.SubscriptionPlan.WeeklyPlan
 import com.gu.memsub.subsv2.{Catalog, ReaderType, Subscription}
-import com.gu.memsub.{Address, BillingPeriod, Product}
+import com.gu.memsub.{Address, BillingPeriod, NormalisedTelephoneNumber, Product}
 import com.gu.salesforce.{Contact, ContactId}
 import com.gu.stripe.Stripe
 import com.gu.zuora.ZuoraRestService
@@ -118,7 +118,7 @@ class CheckoutService(
         name = personalData, // TODO once we have gifting change this to the Giftee's name
         address = paperData.deliveryAddress,
         email = personalData.email, // TODO once we have gifting change this to the Giftee's email address
-        phone = personalData.telephoneNumber
+        phone = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country).map(n => s"${n.countryCode}${n.localNumber}")
       ))
       case _ => None
     }
@@ -285,7 +285,7 @@ class CheckoutService(
       contractAcceptance = firstPaymentDate,
       supplierCode = requestData.supplierCode,
       ipCountry = requestData.ipCountry,
-      phone = personalData.telephoneNumber
+      phone = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber,personalData.address.country)
     )
   }
 

--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -44,7 +44,7 @@ object SalesforceService {
     Keys.MAILING_COUNTRY -> addr.country.fold(addr.countryName)(_.name)
   ) ++ paperData.flatMap(_.deliveryInstructions).fold(Json.obj())(instrs => Json.obj(
     Keys.DELIVERY_INSTRUCTIONS -> instrs
-  ))) ++ NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country).fold(Json.obj())(phone => Json.obj(Keys.TELEPHONE -> Seq(phone.countryCode, phone.localNumber).mkString("")))
+  ))) ++ NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country).fold(Json.obj())(phone => Json.obj(Keys.TELEPHONE -> phone.format))
 }
 
 case class SalesforceServiceError(s: String) extends Throwable {

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.428-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.428",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.428",
+    "com.gu" %% "membership-common" % "0.429-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.427",
+    "com.gu" %% "membership-common" % "0.428-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.429",
+    "com.gu" %% "membership-common" % "0.431",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.429-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.429",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
Previously, the phone number would get stored in Zuora as the string that the user has entered, and in salesforce as 44... and in identity as a case class that's like our NormalisedPhoneNumber. 

This brings salesforce and zuora into line, and they'll now save them as +44...

Depends on https://github.com/guardian/membership-common/pull/502