### PR TITLE
if we cant get the card update form, pretend it doesnt exist

### DIFF
--- a/assets/javascripts/modules/mma/updatePayment.jsx
+++ b/assets/javascripts/modules/mma/updatePayment.jsx
@@ -59,8 +59,7 @@ const CardUpdate = ({ card, handler }) => (<div><button className="button button
 const Success = () => (<p>Thank you, we have successfully updated your payment details.</p>)
 const Failure = ({ phone }) => <p>Unfortunately, we are unable to update your payment details at this time, please contact the call centre. {phone}</p>
 const Unavailable = ({ phone }) => <span>
-    <p>Sorry, unfortunately we are unable to retreive your payment details at this time.</p>
-    <p>If you wish to update your payment details, please refresh the page, alternatively contact the call centre. {phone}</p>
+    <p>To update your payment details, please contact the call centre. {phone}</p>
     </span>
 
 const Waiting = () => (<div className="loader js-loader is-loading">Processing&hellip;</div>)


### PR DESCRIPTION
This may or may not be the cause of people getting worried their renewal hasn't worked and phoning up.  However it makes sense to revisit the message.

To be honest, we should probably track failures to display in sentry so that we know if it's a problem that people can't update their card, but we don't need people to call us thinking something else is wrong.  

We don't need to reveal anything is wrong at all, as there's no specific action they can take as a result, so I've removed all references to problems from the message.

Inspired by Alex' "just create a PR - then get it done and dusted" philosophy, I was in that code anyway so I've done a PR!

Any thoughts @AWare @paulbrown1982 @jacobwinch 
