### PR TITLE
Bump referrer acquisition data version and add support for abTests 

### DIFF
--- a/app/model/SubscriptionAcquisitionComponents.scala
+++ b/app/model/SubscriptionAcquisitionComponents.scala
@@ -106,6 +106,14 @@ object SubscriptionAcquisitionComponents {
       printOptions
     }
 
+    def getAbTests(referrerAcquisitionData: Option[ReferrerAcquisitionData]): Option[AbTestInfo] =
+     referrerAcquisitionData.flatMap { r =>
+       r.abTests match {
+         case Some(tests) => Some(AbTestInfo(tests))
+         case None => r.abTest.map(abTest => AbTestInfo(Set(abTest)))
+       }
+     }
+
     override def buildAcquisition(components: SubscriptionAcquisitionComponents): Either[String, Acquisition] = {
       import components._
       import components.subscribeRequest.productData
@@ -180,7 +188,7 @@ object SubscriptionAcquisitionComponents {
           },
 
           campaignCode = referrerAcquisitionData.flatMap(_.campaignCode.map(Set(_))),
-          abTests = referrerAcquisitionData.flatMap(_.abTest.map(ab => AbTestInfo(Set(ab)))),
+          abTests = getAbTests(referrerAcquisitionData),
           referrerPageViewId = referrerAcquisitionData.flatMap(_.referrerPageviewId),
           referrerUrl = referrerAcquisitionData.flatMap(_.referrerUrl),
           componentId = referrerAcquisitionData.flatMap(_.componentId),

--- a/app/model/SubscriptionAcquisitionComponents.scala
+++ b/app/model/SubscriptionAcquisitionComponents.scala
@@ -107,7 +107,7 @@ object SubscriptionAcquisitionComponents {
     }
 
     def getAbTests(referrerAcquisitionData: Option[ReferrerAcquisitionData]): Option[AbTestInfo] =
-     referrerAcquisitionData.flatMap { r =>
+      referrerAcquisitionData.flatMap { r =>
        r.abTests match {
          case Some(tests) => Some(AbTestInfo(tests))
          case None => r.abTest.map(abTest => AbTestInfo(Set(abTest)))

--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ libraryDependencies ++= Seq(
     "com.gu" % "kinesis-logback-appender" % "1.4.0",
     "net.logstash.logback" % "logstash-logback-encoder" % "4.9",
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.8.7",
-    "com.gu" %% "acquisition-event-producer" % "2.0.2"
+    "com.gu" %% "acquisition-event-producer" % "2.0.3-SNAPSHOT"
 )
 
 testOptions in Test ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ libraryDependencies ++= Seq(
     "com.gu" % "kinesis-logback-appender" % "1.4.0",
     "net.logstash.logback" % "logstash-logback-encoder" % "4.9",
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.8.7",
-    "com.gu" %% "acquisition-event-producer" % "2.0.3-SNAPSHOT"
+    "com.gu" %% "acquisition-event-producer" % "2.0.3"
 )
 
 testOptions in Test ++= Seq(


### PR DESCRIPTION
The new version of `acquisition-event-model` allows multiple AB tests to be passed through. This PR 
allows subs frontend to be able to deal with that, whilst also allowing backwards compatibility with the old, now deprecated, `abTest` field. 