### PR TITLE
Fixed a bug where customers in Australia could not renew their one-off Guardian Weekly subscriptions

### DIFF
--- a/app/services/TouchpointBackend.scala
+++ b/app/services/TouchpointBackend.scala
@@ -53,7 +53,6 @@ trait TouchpointBackend {
   def subsForm: SubscriptionsForm
   def exactTargetService: ExactTargetService
   def checkoutService: CheckoutService
-  def invoiceTemplateIdsByCountry: Map[Country, InvoiceTemplate]
   implicit def simpleRestClient: SimpleClient[Future]
 }
 
@@ -89,8 +88,7 @@ object TouchpointBackend {
       lazy val subscriptionService = new subsv2.services.SubscriptionService[Future](newProductIds, map, simpleRestClient, zuoraService.getAccountIds)
       lazy val stripeUKMembershipService = new StripeService(config.stripeUK, loggingRunner(stripeUKMetrics))
       lazy val stripeAUMembershipService = new StripeService(config.stripeAU, loggingRunner(stripeAUMetrics))
-      lazy val invoiceTemplateIdsByCountry: Map[Country, InvoiceTemplate] = this.zuoraProperties.invoiceTemplates.map(it => it.country -> it).toMap
-      lazy val paymentService = new PaymentService(this.stripeUKMembershipService, this.stripeAUMembershipService, invoiceTemplateIdsByCountry)
+      lazy val paymentService = new PaymentService(this.stripeUKMembershipService, this.stripeAUMembershipService, this.zuoraProperties.invoiceTemplates.map(it => it.country -> it).toMap)
       lazy val commonPaymentService = new CommonPaymentService(zuoraService, this.catalogService.unsafeCatalog.productMap)
       lazy val zuoraProperties: ZuoraProperties = config.zuoraProperties
       lazy val promoService = new PromoService(promoCollection, new Discounter(this.discountRatePlanIds))
@@ -100,7 +98,7 @@ object TouchpointBackend {
       lazy val suspensionService = new SuspensionService[Future](Config.holidayRatePlanIds(config.environmentName), simpleRestClient)
       lazy val subsForm = new forms.SubscriptionsForm(this.catalogService.unsafeCatalog)
       lazy val exactTargetService: ExactTargetService = new ExactTargetService(this.subscriptionService, this.commonPaymentService, this.zuoraService, this.salesforceService)
-      lazy val checkoutService: CheckoutService = new CheckoutService(IdentityService, this.salesforceService, this.paymentService, this.catalogService.unsafeCatalog, this.zuoraService, this.exactTargetService, this.zuoraProperties, this.promoService, this.discountRatePlanIds, this.commonPaymentService, this.invoiceTemplateIdsByCountry)
+      lazy val checkoutService: CheckoutService = new CheckoutService(IdentityService, this.salesforceService, this.paymentService, this.catalogService.unsafeCatalog, this.zuoraService, this.exactTargetService, this.zuoraProperties, this.promoService, this.discountRatePlanIds, this.commonPaymentService)
     }
   }
 

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -1,8 +1,6 @@
 @import configuration.Links
-@import com.gu.memsub.BillingSchedule
 @import com.gu.memsub.subsv2.Subscription
 @import model.DigitalEdition.UK
-@import com.gu.salesforce.Contact
 @import views.support.Dates.prettyDate
 @import com.gu.i18n.Country
 @import controllers.ManageWeekly.WeeklyPlanInfo
@@ -13,13 +11,20 @@
 @import com.gu.i18n.Currency
 @import com.gu.memsub.promo.PromoCode
 @import org.joda.time.LocalDate.now
-@import com.gu.memsub.subsv2.ReaderType
 @import com.gu.zuora.ZuoraRestService.SoldToContact
 @(
     subscription: Subscription[WeeklyPlanOneOff], contact: SoldToContact, email: Option[String], billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackend.Resolution)
 
-@main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {
+@main(
+    title ="Your Guardian Weekly subscription | The Guardian",
+    bodyClasses = List("is-wide"),
+    edition = UK,
+    touchpointBackendResolutionOpt = Some(touchpointBackendResolution),
+    managementPage = true,
+    jsVars = model.JsVars(currency = currency, country = Some(billToCountry))
+) {
+
     @helper.javascriptRouter("jsRoutes")(
         routes.javascript.Promotion.validate
     )

--- a/app/views/fragments/javascriptFirstSteps.scala.html
+++ b/app/views/fragments/javascriptFirstSteps.scala.html
@@ -2,9 +2,10 @@
 @import model.JsVars
 @import controllers.CachedAssets.hashedPathFor
 @import configuration.Config
-@import views.support.{UKStripeService, AUStripeService}
+@import views.support.{UKStripeService, AUStripeService, CountryWithCurrency}
+@import com.gu.i18n.Country.UK
 @(jsVars: JsVars, touchpointBackendResolutionOpt: Option[services.TouchpointBackend.Resolution])
-
+@countryWithCurrency = @{CountryWithCurrency(jsVars.country.getOrElse(UK), jsVars.currency)}
 
 <script src="https://polyfill.guim.co.uk/v2/polyfill.min.js?features=default-3.6,Element.prototype.dataset,Array.prototype.includes"></script>
 
@@ -43,7 +44,7 @@
         '@{AUStripeService.jsLookupKey}': '@backend.stripeAUMembershipService.publicKey.mkString'
     };
     guardian.stripeCheckout = {
-        key: guardian.stripe['@{UKStripeService.jsLookupKey}'],
+        key: guardian.stripe['@countryWithCurrency.stripeServiceName.jsLookupKey'],
         image: 'https://d24w1tjgih0o9s.cloudfront.net/gu.png',
         locale: 'auto',
         name: 'Guardian',


### PR DESCRIPTION
Fixed a bug where customers in Australia could not renew their one-off Guardian Weekly subscriptions. 

It was caused by Stripe Checkout not using the same Stripe account as the serverside interactions. There is no country change on the /manage page so the page renders with the correct country chosen.

Changes in javascriptFirstSteps fix the issue, the stuff in TouchpointBackend and CheckoutService is just some small refactoring to reduce the number of items sitting on TouchpointBackend and required within the CheckoutService.

Tested on code, sub id in dev Zuora: A-S00043952

cc @jacobwinch @AWare 