### PR TITLE
Weekly renew: fix promotional price display

### DIFF
--- a/assets/javascripts/modules/react/weeklyRenew.jsx
+++ b/assets/javascripts/modules/react/weeklyRenew.jsx
@@ -326,7 +326,7 @@ const PlanChooser = ({ plans, selected, handleChange }) => {
 const Plan = ({ promotionalPrice, price }) => {
     if (promotionalPrice) {
         return <span className="option__label">
-            <s>{props.price}</s>
+            <s>{price}</s>
             <strong>&nbsp;{promotionalPrice}</strong>
         </span>
     }


### PR DESCRIPTION
This was found by adding linting to jsx. 
Worth merging before https://github.com/guardian/subscriptions-frontend/pull/1016