### PR TITLE
Add new promo codes and copy for Christmas flash sale

### DIFF
--- a/app/services/FlashSale.scala
+++ b/app/services/FlashSale.scala
@@ -5,13 +5,13 @@ import model.DigitalEdition
 import model.promoCodes.{GuardianWeekly, _}
 import org.joda.time.DateTime
 
-//TODO: Remove after 3rd December 2017
-object BlackFriday {
+object FlashSale {
 
   def inOfferPeriod = {
-    //The offer is valid between 24th November & 3rd December 2017
-    val startTime = new DateTime(2017, 11, 24, 0, 0)
-    val endTime = new DateTime(2017, 12, 4, 0, 0)
+    //The offer is valid between 19th December 2017 & 3rd January 2018
+    //The current sale is digital only paper & paper + digital is unaffected
+    val startTime = new DateTime(2017, 12, 19, 0, 0)
+    val endTime = new DateTime(2018, 1, 4, 0, 0)
     val now = new DateTime()
     now.isAfter(startTime) && now.isBefore(endTime) || !Config.stageProd //allow testing on CODE
   }
@@ -20,9 +20,9 @@ object BlackFriday {
 
   def homePromoCodes(edition: DigitalEdition): Map[PromoCodeKey, String] = if (inOfferPeriod) {
     Map(
-      Digital -> "DBQ80F",
-      PaperAndDigital -> "GBQ80H",
-      Paper -> "GBQ80G",
+      Digital -> "DBR80F",
+      PaperAndDigital -> s"NHOME${edition.id.toUpperCase}D",
+      Paper -> s"NHOME${edition.id.toUpperCase}P",
       GuardianWeekly -> s"WHOME${edition.id.toUpperCase}"
     )
   }
@@ -39,9 +39,9 @@ object BlackFriday {
 
   def offersPromoCodes(edition: DigitalEdition): Map[PromoCodeKey, String] = if (inOfferPeriod) {
     Map(
-      Digital -> "DBQ80J",
-      PaperAndDigital -> "GBQ80L",
-      Paper -> "GBQ80K",
+      Digital -> "DBR80G",
+      PaperAndDigital -> s"NOFF${edition.id.toUpperCase}D",
+      Paper -> s"NOFF${edition.id.toUpperCase}P",
       GuardianWeekly -> "WAL41X"
     )
   } else {

--- a/app/views/fragments/productLists/digitalPack.scala.html
+++ b/app/views/fragments/productLists/digitalPack.scala.html
@@ -1,5 +1,5 @@
 @import model.DigitalEdition
-@import services.BlackFriday._
+@import services.FlashSale._
 @import model.promoCodes._
 @import views.support.DigitalEdition._
 

--- a/app/views/fragments/productLists/productListUk.scala.html
+++ b/app/views/fragments/productLists/productListUk.scala.html
@@ -9,12 +9,7 @@
         <h2 class="block__title">Paper + digital</h2>
         <div class="block__info">
             <ul class="block__list">
-                @if(inOfferPeriod) {
-                    <li class="block__list-item"><strong>Subscribe today and save an extra 50% for the first 3 months</strong></li>
-                    <li class="block__list-item">Year-round savings on the retail price</li>
-                } else {
-                    <li class="block__list-item">Year-round savings of up to 36% off the retail price</li>
-                }
+                <li class="block__list-item">Year-round savings of up to 36% off the retail price</li>
                 <li class="block__list-item">Pick the package you want: Everyday+, Sixday+, Weekend+ and The Observer+</li>
                 <li class="block__list-item">All supplements Monday to Sunday</li>
                 <li class="block__list-item">All the <strong>Digital Pack</strong> benefits</li>
@@ -28,12 +23,7 @@
         <h2 class="block__title">Paper</h2>
         <div class="block__info">
             <ul class="block__list">
-                @if(inOfferPeriod) {
-                    <li class="block__list-item"><strong>Subscribe today and save an extra 50% for the first 3 months</strong></li>
-                    <li class="block__list-item">Year-round savings on the retail price</li>
-                } else {
-                    <li class="block__list-item">Year-round savings of up to 31% off the retail price</li>
-                }
+                <li class="block__list-item">Year-round savings of up to 31% off the retail price</li>
                 <li class="block__list-item">Pick the package you want: Everyday, Sixday, Weekend and The Observer</li>
                 <li class="block__list-item">All supplements Monday to Sunday</li>
                 <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>

--- a/app/views/fragments/productLists/productListUk.scala.html
+++ b/app/views/fragments/productLists/productListUk.scala.html
@@ -1,5 +1,5 @@
 @import model.DigitalEdition.UK
-@import services.BlackFriday._
+@import services.FlashSale._
 @import model.promoCodes._
 
 @(promoCodes: Map[PromoCodeKey, String], includeEditionInUrl: Boolean = false)

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,6 +1,6 @@
 @import model.DigitalEdition.UK
 @import views.support.DigitalEdition._
-@import services.BlackFriday
+@import services.FlashSale
 @()
 
 @main(
@@ -10,7 +10,7 @@
 
     <main class="page-container gs-container">
         @fragments.page.header("Subscriptions and Membership")
-        @fragments.productLists.productListUk(BlackFriday.homePromoCodes, includeEditionInUrl = true)
+        @fragments.productLists.productListUk(FlashSale.homePromoCodes, includeEditionInUrl = true)
         <div class="row row--items-1">
             <div class="row__item">
                 @fragments.promos.members("uk", UK.membershipLandingPage)

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -1,7 +1,7 @@
 @import model.DigitalEdition
 @import views.support.DigitalEdition._
 
-@import services.BlackFriday
+@import services.FlashSale
 @(edition: DigitalEdition)
 
 @main(s"${edition.name} | Subscriptions and Membership | The Guardian",
@@ -10,7 +10,7 @@
 
 <main class="page-container gs-container">
     @fragments.page.header("Subscriptions and Membership", Some("Select your preferred package"))
-    @fragments.productLists.productListInternational(edition, BlackFriday.homePromoCodes(edition), includeEditionInUrl = true)
+    @fragments.productLists.productListInternational(edition, FlashSale.homePromoCodes(edition), includeEditionInUrl = true)
     <div class="row row--items-1">
         <div class="row__item">
             @fragments.promos.members(edition.id, edition.membershipLandingPage)

--- a/app/views/offers/offers_international.scala.html
+++ b/app/views/offers/offers_international.scala.html
@@ -1,7 +1,7 @@
 @import model.DigitalEdition
 @import views.support.DigitalEdition._
 
-@import services.BlackFriday
+@import services.FlashSale
 @(edition: DigitalEdition)
 
 @main(s"${edition.name} | Subscriptions | The Guardian",
@@ -10,6 +10,6 @@
 
     <main class="page-container gs-container">
         @fragments.page.header("Subscription offers", Some("Select your preferred package"))
-        @fragments.productLists.productListInternational(edition, BlackFriday.offersPromoCodes(edition))
+        @fragments.productLists.productListInternational(edition, FlashSale.offersPromoCodes(edition))
     </main>
 }

--- a/app/views/offers/offers_uk.scala.html
+++ b/app/views/offers/offers_uk.scala.html
@@ -1,6 +1,6 @@
 @import model.DigitalEdition.UK
 @import views.support.DigitalEdition._
-@import services.BlackFriday
+@import services.FlashSale
 @()
 
 @main(
@@ -10,7 +10,7 @@
 
     <main class="page-container gs-container">
         @fragments.page.header("Subscription offers")
-        @fragments.productLists.productListUk(BlackFriday.offersPromoCodes)
+        @fragments.productLists.productListUk(FlashSale.offersPromoCodes)
         <div class="row row--items-1">
             <div class="row__item block block--primary block--weekly">
                 <h2 class="block__title">Subscribe to the Guardian Weekly</h2>


### PR DESCRIPTION
This PR replaces https://github.com/guardian/subscriptions-frontend/pull/1023/files which I'm going to close.

Marketing have decided to run another 'Flash sale' similar to Black Friday except that it only applies to digipack. 

To do this I've reused the Black Friday code but renamed it to the more generic Flash Sale. Apparently these are going to be an ongoing feature of our marketing efforts from now on so we might as well leave this code in long term.

