### PR TITLE
Remove the GBP currency override switcher for Australia customers

### DIFF
--- a/app/model/PaymentValidation.scala
+++ b/app/model/PaymentValidation.scala
@@ -1,5 +1,6 @@
 package model
 
+import com.gu.i18n.Country.{Australia, UK, US}
 import com.gu.i18n.Currency._
 import com.gu.i18n.{Country, Currency}
 import com.gu.memsub.Product
@@ -7,10 +8,13 @@ import com.gu.memsub.subsv2.CatalogPlan
 import views.support.CountryWithCurrency
 
 object PaymentValidation {
+
+  private val nonOverridableCountries = Seq(UK, US, Australia)
+
   def validateDirectDebit(subscriptionData: SubscriptionData): Boolean = {
     subscriptionData.paymentData match {
       case _: DirectDebitData =>
-        subscriptionData.personalData.address.country.contains(Country.UK) && subscriptionData.currency == GBP
+        subscriptionData.personalData.address.country.contains(UK) && subscriptionData.currency == GBP
       case _ => true
     }
   }
@@ -18,7 +22,7 @@ object PaymentValidation {
   def validateCurrency(currency: Currency, settings: CountryWithCurrency, plan: CatalogPlan.ContentSubscription): Boolean = {
 
     def isValidCurrencyOverride = plan.product match {
-      case Product.WeeklyZoneC => currency == GBP && settings.country != Country.US && settings.country != Country.UK
+      case Product.WeeklyZoneC => currency == GBP && !nonOverridableCountries.contains(settings.country)
       case _ => false
     }
 

--- a/app/model/PaymentValidation.scala
+++ b/app/model/PaymentValidation.scala
@@ -9,7 +9,7 @@ import views.support.CountryWithCurrency
 
 object PaymentValidation {
 
-  private val nonOverridableCountries = Seq(UK, US, Australia)
+  private val nonOverridableCountries = Set(UK, US, Australia)
 
   def validateDirectDebit(subscriptionData: SubscriptionData): Boolean = {
     subscriptionData.paymentData match {

--- a/assets/javascripts/modules/checkout/fieldSwitcher.js
+++ b/assets/javascripts/modules/checkout/fieldSwitcher.js
@@ -112,7 +112,7 @@ define([
 
     var redrawCurrencyOverride = function (selectedCurrency) {
         var currencySelector = $('.js-checkout-currency-override');
-        if (selectedCurrency === 'GBP') {
+        if (selectedCurrency === 'GBP' || selectedCurrency === 'AUD') {
             formElements.$CURRENCY_OVERRIDE_CHECKBOX.addClass('js-ignore');
             currencySelector.hide();
         } else {


### PR DESCRIPTION
Remove the currency override switcher when customer is paying in AUD (equivalent to buying a GW to be delivered to AU, and so transacting with the AU Stripe card).

This will save customers who want to pay in GBP being charged a transaction fee by banking with GNM's AU Stripe account.

cc @jacobwinch @pvighi 