### PR TITLE
Marketing consent

### DIFF
--- a/app/controllers/SessionKeys.scala
+++ b/app/controllers/SessionKeys.scala
@@ -11,4 +11,5 @@ object SessionKeys {
   val Currency = "newSubs_currency"
   val StartDate = "newSubs_startDate"
   val Edition = "newSubs_edition"
+  val MarketingOptIn = "newSubs_marketingOptIn"
 }

--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -186,10 +186,14 @@ class CheckoutService(
 
   private def sendConsentEmail(subscribeRequest: SubscribeRequest): Future[\/[NonEmptyList[IdentityFailure], Unit]] = {
     val personalData = subscribeRequest.genericData.personalData
-    if (personalData.receiveGnmMarketing)
+    if (personalData.receiveGnmMarketing) {
+      logger.info("User consented to marketing, sending consent email")
       identityService.consentEmail(personalData.email)
-    else
+    }
+    else {
+      logger.info("User did not consent to marketing, skipping consent email")
       Future.successful(\/.right(Unit))
+    }
   }
 
 

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -239,7 +239,7 @@ object IdentityApiClient extends IdentityApiClient with LazyLogging {
 
   override val convertGuest: (Password, IdentityToken) => Future[WSResponse] = (password, token) => {
     val endpoint = authoriseCall(WS.url(s"$identityEndpoint/guest/password"))
-    val json = Json.obj("password" -> password)
+    val json = Json.obj("password" -> password, "validate-email" -> false)
 
     endpoint
       .withHeaders("X-Guest-Registration-Token" -> token.toString)

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -27,7 +27,7 @@ class IdentityService(identityApiClient: => IdentityApiClient) extends LazyLoggi
   def doesUserExist(email: String): Future[Boolean] =
     identityApiClient.userLookupByEmail(email).map { response =>
       response.status match {
-        case Status.OK =>  true
+        case Status.OK => true
         case Status.NOT_FOUND => false
         case status => {
           logger.error(s"ID API failed on email check with HTTP status $status")
@@ -38,9 +38,9 @@ class IdentityService(identityApiClient: => IdentityApiClient) extends LazyLoggi
     }
 
   def userLookupByCredentials(accessCredentials: AccessCredentials): Future[Option[IdUser]] = accessCredentials match {
-    case cookies: AccessCredentials.Cookies => identityApiClient.userLookupByCookies (cookies).map {
-        response => (response.json \ "user").asOpt[IdUser]
-      }
+    case cookies: AccessCredentials.Cookies => identityApiClient.userLookupByCookies(cookies).map {
+      response => (response.json \ "user").asOpt[IdUser]
+    }
     case _ => Future.successful {
       logger.error("ID API only supports forwarded access for Cookies")
       None
@@ -57,6 +57,17 @@ class IdentityService(identityApiClient: => IdentityApiClient) extends LazyLoggi
           Some(response.json.toString()))))
       }
     }
+  }
+
+  def consentEmail(email: String): Future[\/[NonEmptyList[IdentityFailure], Unit]] = identityApiClient.consentEmail(email).map {
+    response =>
+      if (response.status == 200)
+        \/.right(Unit)
+      else
+        \/.left(NonEmptyList(IdentityFailure(
+          "Consent email could not be sent for user",
+          Some(email),
+          Some(response.json.toString()))))
   }
 
   def convertGuest(password: String, token: IdentityToken): Future[Seq[Cookie]] = {
@@ -79,7 +90,8 @@ class IdentityService(identityApiClient: => IdentityApiClient) extends LazyLoggi
           personalData,
           delivery,
           cookies
-        ).map { response => response.status match {
+        ).map { response =>
+          response.status match {
             case Status.OK => \/.right(IdentitySuccess(RegisteredUser(IdMinimalUser("", None))))
             case _ =>
               \/.left(NonEmptyList(IdentityFailure(
@@ -101,34 +113,35 @@ object IdentityService extends IdentityService(IdentityApiClient) {
 
 }
 
-object  PersonalDataJsonSerialiser {
+object PersonalDataJsonSerialiser {
   val primaryEmailAddress = "primaryEmailAddress"
   val publicFields = "publicFields"
 
   implicit def convertToUser(personalData: PersonalData, deliveryAddress: Option[Address]): JsObject = {
-    val telephoneNumber = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber,personalData.address.country)
+    val telephoneNumber = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country)
     Json.obj(
       primaryEmailAddress -> personalData.email,
       publicFields -> Json.obj(
         "displayName" -> s"${personalData.first} ${personalData.last}"
       ),
       "privateFields" -> Json.obj(
-      "firstName" -> personalData.first,
-      "secondName" -> personalData.last,
-      "billingAddress1" -> personalData.address.lineOne,
-      "billingAddress2" -> personalData.address.lineTwo,
-      "billingAddress3" -> personalData.address.town,
-      "billingAddress4" -> personalData.address.countyOrState,
-      "billingPostcode" -> personalData.address.postCode,
-      "billingCountry"  -> personalData.address.country.fold(personalData.address.countryName)(_.name)
+        "firstName" -> personalData.first,
+        "secondName" -> personalData.last,
+        "billingAddress1" -> personalData.address.lineOne,
+        "billingAddress2" -> personalData.address.lineTwo,
+        "billingAddress3" -> personalData.address.town,
+        "billingAddress4" -> personalData.address.countyOrState,
+        "billingPostcode" -> personalData.address.postCode,
+        "billingCountry" -> personalData.address.country.fold(personalData.address.countryName)(_.name)
       ).++(
         personalData.title.fold(Json.obj())(title =>
           Json.obj("title" -> title.title))
       ).++(
-         telephoneNumber.fold[JsObject](Json.obj()){t =>
-           Json.obj(
-             "telephoneNumber" -> Json.toJson(t)
-           )}
+        telephoneNumber.fold[JsObject](Json.obj()) { t =>
+          Json.obj(
+            "telephoneNumber" -> Json.toJson(t)
+          )
+        }
       ).++(deliveryAddress.fold(Json.obj()) { addr =>
         Json.obj(
           "address1" -> addr.lineOne,
@@ -175,8 +188,8 @@ object IdentityApiClient extends IdentityApiClient with LazyLogging {
   implicit class FutureWSLike(eventualResponse: Future[WSResponse]) {
     /**
      * Example of ID API Response: `{"status":"error","errors":[{"message":"Forbidden","description":"Field access denied","context":"privateFields.billingAddress1"}]}`
-      *
-      * @return
+     *
+     * @return
      */
     private def applyOnSpecificErrors(reasons: List[String])(block: WSResponse => Unit): Unit = {
       def errorMessageFilter(error: JsValue): Boolean =
@@ -185,8 +198,8 @@ object IdentityApiClient extends IdentityApiClient with LazyLogging {
       eventualResponse.map(response =>
         (response.json \ "status").asOpt[String].filter(_ == "error")
           .foreach(_ => (response.json \ "errors").asOpt[JsArray].flatMap(_.value.headOption)
-          .filter(errorMessageFilter)
-          .foreach(_ => block(response))))
+            .filter(errorMessageFilter)
+            .foreach(_ => block(response))))
     }
 
     def withWSFailureLogging(request: WSRequest) = {
@@ -219,21 +232,24 @@ object IdentityApiClient extends IdentityApiClient with LazyLogging {
   override val userLookupByEmail: Email => Future[WSResponse] = {
     val endpoint = authoriseCall(WS.url(s"$identityEndpoint/user"))
 
-    email => endpoint.withQueryString(("emailAddress", email)).execute()
-      .withWSFailureLogging(endpoint)
-      .withCloudwatchMonitoringOfGet
+    email =>
+      endpoint.withQueryString(("emailAddress", email)).execute()
+        .withWSFailureLogging(endpoint)
+        .withCloudwatchMonitoringOfGet
   }
 
   override val userLookupByCookies: AccessCredentials.Cookies => Future[WSResponse] = {
     val endpoint = authoriseCall(WS.url(s"$identityEndpoint/user/me").withHeaders(("Referer", s"$identityEndpoint/")))
 
-    cookies => endpoint.withHeaders(cookies.forwardingHeader).execute()
-      .withWSFailureLogging(endpoint)
-      .withCloudwatchMonitoringOfGet
+    cookies =>
+      endpoint.withHeaders(cookies.forwardingHeader).execute()
+        .withWSFailureLogging(endpoint)
+        .withCloudwatchMonitoringOfGet
   }
 
-  override val createGuest: (PersonalData, Option[Address]) => Future[WSResponse] = { case (data, addr) =>
-    val endpoint = authoriseCall(WS.url(s"$identityEndpoint/guest"))
+  override val createGuest: (PersonalData, Option[Address]) => Future[WSResponse] = {
+    case (data, addr) =>
+      val endpoint = authoriseCall(WS.url(s"$identityEndpoint/guest"))
       endpoint.post(convertToUser(data, addr))
         .withWSFailureLogging(endpoint)
         .withCloudwatchMonitoringOfPost
@@ -272,9 +288,9 @@ object IdentityApiClient extends IdentityApiClient with LazyLogging {
 }
 
 class IdApiMetrics(val stage: String) extends CloudWatch
-with StatusMetrics
-with RequestMetrics
-with AuthenticationMetrics {
+  with StatusMetrics
+  with RequestMetrics
+  with AuthenticationMetrics {
 
   val region = Region.getRegion(Regions.EU_WEST_1)
   val application = Config.appName

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -78,7 +78,7 @@
         <span class="review-details__heading">Membership, supporting and subscribing to the Guardian</span>
         <div class="review-details__list">
             <ul class="o-unstyled-list">
-                <li>
+                <li class="u-margin-bottom">
                     <span class="u-note">
                         Whether you’re a subscriber, a member or you support us via a regular or one-off contribution, opt in here so we can keep sending you news, updates and more. Make sure you opt in so you don’t miss out.
                     </span>

--- a/app/views/fragments/checkout/reviewDetails.scala.html
+++ b/app/views/fragments/checkout/reviewDetails.scala.html
@@ -74,27 +74,36 @@
             </ul>
         </div>
     </div>
+    <div class="review-details__item">
+        <span class="review-details__heading">Membership, supporting and subscribing to the Guardian</span>
+        <div class="review-details__list">
+            <ul class="o-unstyled-list">
+                <li>
+                    <span class="u-note">
+                        Whether you’re a subscriber, a member or you support us via a regular or one-off contribution, opt in here so we can keep sending you news, updates and more. Make sure you opt in so you don’t miss out.
+                    </span>
+                </li>
+                <li>
+                    <span class="u-note">
+                        If you’d like to hear about our wide range of subscription offers - or you’re interested in helping to secure our future with a recurring, or one-off contribution, then you’ll need to opt in here, too. Don’t worry, you can opt out at any time.
+                    </span>
+                </li>
+                <li>
+                @defining(personalData.exists(_.receiveGnmMarketing)) { gnmMarketingOpt =>
+                    <span class="option__input">
+                        <input type="checkbox"
+                        name="personal.receiveGnmMarketing"
+                        id="receive-gnm-marketing"
+                            @if(gnmMarketingOpt) { checked="checked" }
+                        >
+                    </span>
+                }
+                </li>
+            </ul>
+        </div>
+    </div>
     <div class="review-details__actions">
-        <p class="u-note">
-            Your subscription includes a range of exclusive benefits which will be sent to you from Guardian Subscriptions.
-            These may include special offers from other companies, but your data will not be shared with these companies.
-        </p>
 
-        <label class="option u-pad-bottom" for="receive-gnm-marketing">
-        @defining(personalData.exists(_.receiveGnmMarketing)) { gnmMarketingOpt =>
-            <span class="option__input">
-                <input type="checkbox"
-                    name="personal.receiveGnmMarketing"
-                    id="receive-gnm-marketing"
-                    @if(gnmMarketingOpt) { checked="checked" }
-                    >
-            </span>
-        }
-            <span class="option__label u-note prose">
-                Guardian News &amp; Media would also like your permission to contact you about other services.
-                If you would like to receive this information, please tick here.
-            </span>
-        </label>
         <p class="u-error js-error u-note prose"></p>
 
         <button type="submit" class="js-checkout-submit button button--primary button--large u-margin-bottom">

--- a/test/services/IdentityServiceTest.scala
+++ b/test/services/IdentityServiceTest.scala
@@ -20,6 +20,7 @@ class IdentityServiceTest extends FreeSpec {
     override def updateUserDetails: (PersonalData, Option[Address], AccessCredentials.Cookies) => Future[WSResponse] = ???
     override def convertGuest: (String, IdentityToken) => Future[WSResponse] = ???
     override def userLookupByEmail: (String) => Future[WSResponse] = ???
+    override def consentEmail = ???
   }
 
   def makeIdentityService(client: IdentityApiClient) = new IdentityService(client)

--- a/test/services/IdentityServiceTest.scala
+++ b/test/services/IdentityServiceTest.scala
@@ -18,7 +18,7 @@ class IdentityServiceTest extends FreeSpec {
     override def userLookupByCookies: (AccessCredentials.Cookies) => Future[WSResponse] = ???
     override def createGuest: (PersonalData, Option[Address]) => Future[WSResponse] = ???
     override def updateUserDetails: (PersonalData, Option[Address], AccessCredentials.Cookies) => Future[WSResponse] = ???
-    override def convertGuest: (String, IdentityToken) => Future[WSResponse] = ???
+    override def convertGuest: (String, IdentityToken, Boolean) => Future[WSResponse] = ???
     override def userLookupByEmail: (String) => Future[WSResponse] = ???
     override def consentEmail = ???
   }


### PR DESCRIPTION
## Why is this PR necessary?
As part of our GDPR work, we need to change the way we collect marketing consent.
Trello card [here](https://trello.com/c/dtlSHP3x/1156-marketing-consent-on-subscribe)
cc @jfsoul

## What needs to be done?
1. Change the wording of the consent form - TODO: this is undergoing some UX analysis but will be completed before launch.
2. Change the way that consent is persisted to Identity:

## How?
Previously we have stored marketing consent by posting to the user/me endpoint with a boolean representing whether the user checked the consent checkbox. Although we will continue to do this for now, Identity will soon start ignoring this value in favour of a [new API](https://docs.google.com/document/d/1JDEpehzToi9aAMg4Fk7n_mnvQ_GOOf_kgOPSyWLBweA/)

### The new method
If user gives consent:
* We call Identity on the new consent-email endpoint to instruct them that the user has given consent to 'supporter' related emails. 
* Identity emails the user asking them to click a link to confirm their choice.

If user does not give consent then no call to the consent emailer is made.

### Guest users
For users who are not signed in during the checkout we create a guest user with Identity. The user then has the option to add a password on the thank you page. 

For users who do this and who have also given us marketing consent we now need to suppress the standard validation email which would otherwise be sent out when we set their password in Identity. 

This is described in more detail in [the doc mentioned above](https://docs.google.com/document/d/1JDEpehzToi9aAMg4Fk7n_mnvQ_GOOf_kgOPSyWLBweA/).

  
 **New copy:**
<img width="781" alt="screen shot 2018-01-10 at 17 19 45" src="https://user-images.githubusercontent.com/181371/34785949-8648582e-f62a-11e7-9df4-7158f46d946d.png">

