### PR TITLE
Post-Garnett Tidying

### DIFF
--- a/assets/stylesheets/garnett.scss
+++ b/assets/stylesheets/garnett.scss
@@ -64,7 +64,7 @@ body {
   color: guss-colour(neutral-1);
   border-color: guss-colour(neutral-1);
 
-  &:hover {
+  &:hover, &:active, &:focus {
     background-color: guss-colour(neutral-1);
     color: #fff;
 

--- a/assets/stylesheets/modules/_popup.scss
+++ b/assets/stylesheets/modules/_popup.scss
@@ -61,6 +61,7 @@
 
     display: block;
     text-decoration: none;
+    color: #121212;
     border-bottom: 1px solid $c-neutral4;
     padding: ($gs-baseline / 2) 0;
 


### PR DESCRIPTION
## Why are you doing this?

Couple tweaks to make stuff look less broken.

## Changes

- Applied the new black to the identity popup links.
- Updated the primary button active and focus states to be more legible, and to match the hover state.

## Screenshots

**Before:**

![popup-before](https://user-images.githubusercontent.com/5131341/34939033-5b5d978a-f9e2-11e7-9d95-68e816be9b91.png)

![button-before](https://user-images.githubusercontent.com/5131341/34939028-54c2ac12-f9e2-11e7-8420-f3c74e0d8d39.png)

**After:**

![popup-after](https://user-images.githubusercontent.com/5131341/34939057-6caa0a64-f9e2-11e7-83cb-1c1ae7fd2548.png)

![button-after](https://user-images.githubusercontent.com/5131341/34939023-4e1de0c0-f9e2-11e7-8ea9-b16b1ae3dd59.png)