### PR TITLE
Send platform as Membership for acquisition events

### DIFF
--- a/app/model/SubscriptionAcquisitionComponents.scala
+++ b/app/model/SubscriptionAcquisitionComponents.scala
@@ -186,7 +186,7 @@ object SubscriptionAcquisitionComponents {
           componentId = referrerAcquisitionData.flatMap(_.componentId),
           componentTypeV2 = referrerAcquisitionData.flatMap(_.componentType),
           source = referrerAcquisitionData.flatMap(_.source),
-          platform = Some(Platform.Subscribe),
+          platform = Some(Platform.Membership),
           promoCode = promoCode.map(_.get),
           labels = if (isSixForSix) Some(Set("guardian-weekly-six-for-six")) else None
         )


### PR DESCRIPTION
We can see subscription acquisition events in elasticsearch, but they have platform set to `EnumUnknownPlatform-1`. The events are also not appearing in the data lake, not even in the `raw` schema.

I can't figure out exactly what's going on but it seems likely that it's to do with one or both of these:
- `Subscribe` is a new enum value for platform - some app might not be aware of it for some reason (although I redeployed them all)
- The pageview platform is `Membership` and always has been for subs, whereas the acquisition platformis `Subscribe` - maybe this is problematic

Setting the platform to `Membership` would resolve both if these, so if my theory's correct this will fix the problem.

It isn't ideal that we won't know the exact cause - ideally we'd find the root of the problem and fix it, possibly by changing subs to send `Subscribe` as its pageview platform too.

But because this is blocking us running revenue-generating tests I'd like to try this and we can return to this issue at a later date. It's not really a problem if subscription acquisitions have the platform `Membership` since there's no other site that can sign people up to subscriptions right now, so we don't lose any information