### PR TITLE
Use the latest membership-common to write the new HolidayStart__c field

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ libraryDependencies ++= Seq(
     ws,
     filters,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.491",
+    "com.gu" %% "membership-common" % "0.493",
     "com.gu" %% "memsub-common-play-auth" % "1.2",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.1",

--- a/test/services/CheckoutServiceTest.scala
+++ b/test/services/CheckoutServiceTest.scala
@@ -2,7 +2,7 @@ package services
 import com.gu.i18n.Country
 import com.gu.memsub.Benefit._
 import com.gu.memsub.Product.{Delivery, ZDigipack}
-import com.gu.memsub.Subscription.{ProductRatePlanChargeId, ProductRatePlanId}
+import com.gu.memsub.Subscription.{ProductRatePlanChargeId, ProductRatePlanId, SubscriptionRatePlanChargeId}
 import com.gu.memsub._
 import com.gu.memsub.subsv2._
 import com.gu.zuora.api.InvoiceTemplate
@@ -31,7 +31,7 @@ class CheckoutServiceTest extends Specification {
     id = ProductRatePlanId("p"),
     name = "name",
     description = "desc",
-    charges = PaidCharge(Digipack, BillingPeriod.Month, PricingSummary(Map.empty), ProductRatePlanChargeId("foo")),
+    charges = PaidCharge(Digipack, BillingPeriod.Month, PricingSummary(Map.empty), ProductRatePlanChargeId("foo"), SubscriptionRatePlanChargeId("")),
     product = Product.Digipack,
     saving = None,
     s = Status.current


### PR DESCRIPTION
Use the latest membership-common to ensure we write the HolidayStart__c field when creating a new holiday.

![picture 284](https://user-images.githubusercontent.com/1515970/34296682-9661fb3a-e70b-11e7-9795-763c7ad52feb.png)

cc @pvighi 