### PR TITLE
Switch renew to use fetch instead of reqwest.

### DIFF
--- a/assets/javascripts/modules/react/weeklyRenew.jsx
+++ b/assets/javascripts/modules/react/weeklyRenew.jsx
@@ -206,7 +206,7 @@ class WeeklyRenew extends React.Component {
     render() {
         return <div>
             {this.state.loading && <div className="loader is-loading"> Processing</div>}
-            {this.state.error && <div className="mma-error"> {this.state.error}</div>}
+            {this.state.error && <div className="mma-error"><h3 className="mma-section__header">{this.state.error.title}</h3><p> {this.state.error.body}</p></div>}
             {!this.state.loading && !this.state.error &&
                 <div>
 

--- a/assets/javascripts/modules/renew/renew.es6
+++ b/assets/javascripts/modules/renew/renew.es6
@@ -103,7 +103,6 @@ export function send(state, errorHandler) {
                     //We got a 200, and then couldn't parse the JSON.
                     //The renewal probably worked, and we should not really be in this branch.
                     errorHandler(renewNetworkErrorMessage)
-
                 })
                 return;
             }

--- a/assets/javascripts/modules/renew/renew.es6
+++ b/assets/javascripts/modules/renew/renew.es6
@@ -19,10 +19,9 @@ export class SortCode {
 
 }
 
-let renewErrorMessage = 'Sorry, your subscription could not be renewed. Please contact us at gwsubs@theguardian.com or call +44 (0) 330 333 6767. Lines open weekdays 8am-8pm, weekend 8pm-6pm';
+let renewErrorMessage = {title:'Sorry', body:'Your subscription could not be renewed. Please contact us at gwsubs@theguardian.com or call +44 (0) 330 333 6767. Lines open weekdays 8am-8pm, weekend 8pm-6pm'};
 
-let renewNetworkErrorMessage = `A response was not received when attempting to renew your subscription. Please refresh this page and try again. If you have seen this error before: please contact us at gwsubs@theguardian.com or call +44 (0) 330 333 6767. Lines open weekdays 8am-8pm, weekend 8pm-6pm
-`
+let renewNetworkErrorMessage = {title:'Connection Error', body:'Please refresh the page to see the current status of your subscription. Alternatively, please contact us at gwsubs@theguardian.com or call +44 (0) 330 333 6767. Lines open weekdays 8am-8pm, weekend 8pm-6pm'};
 
 export function validAccount(accountNumber) {
     return /^\d{6,10}$/.test(accountNumber);

--- a/assets/javascripts/modules/renew/renew.es6
+++ b/assets/javascripts/modules/renew/renew.es6
@@ -94,7 +94,6 @@ export function send(state, errorHandler) {
         })
         fetch(request).then((response) => {
             if (response.status == 200) {
-                console.log(response)
                 response.json().then((json) => {
                     window.location.assign(json.redirect);
                 }).catch((e) => {

--- a/assets/stylesheets/modules/_suspend.scss
+++ b/assets/stylesheets/modules/_suspend.scss
@@ -173,7 +173,7 @@
 }
 
 .mma-error{
-    color: guss-colour(error);
+    color: guss-colour(comment-support-4);
     font-weight: 900;
 }
 


### PR DESCRIPTION
Renew wasn't handling fail states particularly gracefully, and we were seeing successful renews shown the failure screen, this should show them a better error- but gives us more granularity if it continues.