### PR TITLE
When suspending delivery, ignore broken (backwards) holidays

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.438",
+    "com.gu" %% "membership-common" % "0.439",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
Just bump membership common- it seems to work with a test sub in uat A-S00070317

https://github.com/guardian/membership-common/pull/513

@jacobwinch 