### PR TITLE
Polyfill unknown browsers.

### DIFF
--- a/app/views/fragments/javascriptFirstSteps.scala.html
+++ b/app/views/fragments/javascriptFirstSteps.scala.html
@@ -7,7 +7,7 @@
 @(jsVars: JsVars, touchpointBackendResolutionOpt: Option[services.TouchpointBackend.Resolution])
 @countryWithCurrency = @{CountryWithCurrency(jsVars.country.getOrElse(UK), jsVars.currency)}
 
-<script src="https://polyfill.guim.co.uk/v2/polyfill.min.js?features=default-3.6,Element.prototype.dataset,Array.prototype.includes,Array.find,fetch"></script>
+<script src="https://polyfill.guim.co.uk/v2/polyfill.min.js?features=default-3.6,Element.prototype.dataset,Array.prototype.includes,Array.find,fetch%26unknown=polyfill"></script>
 
 
 <script id="gu">


### PR DESCRIPTION
We're getting some Array.from related errors coming from hard to identify browsers. This serves all polyfills if the browser cannot be identified.