### PR TITLE
Added a new routes with the new promocdes for test4

### DIFF
--- a/app/controllers/Offers.scala
+++ b/app/controllers/Offers.scala
@@ -14,6 +14,10 @@ object Offers extends Controller {
     Redirect(routes.Offers.offersPage(digitalEdition.id).url, request.queryString, SEE_OTHER)
   }
 
+  def offersTestUKPage = CachedAction {
+    Ok(views.html.offers.offers_test_uk())
+  }
+
   def offersPage(edition: String) = CachedAction {
     getById(edition) map {
       case UK => Ok(views.html.offers.offers_uk())

--- a/app/views/offers/offers_test_uk.scala.html
+++ b/app/views/offers/offers_test_uk.scala.html
@@ -1,0 +1,75 @@
+@import model.DigitalEdition.UK
+@import views.support.DigitalEdition._
+@()
+
+@main(
+    "Subscriptions | The Guardian",
+    Some("Subscribe to The Guardian & Observer. Support our independent, award-winning journalism."),
+    edition = UK) {
+
+    <main class="page-container gs-container">
+        @fragments.page.header("Subscription offers")
+        <div class="row row--items-3">
+            <div class="row__item block block--primary block--digital">
+                <h2 class="block__title">Digital</h2>
+                <div class="block__info">
+                    <ul class="block__list">
+                        <li class="block__list-item">14-day free trial of our digital pack</li>
+                        @UK.digitalPackSaving.map { saving => <li class="block__list-item"><strong>Save up to @saving% on the app store price</strong></li> }
+                        <li class="block__list-item">Access to the Daily Edition and the advert-free Guardian App Premium Tier</li>
+                        <li class="block__list-item">All supplements Monday to Sunday</li>
+                        <li class="block__list-item">Available on Apple, Android and Kindle Fire</li>
+                        <li class="block__list-item">Use on up to 10 devices</li>
+                    </ul>
+                </div>
+                <div class="block__footer">
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("DJ6P8DA5J", UK.countryGroup.defaultCountry).url">Subscribe now</a>
+                </div>
+            </div>
+            <div class="row__item block block--primary block--paper-digital">
+                <h2 class="block__title">Paper + digital</h2>
+                <div class="block__info">
+                    <ul class="block__list">
+                        <li class="block__list-item">Year-round savings of up to 36% off the retail price</li>
+                        <li class="block__list-item">Pick the package you want: Everyday+, Sixday+, Weekend+ and The Observer+</li>
+                        <li class="block__list-item">All supplements Monday to Sunday</li>
+                        <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
+                    </ul>
+                </div>
+                <div class="block__footer">
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("NJ6P8BJHF", None).url">Subscribe now</a>
+                </div>
+            </div>
+            <div class="row__item block block--primary block--paper">
+                <h2 class="block__title">Paper</h2>
+                <div class="block__info">
+                    <ul class="block__list">
+                        <li class="block__list-item">Year-round savings of up to 31% off the retail price</li>
+                        <li class="block__list-item">Pick the package you want: Everyday, Sixday, Weekend and The Observer</li>
+                        <li class="block__list-item">All supplements Monday to Sunday</li>
+                        <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
+                    </ul>
+                </div>
+                <div class="block__footer">
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("NJ6P8AAX8", None).url">Subscribe now</a>
+                </div>
+            </div>
+        </div>
+        <div class="row row--items-1">
+            <div class="row__item block block--primary block--weekly">
+                <h2 class="block__title">Subscribe to the Guardian Weekly</h2>
+                <div class="block__info">
+                    <ul class="block__list">
+                        <li class="block__list-item">A selection of international editorial from the Guardian, Observer and Washington Post</li>
+                        <li class="block__list-item">A unique blend of international news, politics, culture and comment</li>
+                        <li class="block__list-item">Save on the retail price</li>
+                        <li class="block__list-item">Free delivery to your door, wherever you are in the world</li>
+                    </ul>
+                </div>
+                <div class="block__footer">
+                    <a class="button button--large button--primary" href="@routes.PromoLandingPage.render("WAL41X", UK.countryGroup.defaultCountry).url">Subscribe now</a>
+                </div>
+            </div>
+        </div>
+    </main>
+}

--- a/conf/routes
+++ b/conf/routes
@@ -83,6 +83,7 @@ GET         /Voucher                         controllers.Homepage.index
 GET         /offers                          controllers.Offers.offers
 GET         /:edition/offers                 controllers.Offers.offersPage(edition: String)
 
+# Temporary URL that will be gone after S&C's test 4 is finished
 GET         /offersUK                        controllers.Offers.offersTestUKPage
 
 # Editions hommepage or 404

--- a/conf/routes
+++ b/conf/routes
@@ -83,5 +83,7 @@ GET         /Voucher                         controllers.Homepage.index
 GET         /offers                          controllers.Offers.offers
 GET         /:edition/offers                 controllers.Offers.offersPage(edition: String)
 
+GET         /offersUK                        controllers.Offers.offersTestUKPage
+
 # Editions hommepage or 404
 GET         /:edition                        controllers.Homepage.landingPage(edition: String)


### PR DESCRIPTION
This PR introduces a new route for a new landing page with the promo codes for control variant of simple's test 4.

New path `/offersUK`

## Promocodes:

|Product | Promo code|
|---------|------------|
|Digital |DJ6P8DA5J |
|Paper |NJ6P8AAX8 |
|Paper + Digital | NJ6P8BJHF|

## Related PR
https://github.com/guardian/frontend/pull/17650

## Screenshots
![subsscreenshot](https://user-images.githubusercontent.com/825398/29661669-b157f1cc-88bc-11e7-8462-4f154b8a3087.png)
