### PR TITLE
Make warnings fatal and fix warnings

### DIFF
--- a/app/model/exactTarget/DataExtensionRow.scala
+++ b/app/model/exactTarget/DataExtensionRow.scala
@@ -80,6 +80,7 @@ object DigipackWelcome1DataExtensionRow extends LazyLogging {
         "MandateID" -> mandateId
       )
       case _: PaymentCard => Seq("Default payment method" -> card)
+      case _ => Seq()
     }
 
     val promotionFields = promotionDescription.map(d => "Promotion description" -> trimPromotionDescription(d))
@@ -164,6 +165,7 @@ object PaperFieldsGenerator {
         "mandate_id" -> mandateId
       )
       case _: PaymentCard => Seq("payment_method" -> card)
+      case _ => Seq()
     }
 
     val promotionFields = promotionDescription.map(d => "promotion_details" -> trimPromotionDescription(d))

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -7,7 +7,6 @@ import com.gu.memsub._
 import com.gu.memsub.images.{ResponsiveImage, ResponsiveImageGenerator, ResponsiveImageGroup}
 import com.gu.memsub.subsv2.{CatalogPlan, Plan}
 import com.netaporter.uri.dsl._
-import model.DigitalEdition
 import model.DigitalEdition.{AU, UK, US}
 
 import scala.reflect.internal.util.StringOps
@@ -117,7 +116,7 @@ object PlanOps {
         case _ => "https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
       }
 
-    def phone(digitalEdition: DigitalEdition): String = product match {
+    def phone(digitalEdition: model.DigitalEdition): String = product match {
       case _: Product.Weekly if digitalEdition == US => {"1-844-632-2010 (toll free); 917-900-4663 (direct line)"}
       case _: Product.Weekly if digitalEdition == AU => {"1800 773 766 (toll free within Australia)"}
       case _ => {"+44 (0) 330 333 6767. Open BST 8am to 8pm, Monday to Sunday"}

--- a/app/views/support/Pricing.scala
+++ b/app/views/support/Pricing.scala
@@ -61,6 +61,7 @@ object Pricing {
               "for 1 year"
             }
           case OneYear => s"for 1 year only"
+          case _ => ""
         }
         if (plan.billingPeriod == OneYear) { s"${discountAmount.pretty} $forDuration" } else {
           s"${discountAmount.pretty} $forDuration, then standard rate (${originalAmount.pretty} every ${plan.billingPeriod.noun})"

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val root = (project in file(".")).enablePlugins(
   ))
 
 scalaVersion := "2.11.8"
-scalacOptions ++= Seq("-feature")
+scalacOptions ++= Seq("-feature", "-Xfatal-warnings")
 
 val scalatestVersion = "3.0.0"
 


### PR DESCRIPTION
#990 caused 500 errors in production because of a non-exhaustive pattern match. If warnings were actually treated as errors, this issue would have failed the build and been fixed before making it to production.

Would you be happy to enable this setting on subscriptions-frontend?