### PR TITLE
Updated the logic which decides which renewal plans to show for Guardian Weekly customers

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -4,6 +4,9 @@ import _root_.services.AuthenticationService._
 import _root_.services.TouchpointBackend
 import _root_.services.TouchpointBackend.Resolution
 import actions.CommonActions._
+import com.gu.i18n.Country.{UK, US}
+import com.gu.i18n.Currency
+import com.gu.i18n.Currency.{GBP, USD}
 import com.gu.memsub.Subscription.{Name, ProductRatePlanId}
 import com.gu.memsub.promo.{NormalisedPromoCode, PromoCode}
 import com.gu.memsub.subsv2.SubscriptionPlan._
@@ -14,9 +17,8 @@ import com.gu.subscriptions.suspendresume.SuspensionService.{BadZuoraJson, ErrNe
 import com.gu.zuora.ZuoraRestService
 import com.gu.zuora.soap.models.Queries.Contact
 import configuration.{Config, ProfileLinks}
-import controllers.ManageWeekly.error
 import forms._
-import logging.ContextLogging
+import logging.{Context, ContextLogging}
 import model.ContentSubscriptionPlanOps._
 import model.SubscriptionOps._
 import model.{Renewal, RenewalReads}
@@ -28,7 +30,7 @@ import utils.TestUsers.PreSigninTestCookie
 import views.html.account.thankYouRenew
 import views.support.Dates._
 import views.support.Pricing._
-import logging.Context
+
 import scala.concurrent.Future
 import scalaz.std.scalaFuture._
 import scalaz.syntax.std.option._
@@ -137,15 +139,15 @@ object ManageWeekly extends ContextLogging {
   import play.api.mvc.Results._
 
   // this sequencing concatenates errors if any, otherwise aggregates rights
-  def sequence[A](list: List[Either[String, A]]): Either[String, List[A]] = {
+  def sequence[A](list: List[\/[String, A]]): \/[String, List[A]] = {
     val errors = list collect {
-      case Left(x) => x
+      case -\/(x) => x
     }
     if (errors.nonEmpty)
-      Left(errors.mkString(", "))
+      -\/(errors.mkString(", "))
     else
-      Right(list collect {
-        case Right(x) => x
+      \/-(list collect {
+        case \/-(x) => x
       })
   }
 
@@ -177,49 +179,65 @@ object ManageWeekly extends ContextLogging {
     implicit val zuoraRest = new ZuoraRestService[Future]
     implicit val flash = request.flash
     implicit val subContext = weeklySubscription
-    if (weeklySubscription.readerType != ReaderType.Agent) {
-      EitherT(zuoraRest.getAccount(weeklySubscription.accountId)).map { account =>
-        account.billToContact.country.map { billToCountry =>
-          val catalog = tpBackend.catalogService.unsafeCatalog
-          val weeklyPlans = weeklySubscription.planToManage.product match {
-            case Product.WeeklyZoneA => catalog.weekly.zoneA.plans
-            case Product.WeeklyZoneB => catalog.weekly.zoneB.plans
-            case Product.WeeklyZoneC => catalog.weekly.zoneC.plans
-          }
 
-          val renewalPlans = weeklyPlans.filter(_.availableForRenewal)
+    def getRenewalPlans(account: ZuoraRestService.AccountSummary, currency: Currency) = {
+      val catalog = tpBackend.catalogService.unsafeCatalog
+      // Identifies customers who have been wrongly migrated in on a price-adjusted Zone B or C rate plan and are
+      // having the paper delivered to the UK or USA, and pay by GBP or USD respectively. These customers should
+      // be offered Zone A rate plans upon renewal.
+      def switchToZoneAIfNecessary = account.soldToContact.country.find { soldToCountry =>
+        (soldToCountry == UK && currency == GBP) || (soldToCountry == US && currency == USD)
+      }.map(_ => catalog.weekly.zoneA.plans)
 
-          val currency = account.currency.toRight(s"could not deserialise currency for account ${account.id}")
-          val weeklyPlanInfo = currency.right.flatMap { existingCurrency =>
-            sequence(renewalPlans.map { plan =>
-              val price = plan.charges.price.getPrice(existingCurrency).toRight(s"could not find price in $existingCurrency for plan ${plan.id} ${plan.name}").right
-              price.map(price => WeeklyPlanInfo(plan.id, plan.charges.prettyPricing(price.currency)))
-            }).right.map(r => (existingCurrency, r))
-          }
-          weeklyPlanInfo match {
-            case Left(errorMessage) =>
-              error(s"couldn't get new rate/currency for renewal: $errorMessage")
-              Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but can't renew it via the web, please contact customer services for help.")))
-            case Right((existingCurrency, weeklyPlanInfoList)) =>
-              Ok(weeklySubscription.asRenewable.map { renewableSub =>
-                info(s"sub is renewable - showing weeklyRenew page")
-                views.html.account.weeklyRenew(renewableSub, account.soldToContact, account.billToContact.email, billToCountry, weeklyPlanInfoList, existingCurrency, promoCode)
-              } getOrElse {
-                info(s"sub is not renewable - showing weeklyDetails page")
-                views.html.account.weeklyDetails(weeklySubscription, billingSchedule, account.soldToContact)
-              })
-          }
-        }.getOrElse {
-          error(s"no valid bill to country for account")
-          Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but can't manage it via the web, please contact customer services for help.")))
-        }
-      }.run.map(_.fold({ errorMessage =>
-        error(s"problem getting account: $errorMessage")
-        Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but can't manage it via the web, please contact customer services for help.")))
-      }, identity))
-    } else {
+      // Determine the rate plans to offer for renewal based on what product the customer has currently
+      def usePlansBasedOnExistingProduct = weeklySubscription.planToManage.product match {
+        case Product.WeeklyZoneA => catalog.weekly.zoneA.plans
+        case Product.WeeklyZoneB => catalog.weekly.zoneB.plans
+        case Product.WeeklyZoneC => catalog.weekly.zoneC.plans
+      }
+
+      val weeklyPlans = switchToZoneAIfNecessary getOrElse usePlansBasedOnExistingProduct
+
+      val renewalPlans = weeklyPlans.filter(_.availableForRenewal)
+
+      sequence(renewalPlans.map { plan =>
+        val price = plan.charges.price.getPrice(currency).toRightDisjunction(s"could not find price in $currency for plan ${plan.id} ${plan.name}")
+        price.map(price => WeeklyPlanInfo(plan.id, plan.charges.prettyPricing(price.currency)))
+      })
+    }
+
+    def choosePage(account: ZuoraRestService.AccountSummary) = {
+      val renewPageResult = for {
+        billToCountry <-  account.billToContact.country.toRightDisjunction(s"no valid bill to country for account ${account.id}")
+        currency <- account.currency.toRightDisjunction(s"couldn't get new rate/currency for renewal ${account.id}")
+        weeklyPlanInfo <- getRenewalPlans(account, currency).leftMap(errorMessage => s"couldn't get new rate: $errorMessage")
+      } yield {
+        Ok(weeklySubscription.asRenewable.map { renewableSub =>
+          info(s"sub is renewable - showing weeklyRenew page")
+          views.html.account.weeklyRenew(renewableSub, account.soldToContact, account.billToContact.email, billToCountry, weeklyPlanInfo, currency, promoCode)
+        } getOrElse {
+          info(s"sub is not renewable - showing weeklyDetails page")
+          views.html.account.weeklyDetails(weeklySubscription, billingSchedule, account.soldToContact)
+        })
+      }
+      Future.successful(renewPageResult)
+    }
+
+    def maybePageToShow = {
+      (for {
+        account <- EitherT(zuoraRest.getAccount(weeklySubscription.accountId))
+        page <- EitherT(choosePage(account))
+      } yield page).run
+    }
+
+    if (weeklySubscription.readerType == ReaderType.Agent) {
       info(s"don't support agents, can't manage sub")
       Future.successful(Ok(views.html.account.details(None, promoCode, Some("You subscribe via an agent, at present you can't manage it via the web, please contact customer services for help.")))) // don't support gifts (yet) as they have related contacts in salesforce of unknown structure
+    } else {
+      maybePageToShow.map(_.leftMap(errorMessage => {
+        error(s"problem getting account: $errorMessage")
+        Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but it can't be managed via the web, please contact customer services for help.")))
+      }).fold(identity, identity))
     }
   }
 


### PR DESCRIPTION
Updated the logic which decides which renewal plans to show to Guardian Weekly customers. The logic now identifies customers who have been wrongly migrated in on a price-adjusted Zone B or C rate plan and are having the paper delivered to the UK or USA, and pay by GBP or USD respectively. These customers should be offered Zone A rate plans upon renewal.

I also did a lot of opportunistic refactoring to stop the repeat of the 'please contact customer services' error message, and to separate the rate plan choosing from the page-choosing, by splitting into 2 separate functions: choosePage and getRenewalPlans respectively. Thanks for your help with this @johnduffell!

See: https://trello.com/c/8IM9VB43/244-billing-query-case-00240730-affects-800-other-customers

cc @AWare @lmath @pvighi 