### PR TITLE
Fix error handler to use dependency injection rather than use the default

### DIFF
--- a/app/MyApplicationLoader.scala
+++ b/app/MyApplicationLoader.scala
@@ -5,7 +5,6 @@ import loghandling.Logstash
 import monitoring.{ErrorHandler, SentryLogging}
 import play.api.ApplicationLoader.Context
 import play.api._
-import play.api.http.DefaultHttpErrorHandler
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.EssentialFilter
 import play.filters.csrf.CSRFComponents

--- a/app/MyApplicationLoader.scala
+++ b/app/MyApplicationLoader.scala
@@ -2,9 +2,10 @@ import configuration.Config
 import controllers._
 import filters.{AddEC2InstanceHeader, AddGuIdentityHeaders, CheckCacheHeadersFilter, HandleXFrameOptionsOverrideHeader}
 import loghandling.Logstash
-import monitoring.SentryLogging
+import monitoring.{ErrorHandler, SentryLogging}
 import play.api.ApplicationLoader.Context
 import play.api._
+import play.api.http.DefaultHttpErrorHandler
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.EssentialFilter
 import play.filters.csrf.CSRFComponents
@@ -31,7 +32,10 @@ class MyComponents(context: Context)
 
   val touchpointBackends = new TouchpointBackends(actorSystem, wsClient)
 
-  lazy val router = new Routes(
+  override lazy val httpErrorHandler: ErrorHandler =
+    new ErrorHandler(environment, configuration, sourceMapper, Some(router))
+
+  lazy val router: Routes = new Routes(
     httpErrorHandler,
     new CachedAssets(),
     new Homepage(),

--- a/app/monitoring/ErrorHandler.scala
+++ b/app/monitoring/ErrorHandler.scala
@@ -1,25 +1,22 @@
 package monitoring
 
-import javax.inject._
-
 import controllers.{Cached, NoCache}
 import play.api._
 import play.api.http.DefaultHttpErrorHandler
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.routing.Router
-import com.gu.zuora.soap
+import play.core.SourceMapper
 
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import scala.concurrent._
 
-class ErrorHandler @Inject() (env: Environment,
-                              config: Configuration,
-                              sourceMapper: OptionalSourceMapper,
-                              router: Provider[Router]
-                              ) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) {
-
-  type Handler = PartialFunction[Throwable, Future[Result]]
+class ErrorHandler(
+  env: Environment,
+  config: Configuration,
+  sourceMapper: Option[SourceMapper],
+  router: => Option[Router]
+) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) {
 
   override def onClientError(request: RequestHeader, statusCode: Int, message: String = ""): Future[Result] = {
     super.onClientError(request, statusCode, message).map(Cached(_))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -35,8 +35,6 @@ subscriptions.url="https://subscribe.theguardian.com"
 
 subscriptions.preview-x-frame-options-override = "https://memsub-promotions.gutools.co.uk"
 
-play.http.errorHandler = "monitoring.ErrorHandler"
-
 play.application.loader=MyApplicationLoader
 
 cas {


### PR DESCRIPTION
Following updating things to use Dependency injection, unfortunately I missed the fact that the error handler used to be loaded from an old style class from reflection.

This meant that 404 errors were served the default way which didn't include caching, at which point our cacheing header checking code turned it into a 500.

I worked out what the problem was and wired in the correct functinality.

Ideally I can get this out before the end of the day, to avoid having to decide whether to roll back the main change over the weekend (to avoid messing up our alerting)

@jacobwinch @pvighi @paulbrown1982 