### PR TITLE
update GNM membership stripe version via a 0.488 membership-common bump

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.484",
+    "com.gu" %% "membership-common" % "0.488",
     "com.gu" %% "memsub-common-play-auth" % "1.2",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
[PR 550](https://github.com/guardian/membership-common/pull/550) in membership-common makes it possible to send a Stripe-Version header to Stripe and I'm bumping the membership common-version so that I can send the latest Stripe-Version header to Stripe and ensure it works app by app. 

**Pre-merge:** In s3://subscriptions-private/PROD/subscriptions-frontend.private.conf I shall add the stripe version 2017-08-15 to the config

So that we will send header Stripe-Version -> 2017-08-15 in each request to stripe

Later, when we change the api version for GNM membership-stripe globally in the stripe dashboard, this version can be removed from the config. 

If something goes wrong using this stripe version I shall:
1) Use s3://subscriptions-private/PROD/subscriptions-frontend.private.conf.backup as ../subscriptions-frontend.private.conf (removing the version from the config again)
2) redeploy the app

cc @paulbrown1982 @johnduffell @AWare @jacobwinch @pvighi 