### PR TITLE
Remove caching on entry points to subs site

### DIFF
--- a/app/controllers/DigitalPack.scala
+++ b/app/controllers/DigitalPack.scala
@@ -26,7 +26,7 @@ object DigitalPack extends Controller {
     }
   }
 
-  def landingPage(code: String) = CachedAction { _ =>
+  def landingPage(code: String) = NoCacheAction { _ =>
     val digitalEdition = getById(code).getOrElse(INT)
     val plan = TouchpointBackend.Normal.catalogService.unsafeCatalog.digipack.month
     val price = plan.charges.price.getPrice(digitalEdition.countryGroup.currency).getOrElse(plan.charges.gbpPrice)

--- a/app/controllers/Homepage.scala
+++ b/app/controllers/Homepage.scala
@@ -18,7 +18,7 @@ object Homepage extends Controller {
     Redirect(routes.Homepage.landingPage(digitalEdition.id).url, request.queryString, SEE_OTHER)
   }
 
-  def landingPage(code: String) = CachedAction {
+  def landingPage(code: String) = NoCacheAction {
     getById(code).fold {
       NotFound(views.html.error404())
     } {

--- a/app/controllers/Offers.scala
+++ b/app/controllers/Offers.scala
@@ -14,11 +14,11 @@ object Offers extends Controller {
     Redirect(routes.Offers.offersPage(digitalEdition.id).url, request.queryString, SEE_OTHER)
   }
 
-  def offersTestUKPage = CachedAction {
+  def offersTestUKPage = NoCacheAction {
     Ok(views.html.offers.offers_test_uk())
   }
 
-  def offersPage(edition: String) = CachedAction {
+  def offersPage(edition: String) = NoCacheAction {
     getById(edition) map {
       case UK => Ok(views.html.offers.offers_uk())
       case digitalEdition => Ok(views.html.offers.offers_international(digitalEdition))

--- a/app/controllers/Shipping.scala
+++ b/app/controllers/Shipping.scala
@@ -21,7 +21,7 @@ object Shipping extends Controller {
       routes.Checkout.renderCheckout(UK.id, None, None, in.slug).url
     )
 
-  def viewCollectionPaperDigital() = CachedAction {
+  def viewCollectionPaperDigital() = NoCacheAction {
     val segment = "paper-digital"
     index(CollectionSubscriptionProduct(
       title = "Paper + digital voucher subscription",
@@ -31,7 +31,7 @@ object Shipping extends Controller {
     ), segment)
   }
 
-  def viewCollectionPaper() = CachedAction {
+  def viewCollectionPaper() = NoCacheAction {
     val segment = "paper"
     index(CollectionSubscriptionProduct(
       title = "Paper voucher subscription",
@@ -41,7 +41,7 @@ object Shipping extends Controller {
     ), segment)
   }
 
-  def viewDeliveryPaperDigital() = CachedAction {
+  def viewDeliveryPaperDigital() = NoCacheAction {
     val segment = "paper-digital"
     index(DeliverySubscriptionProduct(
       title = "Paper + digital home delivery subscription",
@@ -52,7 +52,7 @@ object Shipping extends Controller {
     ), segment)
   }
 
-  def viewDeliveryPaper() = CachedAction {
+  def viewDeliveryPaper() = NoCacheAction {
     val segment = "paper"
     index(DeliverySubscriptionProduct(
       title = "Paper home delivery subscription",

--- a/app/controllers/WeeklyLandingPage.scala
+++ b/app/controllers/WeeklyLandingPage.scala
@@ -25,7 +25,7 @@ object WeeklyLandingPage extends Controller {
 
   val description = landing_description()
 
-  def withCountry(country: String) = CachedAction {
+  def withCountry(country: String) = NoCacheAction {
     val parsedCountry = if (country == international) Some(Country.UK) else CountryGroup.countryByCode(country)
     parsedCountry.fold {
       MovedPermanently(routes.WeeklyLandingPage.withCountry(international).url)


### PR DESCRIPTION
Caching on the entry points to the subs sites breaks our acquisition tracking. After a conversation with @paulbrown1982, it was decided that we should turn off caching for these routes. 