### PR TITLE
correctly send public key to members-data-api

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -68,7 +68,7 @@ object SessionSubscription extends StrictLogging {
         d.leftMap(e => logger.warn(s"Error looking up SF Contact for logged in user with Identity ID ${identityUser.user.id}: $e")).toOption.flatten
       })
       zuoraSubscription <- OptionT(tpBackend.subscriptionService.current[ContentSubscription](salesForceUser).map{subs =>
-        if (subs.length > 1) logger.warn("User with multiple subscriptions, only serving first.")
+        if (subs.length > 1) logger.warn(s"Logged in user with Identity ID ${identityUser.user.id}: with ${subs.length} subscriptions, only serving first.")
         subs.headOption
         /*FIXME if they have more than one they can only manage the first*/})
     } yield zuoraSubscription).run

--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -67,7 +67,10 @@ object SessionSubscription extends StrictLogging {
       salesForceUser <- OptionT(tpBackend.salesforceService.repo.get(identityUser.user.id).map { d =>
         d.leftMap(e => logger.warn(s"Error looking up SF Contact for logged in user with Identity ID ${identityUser.user.id}: $e")).toOption.flatten
       })
-      zuoraSubscription <- OptionT(tpBackend.subscriptionService.current[ContentSubscription](salesForceUser).map(_.headOption/*FIXME if they have more than one they can only manage the first*/))
+      zuoraSubscription <- OptionT(tpBackend.subscriptionService.current[ContentSubscription](salesForceUser).map{subs =>
+        if (subs.length > 1) logger.warn("User with multiple subscriptions, only serving first.")
+        subs.headOption
+        /*FIXME if they have more than one they can only manage the first*/})
     } yield zuoraSubscription).run
   }
 

--- a/assets/javascripts/modules/mma/updatePayment.jsx
+++ b/assets/javascripts/modules/mma/updatePayment.jsx
@@ -64,7 +64,7 @@ class Payment extends React.Component {
 
         const token = (t) => {
             this.setState({ state: WAITING })
-            handleStripeResponse(t, cardUrl, this.state.stripePublicKeyForUpdate).then(json => {
+            handleStripeResponse(t, cardUrl, this.state.card.stripePublicKeyForUpdate).then(json => {
                 this.setState({ state: SUCCESS })
             })
                 .catch((e) => {


### PR DESCRIPTION
Still trying to debug identity subscriptions not being identified correctly by /manage 

But this fixes a nasty bug with the renewal flow on /manage

I'd like to see this as an [ERROR] instead of a [WARN]:
https://github.com/guardian/members-data-api/blob/64f4342e570d25da8bdb4e0d4f09a4ea7ace28e3/membership-attribute-service/app/controllers/AccountController.scala#L123-L123
