### PR TITLE
Fix polyfill and widths of renew radio buttons in ie11.

### DIFF
--- a/app/views/fragments/javascriptFirstSteps.scala.html
+++ b/app/views/fragments/javascriptFirstSteps.scala.html
@@ -7,7 +7,7 @@
 @(jsVars: JsVars, touchpointBackendResolutionOpt: Option[services.TouchpointBackend.Resolution])
 @countryWithCurrency = @{CountryWithCurrency(jsVars.country.getOrElse(UK), jsVars.currency)}
 
-<script src="https://polyfill.guim.co.uk/v2/polyfill.min.js?features=default-3.6,Element.prototype.dataset,Array.prototype.includes,Array.find,fetch%26unknown=polyfill"></script>
+<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default-3.6,Element.prototype.dataset,Array.prototype.includes,Array.prototype.find,fetch,Array.prototype.findIndex,&unknown=polyfill"></script>
 
 
 <script id="gu">

--- a/app/views/fragments/javascriptFirstSteps.scala.html
+++ b/app/views/fragments/javascriptFirstSteps.scala.html
@@ -7,7 +7,7 @@
 @(jsVars: JsVars, touchpointBackendResolutionOpt: Option[services.TouchpointBackend.Resolution])
 @countryWithCurrency = @{CountryWithCurrency(jsVars.country.getOrElse(UK), jsVars.currency)}
 
-<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default-3.6,Element.prototype.dataset,Array.prototype.includes,Array.prototype.find,fetch,Array.prototype.findIndex,&unknown=polyfill"></script>
+<script src="https://polyfill.guim.co.uk/v2/polyfill.min.js?features=default-3.6,Element.prototype.dataset,Array.prototype.includes,Array.prototype.find,fetch,Array.prototype.findIndex,&unknown=polyfill"></script>
 
 
 <script id="gu">

--- a/assets/javascripts/modules/react/weeklyRenew.jsx
+++ b/assets/javascripts/modules/react/weeklyRenew.jsx
@@ -16,7 +16,7 @@ import {
     init as stripeInit
 } from 'modules/renew/renew'
 
-const RadioButton = ({ children, ...props }) => <div style={{ boxSizing: 'unset' }}><UnspacedRadioButton pointColor="#005689" {...props}><span style={{ paddingRight: '10px' }}>{children}</span></UnspacedRadioButton></div>;
+const RadioButton = ({ children, ...props }) => <div style={{ boxSizing: 'unset', minWidth: '250px' }}><UnspacedRadioButton pointColor="#005689" {...props}><span style={{ paddingRight: '10px' }}>{children}</span></UnspacedRadioButton></div>;
 //This component sets styles directly, and they conflict a bit with our css.
 
 const empty = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5445,11 +5445,11 @@ react-onclickoutside@^4.8.0:
     object-assign "^4.0.1"
 
 react-radio-buttons@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-radio-buttons/-/react-radio-buttons-1.2.0.tgz#7bcad56c0a22a3a0f460b2171ce1acbcba397ee2"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-radio-buttons/-/react-radio-buttons-1.2.1.tgz#a61c878be9b84fbb79a271293469af1ba2fd2257"
   dependencies:
     prop-types "^15.5.10"
-    react "^15.3.2"
+    react "^15.6.1"
     react-dom "^15.3.2"
 
 react-redux@^4.4.5:
@@ -5463,7 +5463,7 @@ react-redux@^4.4.5:
     loose-envify "^1.1.0"
     prop-types "^15.5.4"
 
-react@^15.1.0, react@^15.3.2:
+react@^15.1.0, react@^15.6.1:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:


### PR DESCRIPTION
The final polyfill in the list was not loading as the get parameter separator wasn't separating as it still thought it was in a list. This also adds Array.prototype.findIndex