### PR TITLE
membership-common to 0.471

### DIFF
--- a/app/services/PaymentService.scala
+++ b/app/services/PaymentService.scala
@@ -3,6 +3,8 @@ import com.gu.i18n.Country.UK
 import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{CountryGroup, Currency}
 import com.gu.stripe.StripeService
+import com.gu.zuora.api.GoCardless
+import com.gu.zuora.api.StripeUKMembershipGateway
 import com.gu.zuora.soap.models.Commands._
 import model._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -32,7 +34,7 @@ class PaymentService(val stripeService: StripeService) {
   }
 
   class ZuoraAccountCreditCard(val paymentData: CreditCardData, val currency: Currency, val purchaserIds: PurchaserIdentifiers) extends AccountAndPayment {
-    override def makeAccount = Account(purchaserIds.contactId, identityIdForAccount(purchaserIds), currency, autopay = true, Stripe)
+    override def makeAccount = Account(purchaserIds.contactId, identityIdForAccount(purchaserIds), currency, autopay = true, StripeUKMembershipGateway)
 
     override def makePaymentMethod = {
       stripeService.Customer.create(description = purchaserIds.description, card = paymentData.stripeToken)

--- a/app/services/TouchpointBackend.scala
+++ b/app/services/TouchpointBackend.scala
@@ -80,7 +80,7 @@ object TouchpointBackend {
       val map = this.catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.mkString}"); Map()}, _.map))
       lazy val subscriptionService = new subsv2.services.SubscriptionService[Future](newProductIds, map, simpleRestClient, zuoraService.getAccountIds)
       lazy val paymentService = new PaymentService(_stripeService)
-      lazy val commonPaymentService = new CommonPaymentService(_stripeService, zuoraService, this.catalogService.unsafeCatalog.productMap)
+      lazy val commonPaymentService = new CommonPaymentService(zuoraService, this.catalogService.unsafeCatalog.productMap)
       lazy val zuoraProperties = config.zuoraProperties
       lazy val promoService = new PromoService(promoCollection, new Discounter(this.discountRatePlanIds))
       lazy val promoCollection = new DynamoPromoCollection(this.promoStorage, 15.seconds)

--- a/app/touchpoint/TouchpointBackendConfig.scala
+++ b/app/touchpoint/TouchpointBackendConfig.scala
@@ -1,8 +1,9 @@
 package touchpoint
 
+import com.gu.i18n.Country
 import com.gu.salesforce.SalesforceConfig
 import com.gu.stripe.StripeApiConfig
-import com.gu.zuora.{ZuoraRestConfig, ZuoraSoapConfig, ZuoraApiConfig}
+import com.gu.zuora.{ZuoraApiConfig, ZuoraRestConfig, ZuoraSoapConfig}
 import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.Days
 
@@ -48,7 +49,7 @@ object TouchpointBackendConfig extends LazyLogging {
       ZuoraApiConfig.soap(envBackendConf, environmentName),
       ZuoraApiConfig.rest(envBackendConf, environmentName),
       ZuoraProperties.from(envBackendConf, environmentName),
-      StripeApiConfig.from(envBackendConf, environmentName)
+      StripeApiConfig.from(envBackendConf, environmentName, Country.UK)
     )
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2,
-    "com.gu" %% "membership-common" % "0.447",
+    "com.gu" %% "membership-common" % "0.471",
     "com.gu" %% "memsub-common-play-auth" % "0.8",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
[PR 530](https://github.com/guardian/membership-common/pull/530) enabled support for multiple stripe accounts.

This PR bumps the membership common version and assumes the UK stripe account in each case (current behaviour).

Selecting the appropriate stripe account for Australian customers to follow in next PR. 

cc @paulbrown1982 @jacobwinch @johnduffell @AWare @pvighi 