### PR TITLE
Actually fix weekly renew

### DIFF
--- a/assets/javascripts/modules/react/weeklyRenew.jsx
+++ b/assets/javascripts/modules/react/weeklyRenew.jsx
@@ -178,12 +178,10 @@ class WeeklyRenew extends React.Component {
     }
 
     handlePlan(id) {
-        this.setState({ plan: id, displayedPrice: this.getPrice(id) });
+        this.setState({ plan: id, displayedPrice: this.getPrice(this.state.plans.find(p => p.id == id)) });
     }
 
-    getPrice(idOrPlan) {
-        let id = idOrPlan.id || idOrPlan;
-        let plan = this.state.plans.find(p => p.id == id)
+    getPrice(plan) {
         return plan.promotionalPrice || plan.price;
     }
 


### PR DESCRIPTION
By using plan id, we were updating the price using the plan before storing the new plans in the state. 

Changing getPrice to always use the plan rather than its id.