### PR TITLE
Swap customer.experience for customer.operations in CAS staff access list

### DIFF
--- a/app/actions/OAuthActions.scala
+++ b/app/actions/OAuthActions.scala
@@ -35,7 +35,7 @@ trait OAuthActions extends googleauth.Actions with googleauth.Filters with Commo
   ))
 
   val StaffAuthorisedForCASAction = GoogleAuthenticatedStaffAction andThen requireGroup[GoogleAuthRequest](Set(
-    "customer.experience@guardian.co.uk",
+    "customer.operations@guardian.co.uk",
     "directteam@guardian.co.uk",
     "userhelp@guardian.co.uk",
     "dig.qa@guardian.co.uk",


### PR DESCRIPTION
I've spoken to a few people in CEX and none of them are able to access this tool. I think this might be down to the Google group that we're currently using, hence this PR.

cc @paulbrown1982 