### PR TITLE
Move the delivery instructions back to the SoldTo contact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.431",
+    "com.gu" %% "membership-common" % "0.438",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
Moved the delivery instructions back to the SoldTo contact now that we can definitely sync down from Salesforce into that object.

See: https://github.com/guardian/membership-common/pull/510

cc @AWare @johnduffell @pvighi @lmath @jacobwinch 