### PR TITLE
Strip quotation marks from delivery instructions

### DIFF
--- a/app/model/SubscriptionData.scala
+++ b/app/model/SubscriptionData.scala
@@ -66,7 +66,9 @@ case class PaperData(
   deliveryAddress: Address,
   deliveryInstructions: Option[String],
   plan: CatalogPlan.Paper
-)
+) {
+  val sanitizedDeliveryInstructions = deliveryInstructions.map(instructions => instructions.replaceAll("\"", ""))
+}
 
 object PersonalData {
   def fromIdUser(u: IdUser) = {

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -124,7 +124,7 @@ class CheckoutService(
         address = paperData.deliveryAddress,
         email = personalData.email, // TODO once we have gifting change this to the Giftee's email address
         phone = telephoneNumber,
-        deliveryInstructions = paperData.deliveryInstructions
+        deliveryInstructions = paperData.sanitizedDeliveryInstructions
       ))
       case _ => None
     }

--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -42,7 +42,7 @@ object SalesforceService {
     Keys.MAILING_POSTCODE -> addr.postCode,
     Keys.MAILING_STATE -> addr.countyOrState,
     Keys.MAILING_COUNTRY -> addr.country.fold(addr.countryName)(_.name)
-  ) ++ paperData.flatMap(_.deliveryInstructions).fold(Json.obj())(instrs => Json.obj(
+  ) ++ paperData.flatMap(_.sanitizedDeliveryInstructions).fold(Json.obj())(instrs => Json.obj(
     Keys.DELIVERY_INSTRUCTIONS -> instrs
   ))) ++ NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country).fold(Json.obj())(phone => Json.obj(Keys.TELEPHONE -> phone.format))
 }


### PR DESCRIPTION
Every now and then somebody includes a " character in their Delivery Instructions. This breaks the csv parser I'm using in fulfilment lookup. Presumably it could also cause problems for the fulfilment-lambdas project.

We could spend time adding client-side validation, and preventing users from doing this, but I think stripping these characters out before we write them into Zuora/Salesforce is sufficient (and also probably less frustrating for the user completing the form).

We need to do something similar in Salesforce to prevent CEX from including these characters when manually updating address details.