### PR TITLE
Update Identity ID for guest checkout.

### DIFF
--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -186,7 +186,7 @@ class CheckoutService(
   private def storeIdentityDetails(
       subscribeRequest: SubscribeRequest,
       authenticatedUserOpt: Option[AuthenticatedIdUser],
-      memberId: ContactId,result: SubscribeResult): EitherT[Future, NonEmptyList[SubsError], IdentitySuccess] = {
+      memberId: ContactId, result: SubscribeResult): EitherT[Future, NonEmptyList[SubsError], IdentitySuccess] = {
 
     val personalData = subscribeRequest.genericData.personalData
     val deliveryAddress = subscribeRequest.productData.left.toOption.map(_.deliveryAddress)

--- a/app/services/TouchpointBackend.scala
+++ b/app/services/TouchpointBackend.scala
@@ -16,7 +16,7 @@ import com.gu.subscriptions.suspendresume.SuspensionService
 import com.gu.zuora
 import com.gu.zuora.api.InvoiceTemplate
 import com.gu.zuora.rest.SimpleClient
-import com.gu.zuora.{rest, soap}
+import com.gu.zuora.{ZuoraRestService, rest, soap}
 import configuration.Config
 import forms.SubscriptionsForm
 import monitoring.TouchpointBackendMetrics
@@ -98,7 +98,7 @@ object TouchpointBackend {
       lazy val suspensionService = new SuspensionService[Future](Config.holidayRatePlanIds(config.environmentName), simpleRestClient)
       lazy val subsForm = new forms.SubscriptionsForm(this.catalogService.unsafeCatalog)
       lazy val exactTargetService: ExactTargetService = new ExactTargetService(this.subscriptionService, this.commonPaymentService, this.zuoraService, this.salesforceService)
-      lazy val checkoutService: CheckoutService = new CheckoutService(IdentityService, this.salesforceService, this.paymentService, this.catalogService.unsafeCatalog, this.zuoraService, this.exactTargetService, this.zuoraProperties, this.promoService, this.discountRatePlanIds, this.commonPaymentService)
+      lazy val checkoutService: CheckoutService = new CheckoutService(IdentityService, this.salesforceService, this.paymentService, this.catalogService.unsafeCatalog, this.zuoraService, new ZuoraRestService[Future], this.exactTargetService, this.zuoraProperties, this.promoService, this.discountRatePlanIds, this.commonPaymentService)
     }
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.488",
+    "com.gu" %% "membership-common" % "0.1-SNAPSHOT",
     "com.gu" %% "memsub-common-play-auth" % "1.2",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.1-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.491",
     "com.gu" %% "memsub-common-play-auth" % "1.2",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",


### PR DESCRIPTION
Requires https://github.com/guardian/membership-common/pull/555

Saves the identity id for guests in the post successful subscription call