### PR TITLE
Use CODE fulfilment API for test users running against PROD app

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -128,8 +128,7 @@ object Config {
   val getAddressIOApiUrl = config.getString("get-address-io-api.url")
   val getAddressIOApiKey = config.getString("get-address-io-api.key")
 
-  val fulfilmentLookupApiKey = config.getString("fulfilment-lookup-api.key")
-
-  val fulfilmentLookupApiUrl = config.getString("fulfilment-lookup-api.url")
+  def fulfilmentLookupApiKey(env: String) = config.getString(s"fulfilment-lookup-api.$env.key")
+  def fulfilmentLookupApiUrl(env: String) = config.getString(s"fulfilment-lookup-api.$env.url")
 
 }

--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -139,16 +139,16 @@ object ManageDelivery extends ContextLogging {
   }
 
   def fulfilmentLookup(implicit request: Request[ReportDeliveryProblem], touchpoint: TouchpointBackend.Resolution): Future[Result] = {
-    implicit val tpBackend = touchpoint.backend
+    val env = touchpoint.backend.environmentName
     val deliveryProblem = request.body
-    logger.info(s"Attempting to raise a delivery issue: $deliveryProblem")
-    val futureLookupAttempt = FulfilmentLookupService.lookupSubscription(tpBackend.environmentName, deliveryProblem)
+    logger.info(s"[${env}] Attempting to raise a delivery issue: $deliveryProblem")
+    val futureLookupAttempt = FulfilmentLookupService.lookupSubscription(env, deliveryProblem)
     futureLookupAttempt.map { lookupAttempt => lookupAttempt match {
         case \/-(lookup) =>
-          logger.info(s"Successfully raised a delivery issue for $deliveryProblem")
+          logger.info(s"[${env}] Successfully raised a delivery issue for $deliveryProblem")
           Ok(views.html.account.reportDeliveryProblemSuccess(lookup, deliveryProblem.issueDate))
         case -\/(message) =>
-          logger.error(s"Failed to raise a delivery issue for ${deliveryProblem.subscriptionName}: $message")
+          logger.error(s"[${env}] Failed to raise a delivery issue for ${deliveryProblem.subscriptionName}: $message")
           Ok(views.html.account.reportDeliveryProblemFailure())
       }
     }

--- a/app/services/FulfilmentLookupService.scala
+++ b/app/services/FulfilmentLookupService.scala
@@ -26,20 +26,20 @@ object FulfilmentLookupService extends StrictLogging {
     )
     val body = RequestBody.create(MediaType.parse("application/json"), json.toString())
     new okhttp3.Request.Builder()
-      .addHeader("x-api-key", Config.fulfilmentLookupApiKey)
-      .url(s"${Config.fulfilmentLookupApiUrl}/fulfilment-lookup")
+      .addHeader("x-api-key", Config.fulfilmentLookupApiKey(environment))
+      .url(s"${Config.fulfilmentLookupApiUrl(environment)}/fulfilment-lookup")
       .post(body)
       .build()
   }
 
-  def lookupSubscription(environment: String, deliveryProblem: ReportDeliveryProblem): Future[String \/ FulfilmentLookup] = {
-    val request = buildRequest(environment, deliveryProblem)
+  def lookupSubscription(env: String, deliveryProblem: ReportDeliveryProblem): Future[String \/ FulfilmentLookup] = {
+    val request = buildRequest(env, deliveryProblem)
     val futureResponse = httpClient(request)
     futureResponse.map { response =>
       val responseBody = response.body.string
       response.body.close
       if (response.isSuccessful) {
-        logger.info(s"Successfully performed lookup for ${deliveryProblem.subscriptionName}")
+        logger.info(s"[${env}] Successfully performed lookup for ${deliveryProblem.subscriptionName}")
         val jsonBody = Json.parse(responseBody)
         jsonBody.validate[FulfilmentLookup] match {
           case validLookup: JsSuccess[FulfilmentLookup] =>

--- a/app/services/FulfilmentLookupService.scala
+++ b/app/services/FulfilmentLookupService.scala
@@ -16,7 +16,7 @@ object FulfilmentLookupService extends StrictLogging {
 
   val httpClient = futureRunner
 
-  def buildRequest(environment: String, deliveryProblem: ReportDeliveryProblem): okhttp3.Request = {
+  def buildRequest(env: String, deliveryProblem: ReportDeliveryProblem): okhttp3.Request = {
     val apiDateFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
     val formattedDate = apiDateFormatter.print(deliveryProblem.issueDate)
     val json = Json.obj(
@@ -26,8 +26,8 @@ object FulfilmentLookupService extends StrictLogging {
     )
     val body = RequestBody.create(MediaType.parse("application/json"), json.toString())
     new okhttp3.Request.Builder()
-      .addHeader("x-api-key", Config.fulfilmentLookupApiKey(environment))
-      .url(s"${Config.fulfilmentLookupApiUrl(environment)}/fulfilment-lookup")
+      .addHeader("x-api-key", Config.fulfilmentLookupApiKey(env))
+      .url(s"${Config.fulfilmentLookupApiUrl(env)}/fulfilment-lookup")
       .post(body)
       .build()
   }


### PR DESCRIPTION
After shipping https://github.com/guardian/subscriptions-frontend/pull/984, I wanted to perform an end-to-end test in Production. But I'd forgotten to do this...

Note that this requires an update for the private PROD config file.