### PR TITLE
Add StoreAcquisitionDataAction to NoCacheAction

### DIFF
--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -12,7 +12,16 @@ import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent.Future
 object CommonActions {
 
-  val NoCacheAction = resultModifier(noCache)
+  val StoreAcquisitionDataAction = new ActionBuilder[Request] {
+    def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request).map(result => {
+      request.getQueryString("acquisitionData").fold(result)(a => {
+        val sessionWithAcquisitionData = request.session.data.toSeq ++ Seq("acquisitionData" -> a)
+        result.withSession(sessionWithAcquisitionData: _*)
+      })
+    })
+  }
+
+  val NoCacheAction = StoreAcquisitionDataAction andThen resultModifier(noCache)
 
   type GoogleAuthRequest[A] = AuthenticatedRequest[A, googleauth.UserIdentity]
 
@@ -44,15 +53,6 @@ object CommonActions {
   ))
 
   val CachedAction = resultModifier(Cached(_))
-
-  val StoreAcquisitionDataAction = new ActionBuilder[Request] {
-    def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request).map(result => {
-      request.getQueryString("acquisitionData").fold(result)(a => {
-        val sessionWithAcquisitionData = request.session.data.toSeq ++ Seq("acquisitionData" -> a)
-        result.withSession(sessionWithAcquisitionData: _*)
-      })
-    })
-  }
 
   val CSRFCachedAsyncAction = (block: Request[_] => Future[Result]) => CSRFCheck(action = CachedAction.async(block), config = CSRFConfig.global.copy(checkContentType = (x: Option[String]) => true))
 

--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -97,7 +97,7 @@ object PromoLandingPage extends Controller {
     }
   }
 
-  def render(promoCodeStr: String, maybeCountry: Option[Country]): Action[AnyContent] = (NoCacheAction andThen StoreAcquisitionDataAction).async { implicit request =>
+  def render(promoCodeStr: String, maybeCountry: Option[Country]): Action[AnyContent] = NoCacheAction.async { implicit request =>
     implicit val promoCode = PromoCode(promoCodeStr)
 
     tpBackend.promoService.findPromotionFuture(promoCode) map { maybePromotion =>


### PR DESCRIPTION
When someone hits the subs site (on a non-cached page), we want to store the acquisitionData in the session cookie. Previously, this was only implemented for `/p/{promocode}` routes, but we want it for all non-cached pages. This PR adds this functionality