### PR TITLE
Make the contact centre details respond to URL and billing country better

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -255,11 +255,11 @@ object ManageWeekly extends ContextLogging {
 
     if (weeklySubscription.readerType == ReaderType.Agent) {
       info(s"don't support agents, can't manage sub")
-      Future.successful(Ok(views.html.account.details(None, promoCode, Some("You subscribe via an agent, at present you can't manage it via the web, please contact customer services for help.")))) // don't support gifts (yet) as they have related contacts in salesforce of unknown structure
+      Future.successful(Ok(views.html.account.details(None, promoCode, Some("You subscribe via an agent, at present you can't manage it via the web, please contact Customer Services for help.")))) // don't support gifts (yet) as they have related contacts in salesforce of unknown structure
     } else {
       maybePageToShow.map(_.leftMap(errorMessage => {
         error(s"problem getting account: $errorMessage")
-        Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but it can't be managed via the web, please contact customer services for help.")))
+        Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but it can't be managed via the web, please contact Customer Services for help.")))
       }).fold(identity, identity))
     }
   }
@@ -393,7 +393,7 @@ class AccountManagement(touchpointBackends: TouchpointBackends) extends Controll
       }
       maybeFutureManagePage.getOrElse {
         // the product type didn't have the right charges
-        Future.successful(Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but can't manage it via the web, please contact customer services for help."))))
+        Future.successful(Ok(views.html.account.details(None, promoCode, Some("We found your subscription, but can't manage it via the web, please contact Customer Services for help."))))
       }
     }
 
@@ -414,7 +414,7 @@ class AccountManagement(touchpointBackends: TouchpointBackends) extends Controll
       "error" -> errorMessage
     )
     subscriptionFromUserDetails(loginRequest).map {
-        case Some(sub) if (sub.isCancelled) =>  loginError(s"Your subscription is cancelled as of ${sub.termEndDate.pretty}, please contact customer services.")
+        case Some(sub) if (sub.isCancelled) =>  loginError(s"Your subscription is cancelled as of ${sub.termEndDate.pretty}, please contact Customer Services.")
         case Some(sub) => SessionSubscription.set(Redirect(routes.AccountManagement.manage(None, None, promoCode)), sub)
         case _ => loginError("Unable to verify your details.")
     }

--- a/app/controllers/SessionKeys.scala
+++ b/app/controllers/SessionKeys.scala
@@ -10,6 +10,6 @@ object SessionKeys {
   val SupplierTrackingCode = "newSubs_supplierCode"
   val Currency = "newSubs_currency"
   val StartDate = "newSubs_startDate"
-  val Edition = "newSubs_edition"
+  val BillingCountryName = "newSubs_billingCountryName"
   val MarketingOptIn = "newSubs_marketingOptIn"
 }

--- a/app/model/Subscriptions.scala
+++ b/app/model/Subscriptions.scala
@@ -1,5 +1,6 @@
 package model
 
+import com.gu.memsub.Product
 import com.gu.memsub.Product.{Delivery, Voucher}
 import play.twirl.api.Html
 
@@ -26,6 +27,7 @@ object Subscriptions {
     val steps: Seq[String]
     val insideM25: Boolean
     val isDiscounted: Boolean
+    val catalogProduct: Product
     def capitalizedTitle = title.split("\\s").map(_.capitalize).mkString(" ")
   }
 
@@ -36,6 +38,7 @@ object Subscriptions {
     options: Seq[SubscriptionOption],
     isDiscounted: Boolean = false
   ) extends SubscriptionProduct {
+    override val catalogProduct = Product.Delivery
     override val insideM25 = true
     override val id = Delivery.name
     val stepsHeading = "This is how direct delivery works"
@@ -53,6 +56,7 @@ object Subscriptions {
     options: Seq[SubscriptionOption],
     isDiscounted: Boolean = false
   ) extends SubscriptionProduct {
+    override val catalogProduct = Product.Voucher
     override val insideM25 = false
     override val id = Voucher.name
     val stepsHeading = "This is how the voucher scheme works"

--- a/app/views/account/delivery.scala.html
+++ b/app/views/account/delivery.scala.html
@@ -1,6 +1,6 @@
 @import com.gu.i18n.Country
 @import com.gu.memsub.Benefit.PaperDay
-@import com.gu.memsub.BillingSchedule
+@import com.gu.memsub.{BillingSchedule, Product}
 @import com.gu.memsub.subsv2.Subscription
 @import com.gu.memsub.subsv2.SubscriptionPlan.DailyPaper
 @import com.gu.subscriptions.suspendresume.SuspensionService.{HolidayRefund, holidayToDays}
@@ -23,7 +23,7 @@
     maybeEmail: Option[String],
     paymentMethodIsPaymentCard: Boolean
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackends.Resolution)
-@main("Manage your subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true, contactUsCountry = Some(Country.UK)) {
+@main("Manage your subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true, contactUsCountry = Some(Country.UK), product = Some(Product.Delivery)) {
 
     <main class="page-container gs-container">
         <section class="suspend-container">

--- a/app/views/account/delivery.scala.html
+++ b/app/views/account/delivery.scala.html
@@ -1,16 +1,16 @@
+@import com.gu.i18n.Country
+@import com.gu.memsub.Benefit.PaperDay
 @import com.gu.memsub.BillingSchedule
-@import com.gu.subscriptions.suspendresume.SuspensionService.HolidayRefund
 @import com.gu.memsub.subsv2.Subscription
+@import com.gu.memsub.subsv2.SubscriptionPlan.DailyPaper
+@import com.gu.subscriptions.suspendresume.SuspensionService.{HolidayRefund, holidayToDays}
+@import com.gu.zuora.soap.models.Queries.Account
 @import configuration.Config.suspendableWeeks
-@import com.gu.subscriptions.suspendresume.SuspensionService.holidayToDays
 @import model.DigitalEdition.UK
 @import model.SubscriptionOps._
-@import com.gu.memsub.Product.Delivery
-@import views.support.Dates.prettyDate
 @import views.support.AccountManagementOps._
-@import com.gu.memsub.subsv2.SubscriptionPlan.DailyPaper
-@import com.gu.memsub.Benefit.PaperDay
-@import com.gu.zuora.soap.models.Queries.Account
+@import views.support.ContactCentreOps
+@import views.support.Dates.prettyDate
 @(
     subscription: Subscription[DailyPaper],
     billingAccount: Account,
@@ -23,7 +23,7 @@
     maybeEmail: Option[String],
     paymentMethodIsPaymentCard: Boolean
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackends.Resolution)
-@main("Manage your subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {
+@main("Manage your subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true, contactUsCountry = Some(Country.UK)) {
 
     <main class="page-container gs-container">
         <section class="suspend-container">
@@ -38,7 +38,7 @@
                 </p>
                 <p>
                     If you have any other customer service enquir​ies,
-                    please contact us on: <a href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
+                    please contact us on: <a href="@ContactCentreOps.hrefTelNumber(Country.UK)">@ContactCentreOps.directLine(Country.UK)</a>
                     or email <a href="mailto:homedelivery@@theguardian.com">homedelivery@@theguardian.com</a>.
                 </p>
             </div>
@@ -140,7 +140,7 @@
             @if(paymentMethodIsPaymentCard) {
                 <section class="mma-section">
                     <h3 class="mma-section__header">Update your payment method</h3>
-                    @views.html.account.fragments.paymentUpdate(subscription, maybeEmail, subscription.plans.head.product, UK)
+                    @views.html.account.fragments.paymentUpdate(subscription, maybeEmail, subscription.plans.head.product, Some(Country.UK))
                 </section>
             }
         </section>

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -1,45 +1,39 @@
-@import model.DigitalEdition.UK
-@import configuration.Config.Identity.idWebAppSigninUrl
+@import com.gu.i18n.Country
 @import com.gu.memsub.promo.PromoCode
+@import configuration.Config.Identity.idWebAppSigninUrl
+@import model.DigitalEdition.UK
+@import views.support.ContactCentreOps._
 @(
     subscriberId: Option[String],
     promoCode: Option[PromoCode],
     message: Option[String]= None
 )(implicit request: RequestHeader, flash: Flash, touchpointBackendResolution: services.TouchpointBackends.Resolution)
 
-@main("Manage your subscription | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution)) {
+@main("Manage your subscription | The Guardian", edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {
 
     <main class="page-container gs-container">
 
         <section class="suspend-container">
 
             <div class="suspend-header">
-                <h1 class="suspend-header__title">Manage your Guardian subscription</h1>
+                <h1 class="suspend-header__title">Manage your subscription</h1>
             </div>
 
             <div>
-                <p>All subscribers - check your subscription details and payment schedule here.</p>
-                <p>In addition:</p>
-                <p>Home Delivery subscribers - suspend your deliveries while you're away.</p>
-                <p>Guardian Weekly subscribers - renew your subscription here.</p>
+                <h3>In this area you can:</h3>
+                <p>Review your subscription details and payment schedule.</p>
+                <p>If you get your copy of The Guardian or The Observer delivered, you can suspend delivery while you're away.</p>
+                <p>If you have a fixed-term Guardian Weekly subscription, you can renew it here.</p>
             </div>
 
-            <br/>
-
-            <div class="prose">
+            <div>
+                <h3>Instructions</h3>
                 <p>
-                    Please log in below using your ​​Subscriber ID​, which you can find on any correspondence.
-                </p>
-                <p>
-                    If you do not have your Subscriber ID to hand, or need anything else,
-                    please contact customer services on: <a class="u-link" href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
-                    or email <a class="u-link" href="mailto:subscriptions@@theguardian.com">subscriptions@@theguardian.com</a>.
+                    Please log in below using your ​​Subscriber ID​, which you can find on any correspondence, and your last name.
                 </p>
             </div>
 
-            <br/>
-
-            <form class="form js-suspend-form" action="@routes.AccountManagement.processLogin().url" method="POST" novalidate>
+            <form class="form js-suspend-form u-cf" action="@routes.AccountManagement.processLogin().url" method="POST" novalidate>
 
                 @helper.CSRF.formField
 
@@ -94,6 +88,19 @@
                 </div>
 
             </form>
+
+            <div>
+                <p>
+                    If you do not have your Subscriber ID to hand, or need anything else,
+                    please email <a class="u-link" href="@hrefMailto">@email</a> or contact customer services:
+                </p>
+                <h4>Australia and New Zealand</h4>
+                <p>@phone(Country.Australia)&#46;</p>
+                <h4>United States and Canada</h4>
+                <p>@phone(Country.US)&#46;</p>
+                <h4>UK and rest of the world</h4>
+                <p>@phone()&#46;</p>
+            </div>
 
         </section>
         <br/>

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -92,7 +92,7 @@
             <div>
                 <p>
                     If you do not have your Subscriber ID to hand, or need anything else,
-                    please email <a class="u-link" href="@hrefMailto">@email</a> or contact customer services:
+                    please email <a class="u-link" href="@hrefMailto">@email</a> or contact Customer Services:
                 </p>
                 <h4>Australia and New Zealand</h4>
                 <p>@phone(Country.Australia)&#46;</p>

--- a/app/views/account/digitalpack.scala.html
+++ b/app/views/account/digitalpack.scala.html
@@ -1,18 +1,15 @@
+@import com.gu.i18n.Country
 @import com.gu.memsub.BillingSchedule
-@import com.gu.memsub.subsv2.SubscriptionPlan.Digipack
 @import com.gu.memsub.subsv2.Subscription
+@import com.gu.memsub.subsv2.SubscriptionPlan.Digipack
 @import model.DigitalEdition.UK
-@import model.DigitalEdition
 @import model.SubscriptionOps._
-@import org.joda.time.LocalDate.now
 @import org.joda.time.Days.daysBetween
+@import org.joda.time.LocalDate.now
 @import views.support.Dates._
 @import views.support.Pricing._
-@import com.gu.zuora.ZuoraRestService.SoldToContact
-
-@import com.gu.i18n.Country
 @(
-    subscription: Subscription[Digipack], billingSchedule: Option[BillingSchedule], country: Option[Country], maybeEmail:Option[String], paymentMethodIsPaymentCard: Boolean
+    subscription: Subscription[Digipack], billingSchedule: Option[BillingSchedule], billingCountry: Option[Country], maybeEmail: Option[String], paymentMethodIsPaymentCard: Boolean
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackends.Resolution)
 
 @main("Your Guardian Digital Pack subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {
@@ -62,7 +59,7 @@
             @if(paymentMethodIsPaymentCard) {
                 <section class="mma-section">
                     <h3 class="mma-section__header">Update your payment method</h3>
-                    @views.html.account.fragments.paymentUpdate(subscription, maybeEmail, subscription.plans.head.product, DigitalEdition.getForCountry(country))
+                    @views.html.account.fragments.paymentUpdate(subscription, maybeEmail, subscription.plans.head.product, billingCountry)
                 </section>
             }
         </section>

--- a/app/views/account/fragments/paymentUpdate.scala.html
+++ b/app/views/account/fragments/paymentUpdate.scala.html
@@ -1,10 +1,7 @@
-@import com.gu.memsub.subsv2.Subscription
-@import com.gu.memsub.subsv2.SubscriptionPlan
-@import model.DigitalEdition
+@import com.gu.i18n.Country
 @import com.gu.memsub.Product
-
+@import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
 @import views.support.PlanOps._
 
-@import com.gu.zuora.ZuoraRestService.SoldToContact
-@(subscription:Subscription[SubscriptionPlan.ContentSubscription], maybeEmail: Option[String], product: Product, edition: DigitalEdition)
-<div class="js-payment-update" data-sub-id="@{subscription.name.get}" @for(email <- maybeEmail) {data-email="@email"} data-phone="@product.phone(edition)" data-product="@product.name"></div>
+@(subscription:Subscription[SubscriptionPlan.ContentSubscription], maybeEmail: Option[String], product: Product, contactUsCountry: Option[Country])
+<div class="js-payment-update" data-sub-id="@{subscription.name.get}" @for(email <- maybeEmail) {data-email="@email"} data-phone="@product.phone(contactUsCountry)" data-product="@product.name"></div>

--- a/app/views/account/fragments/suspensions.scala.html
+++ b/app/views/account/fragments/suspensions.scala.html
@@ -1,6 +1,8 @@
+@import com.gu.i18n.Country.UK
 @import com.gu.i18n.Currency.GBP
 @import com.gu.memsub.Price
 @import com.gu.subscriptions.suspendresume.SuspensionService.HolidayRefund
+@import views.support.ContactCentreOps
 @import views.support.Dates.formattedDateRange
 
 @(holidayRefunds: Seq[HolidayRefund] = Seq.empty, suspendableDays: Int, suspendedDays: Int)
@@ -18,7 +20,7 @@
                 <strong>You cannot line up any more days</strong>.
             }
             <p class="scheduled-suspensions__help">
-                Please contact Customer Services on <a href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a> or email <a href="mailto:subscriptions@@theguardian.com">subscriptions@@theguardian.com</a> if you wish to cancel or amend any of these.
+                Please contact Customer Services on: <a href="@ContactCentreOps.hrefTelNumber(UK)">@ContactCentreOps.directLine(UK)</a> or email <a href="@ContactCentreOps.hrefMailto">@ContactCentreOps.email</a> if you wish to cancel or amend any of these.
             </p>
     </div>
 } else {

--- a/app/views/account/reportDeliveryProblemFailure.scala.html
+++ b/app/views/account/reportDeliveryProblemFailure.scala.html
@@ -1,9 +1,12 @@
+@import com.gu.i18n.Country.UK
+@import views.support.ContactCentreOps
+
 @main("Delivery Problem | The Guardian", bodyClasses=List("is-wide")) {
     <main class="page-container gs-container gs-container--slim">
         @fragments.page.header("Sorry, we were unable to determine your delivery status", None, List("l-padded"))
         <section class="section-slice section-slice--bleed section-slice--limited">
-            In order to resolve this problem, please contact customer services on: <a class="u-link" href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
-            or email <a class="u-link" href="mailto:subscriptions@@theguardian.com">subscriptions@@theguardian.com</a>.
+            In order to resolve this problem, please contact Customer Services on: <a class="u-link" href="@ContactCentreOps.hrefTelNumber(UK)">@ContactCentreOps.directLine(UK)</a>
+            or email <a class="u-link" href="@ContactCentreOps.hrefMailto">@ContactCentreOps.email</a>.
         </section>
         <section class="section-slice--bleed mma-section">
             <a class="button button--primary button--large" href="@routes.AccountManagement.processLogin().url">

--- a/app/views/account/reportDeliveryProblemSuccess.scala.html
+++ b/app/views/account/reportDeliveryProblemSuccess.scala.html
@@ -1,5 +1,7 @@
+@import com.gu.i18n.Country.UK
 @import model.FulfilmentLookup
 @import org.joda.time.LocalDate
+@import views.support.ContactCentreOps
 @(
     fulfilmentLookup: FulfilmentLookup,
     date: LocalDate
@@ -13,8 +15,8 @@
                 Thanks for reporting this problem. We will investigate and get back to you soon.
             </p>
             <p>
-                If you need any further assistance, please contact customer services on: <a class="u-link" href="tel:+44 330 333 6767">+44 (0) 330 333 6767</a>
-                or email <a class="u-link" href="mailto:subscriptions@@theguardian.com">subscriptions@@theguardian.com</a>.
+                If you need any further assistance, please contact customer services on: <a class="u-link" href="@ContactCentreOps.hrefTelNumber(UK)">@ContactCentreOps.phone(UK)</a>
+                or email <a class="u-link" href="@ContactCentreOps.hrefMailto">@ContactCentreOps.email</a>.
             </p>
         </section>
         <section class="section-slice--bleed mma-section">

--- a/app/views/account/reportDeliveryProblemSuccess.scala.html
+++ b/app/views/account/reportDeliveryProblemSuccess.scala.html
@@ -15,7 +15,7 @@
                 Thanks for reporting this problem. We will investigate and get back to you soon.
             </p>
             <p>
-                If you need any further assistance, please contact customer services on: <a class="u-link" href="@ContactCentreOps.hrefTelNumber(UK)">@ContactCentreOps.phone(UK)</a>
+                If you need any further assistance, please contact Customer Services on: <a class="u-link" href="@ContactCentreOps.hrefTelNumber(UK)">@ContactCentreOps.phone(UK)</a>
                 or email <a class="u-link" href="@ContactCentreOps.hrefMailto">@ContactCentreOps.email</a>.
             </p>
         </section>

--- a/app/views/account/voucher.scala.html
+++ b/app/views/account/voucher.scala.html
@@ -1,13 +1,14 @@
+@import com.gu.i18n.Country
 @import com.gu.memsub.BillingSchedule
 @import com.gu.memsub.subsv2.Subscription
+@import com.gu.memsub.subsv2.SubscriptionPlan.Voucher
 @import model.DigitalEdition.UK
 @import model.SubscriptionOps._
-@import com.gu.memsub.subsv2.SubscriptionPlan.Voucher
 @(
     subscription: Subscription[Voucher], billingSchedule: Option[BillingSchedule], maybeEmail: Option[String], paymentMethodIsPaymentCard: Boolean
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackends.Resolution)
 
-@main("Your Guardian subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {
+@main("Your Guardian subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true, contactUsCountry = Some(Country.UK)) {
 
     <main class="page-container gs-container">
         <section class="suspend-container">
@@ -35,7 +36,7 @@
             @if(paymentMethodIsPaymentCard) {
                 <section class="mma-section">
                     <h3 class="mma-section__header">Update your payment method</h3>
-                    @views.html.account.fragments.paymentUpdate(subscription, maybeEmail, subscription.plans.head.product, UK)
+                    @views.html.account.fragments.paymentUpdate(subscription, maybeEmail, subscription.plans.head.product, Some(Country.UK))
                 </section>
             }
         </section>

--- a/app/views/account/voucher.scala.html
+++ b/app/views/account/voucher.scala.html
@@ -1,5 +1,5 @@
 @import com.gu.i18n.Country
-@import com.gu.memsub.BillingSchedule
+@import com.gu.memsub.{BillingSchedule, Product}
 @import com.gu.memsub.subsv2.Subscription
 @import com.gu.memsub.subsv2.SubscriptionPlan.Voucher
 @import model.DigitalEdition.UK
@@ -8,7 +8,7 @@
     subscription: Subscription[Voucher], billingSchedule: Option[BillingSchedule], maybeEmail: Option[String], paymentMethodIsPaymentCard: Boolean
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackends.Resolution)
 
-@main("Your Guardian subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true, contactUsCountry = Some(Country.UK)) {
+@main("Your Guardian subscription | The Guardian", bodyClasses = List("is-wide"), edition = UK, touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true, contactUsCountry = Some(Country.UK), product = Some(Product.Voucher)) {
 
     <main class="page-container gs-container">
         <section class="suspend-container">

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -1,16 +1,14 @@
+@import com.gu.i18n.Country
 @import com.gu.memsub.BillingSchedule
-@import com.gu.memsub.subsv2.SubscriptionPlan
-@import com.gu.memsub.subsv2.Subscription
-@import model.DigitalEdition
-@import com.gu.salesforce.Contact
-@import model.SubscriptionOps._
-@import org.joda.time.LocalDate.now
+@import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
 @import com.gu.zuora.ZuoraRestService.SoldToContact
+@import model.DigitalEdition
+@import model.SubscriptionOps._
 @(
-    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: Option[BillingSchedule], contact: SoldToContact, maybeEmail:Option[String], paymentMethodIsPaymentCard: Boolean
+    subscription: Subscription[SubscriptionPlan.WeeklyPlan], billingSchedule: Option[BillingSchedule], contact: SoldToContact, maybeEmail:Option[String], paymentMethodIsPaymentCard: Boolean, contactUsCountry: Option[Country]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackends.Resolution)
 
-@main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = DigitalEdition.getForCountry(contact.country), touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true) {
+@main("Your Guardian Weekly subscription | The Guardian", bodyClasses = List("is-wide"), edition = DigitalEdition.getForCountry(contactUsCountry), touchpointBackendResolutionOpt = Some(touchpointBackendResolution), managementPage = true, contactUsCountry = contactUsCountry) {
     @helper.javascriptRouter("jsRoutes")(
         routes.javascript.Promotion.validate
     )
@@ -41,7 +39,7 @@
             @if(paymentMethodIsPaymentCard) {
                 <section class="mma-section">
                     <h3 class="mma-section__header">Update your payment method</h3>
-                    @views.html.account.fragments.paymentUpdate(subscription, maybeEmail, subscription.plans.head.product, DigitalEdition.getForCountry(contact.country))
+                    @views.html.account.fragments.paymentUpdate(subscription, maybeEmail, subscription.plans.head.product, contactUsCountry)
                 </section>
             }
         </section>

--- a/app/views/account/weeklyRenew.scala.html
+++ b/app/views/account/weeklyRenew.scala.html
@@ -1,17 +1,15 @@
-@import configuration.Links
-@import com.gu.memsub.subsv2.Subscription
-@import model.DigitalEdition.UK
-@import views.support.Dates.prettyDate
-@import com.gu.i18n.Country
-@import controllers.ManageWeekly.WeeklyPlanInfo
-@import model.SubscriptionOps._
-@import play.api.libs.json.Json
-@import controllers.CachedAssets.hashedPathFor
-
-@import com.gu.i18n.Currency
+@import com.gu.i18n.{Country, Currency}
 @import com.gu.memsub.promo.PromoCode
-@import org.joda.time.LocalDate.now
+@import com.gu.memsub.subsv2.Subscription
 @import com.gu.zuora.ZuoraRestService.SoldToContact
+@import configuration.Links
+@import controllers.CachedAssets.hashedPathFor
+@import controllers.ManageWeekly.WeeklyPlanInfo
+@import model.DigitalEdition.UK
+@import model.SubscriptionOps._
+@import org.joda.time.LocalDate.now
+@import play.api.libs.json.Json
+@import views.support.Dates.prettyDate
 @(
     subscription: Subscription[WeeklyPlanOneOff], contact: SoldToContact, email: Option[String], billToCountry: Country, plans: List[WeeklyPlanInfo], currency: Currency, promoCode: Option[PromoCode]
 )(implicit r: RequestHeader, touchpointBackendResolution: services.TouchpointBackends.Resolution)
@@ -22,7 +20,8 @@
     edition = UK,
     touchpointBackendResolutionOpt = Some(touchpointBackendResolution),
     managementPage = true,
-    jsVars = model.JsVars(currency = currency, country = Some(billToCountry))
+    jsVars = model.JsVars(currency = currency, country = Some(billToCountry)),
+    contactUsCountry = Some(billToCountry)
 ) {
 
     @helper.javascriptRouter("jsRoutes")(

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -1,17 +1,13 @@
-@import model.JsVars
-@import configuration.Config.Identity._
-@import views.support.Pricing._
-@import com.gu.memsub.promo.PromoCode
-@import com.gu.memsub.SupplierCode
-@import model.PersonalData
-@import views.support.PlanOps._
-@import views.support.ProductPopulationData
-@import com.gu.memsub.subsv2.CatalogPlan
-@import com.gu.i18n.Currency
-@import com.gu.i18n._
-@import model.DigitalEdition
-@import views.support.CountryAndCurrencySettings
+@import com.gu.i18n.{Currency, _}
 @import com.gu.memsub.Product.WeeklyZoneC
+@import com.gu.memsub.SupplierCode
+@import com.gu.memsub.promo.PromoCode
+@import com.gu.memsub.subsv2.CatalogPlan
+@import configuration.Config.Identity._
+@import model.{DigitalEdition, JsVars, PersonalData}
+@import views.support.PlanOps._
+@import views.support.Pricing._
+@import views.support.{CountryAndCurrencySettings, ProductPopulationData}
 
 @(
     personalData: Option[PersonalData],
@@ -68,7 +64,8 @@
     bodyClasses = List("is-wide"),
     touchpointBackendResolutionOpt = Some(touchpointBackendResolution),
     product = Some(productData.plans.default.product),
-    edition = edition
+    edition = edition,
+    contactUsCountry = countryAndCurrencySettings.defaultCountry
 ) {
 <script>
     guardian.supplierCode = '@{supplierCode.mkString}';
@@ -132,7 +129,7 @@
                         }
                         </div>
                         <div class="js-payment-type-direct-debit u-note" hidden="true">
-                            @fragments.checkout.noticesDirectDebit(productData.plans.default)
+                            @fragments.checkout.noticesDirectDebit(productData.plans.default, countryAndCurrencySettings.defaultCountry)
                         </div>
                         <div class="js-payment-type-card u-note" hidden="true">
                             @fragments.checkout.noticesCard()

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -1,20 +1,20 @@
-@import com.gu.i18n.Currency
+@import com.gu.i18n.Country
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import com.gu.memsub.subsv2.Subscription
 @import com.gu.memsub.subsv2.SubscriptionPlan.ContentSubscription
-@import views.support.PlanOps._
-@import model.SubscriptionOps._
-
 @import model.DigitalEdition
+@import model.SubscriptionOps._
+@import views.support.PlanOps._
 @(  subscription: Subscription[ContentSubscription],
     guestAccountForm: Option[Form[model.GuestAccountData]] = None,
     touchpointBackendResolution: services.TouchpointBackends.Resolution,
     promotion: Option[AnyPromotion] = None,
     startDate: String,
-    edition: DigitalEdition
+    edition: DigitalEdition,
+    contactUsCountry: Option[Country]
 )(implicit request: RequestHeader)
 
-@main(s"Confirmation | Subscribe to the ${subscription.firstPlan.title} | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution), product = Some(subscription.firstProduct), edition = edition) {
+@main(s"Confirmation | Subscribe to the ${subscription.firstPlan.title} | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution), product = Some(subscription.firstProduct), edition = edition, contactUsCountry = contactUsCountry) {
 
 <script type="text/javascript">
     guardian.pageInfo.pageType = 'Thankyou';
@@ -44,8 +44,7 @@
                     you'll receive email confirmation of this shortly.
                 </p>
                 <p>Here are the details of your subscription, if any of these are incorrect please get in touch with us straight away via email at
-                    <a href="mailto:@subscription.firstProduct.email">@subscription.firstProduct.email</a> or on <strong>+44 (0) 330 333 6767</strong>.
-                    Lines open weekdays 8am-8pm, weekend 8pm-6pm.</p>
+                    <a href="mailto:@{subscription.firstProduct.email(contactUsCountry)}">@subscription.firstProduct.email(contactUsCountry)</a> or on @subscription.firstProduct.phone(contactUsCountry).</p>
             </div>
             @fragments.checkout.reviewPanel(subscription, promotion)
         </div>

--- a/app/views/digitalpack/info.scala.html
+++ b/app/views/digitalpack/info.scala.html
@@ -1,7 +1,7 @@
 @import com.gu.memsub.Price
+@import com.gu.memsub.Product.Digipack
 @import model.DigitalEdition
 @import views.support.DigitalEdition._
-@import model.DigitalEdition.UK
 @(edition: DigitalEdition, price: Price)
 
 @import model.Benefits
@@ -25,7 +25,9 @@
     title = s"Subscribe to the Guardian Digital Pack | The Guardian (${edition.name})",
     description = Some("The Digital Pack gives you access to the Guardian & Observer daily editions as well as premium tier access to the iOS and Android live news apps"),
     bodyClasses = List("is-wide"),
-    edition=edition
+    edition = edition,
+    product = Some(Digipack),
+    contactUsCountry = edition.countryGroup.defaultCountry
 ) {
 <script>
     guardian.pageInfo.pageType = 'Landing';
@@ -35,7 +37,7 @@
 
     <section class="page-slice">
         <div class="page-slice__content">
-            @fragments.page.header("Digital Pack", Some("Digital access to our Daily Edition and Guardian App Premium Tier"))
+            @fragments.page.header(s"Digital Pack", Some("Digital access to our Daily Edition and Guardian App Premium Tier"))
             @startTrial(edition, price)
         </div>
     </section>

--- a/app/views/error400.scala.html
+++ b/app/views/error400.scala.html
@@ -5,7 +5,7 @@
             <div class="prose">
                     <p>
                         Sorry, there was an error with this page. Please contact support at
-                        <a href="mailto:customer.experience@@theguardian.com">customer.experience@@theguardian.com</a>.
+                        <a href="mailto:userhelp@@theguardian.com">userhelp@@theguardian.com</a>.
                     </p>
 
                     <p>Please provide the following error code to help identify the issue.</p>

--- a/app/views/error500.scala.html
+++ b/app/views/error500.scala.html
@@ -4,7 +4,7 @@
         @fragments.page.header("Error 500", Some("There was an error on this page"))
         <p>
             Sorry, there was an error on this page. We're aware of the problem. If this error persists, please contact
-            support at <a href="mailto:customer.experience@@theguardian.com">customer.experience@@theguardian.com</a>.
+            support at <a href="mailto:userhelp@@theguardian.com">userhelp@@theguardian.com</a>.
         </p>
         @ex match {
             case err: play.api.UsefulException => {

--- a/app/views/fragments/checkout/address.scala.html
+++ b/app/views/fragments/checkout/address.scala.html
@@ -1,11 +1,11 @@
+@import com.gu.i18n.Country.UK
 @import com.gu.i18n.Currency
 @import com.gu.memsub.Address
 @import com.gu.memsub.subsv2.CatalogPlan
 @import views.support.AddressValidationRulesOps._
 @import views.support.CountryOps._
-@import views.support.CountryWithCurrency
+@import views.support.{ContactCentreOps, CountryWithCurrency}
 @import views.support.PlanOps._
-
 @(address: Option[Address], namePrefix: String, countriesWithCurrency: List[CountryWithCurrency], plan: CatalogPlan.Paid, usePostcodeLookup: Boolean, determinesPriceBanding: Boolean, defaultCurrency: Currency)
 
 
@@ -21,7 +21,7 @@
     <div class="form-field js-checkout-postcode"
         @if(plan.isHomeDelivery) {
             data-validate-for="@namePrefix"
-            data-error-message="Sorry, we cannot deliver a paper to an address with this postcode. Please call Customer Services on: +44 (0) 330 333 6767 or press Back to purchase a voucher subscription."
+            data-error-message="Sorry, we cannot deliver a paper to an address with this postcode. Please call Customer Services on: @{ContactCentreOps.directLine(UK)} or press Back to purchase a voucher subscription."
         }>
         <label class="label" @labelFor("postcode")>Postcode</label>
         @if(usePostcodeLookup) {

--- a/app/views/fragments/checkout/noticesDirectDebit.scala.html
+++ b/app/views/fragments/checkout/noticesDirectDebit.scala.html
@@ -1,7 +1,8 @@
+@import com.gu.i18n.Country
+@import com.gu.memsub.subsv2.CatalogPlan
 @import controllers.CachedAssets.hashedPathFor
 @import views.support.PlanOps._
-@import com.gu.memsub.subsv2.CatalogPlan
-@(plan: CatalogPlan.Paid)
+@(plan: CatalogPlan.Paid, defaultCountry: Option[Country])
 
 @fragments.checkout.notice("Advance Notice") {
     <p>
@@ -23,8 +24,8 @@
     </address>
 
     <ul class="o-unstyled-list">
-        <li>Tel: +44 (0) 330 333 6767</li>
-        <li><a href="mailto:@plan.product.email">@plan.product.email</a></li>
+        <li>Tel: @plan.product.phone(defaultCountry)</li>
+        <li><a href="mailto:@plan.product.email(defaultCountry)">@plan.product.email(defaultCountry)</a></li>
     </ul>
 
     <aside class="direct-debit">

--- a/app/views/fragments/global/footer.scala.html
+++ b/app/views/fragments/global/footer.scala.html
@@ -1,28 +1,27 @@
-@import configuration.Links
-@import org.joda.time.DateTime
-@import com.gu.memsub.BillingPeriod
-@import views.support.PlanOps._
-@import com.gu.memsub.subsv2.CatalogPlan
-@import com.gu.memsub.Current
-@import model.DigitalEdition
+@import com.gu.i18n.Country
 @import com.gu.memsub.Product
+@import com.gu.memsub.Product.Digipack
+@import model.DigitalEdition
+@import org.joda.time.DateTime
+@import views.support.PlanOps._
+@(maybeProduct: Option[Product], edition: DigitalEdition, contactUsCountry: Option[Country])
 
-@(maybeProduct: Option[Product], edition: DigitalEdition)
-@product = @{maybeProduct.getOrElse(Product.Digipack)}
+@email = @{maybeProduct.email(contactUsCountry)}
+@phone = @{maybeProduct.phone(contactUsCountry)}
 <footer class="global-footer">
 
     @fragments.global.brandbar()
-    @fragments.global.navigation(edition, false)
+    @fragments.global.navigation(edition, managementPage = false)
 
     <div class="global-footer__info">
         <div class="gs-container">
             <p>
               For help with Guardian and Observer subscription services please email
-                  <a href="mailto:@maybeProduct.fold("subscriptions@theguardian.com")(_.email)">@maybeProduct.fold("subscriptions@theguardian.com")(_.email)</a> or call            @product.phone(edition)
+                  <a href="mailto:@email">@email</a> or call @phone
             </p>
             <p>
                 You may also find help in our
-                <a href="@product.faqHref"
+                <a href="@maybeProduct.getOrElse(Digipack).faqHref"
                    title="Frequently Asked Questions">
                    Frequently Asked Questions.
                 </a>

--- a/app/views/fragments/promotion/digitalpackLegalTerms.scala.html
+++ b/app/views/fragments/promotion/digitalpackLegalTerms.scala.html
@@ -1,14 +1,14 @@
-@import com.gu.memsub.promo.Promotion.AnyPromotion
-@import views.support.MarkdownRenderer
 @import com.gu.memsub.promo.PromoCode
+@import com.gu.memsub.promo.Promotion.AnyPromotion
 @import views.support.Dates.prettyLegalDate
+@import views.support.MarkdownRenderer
 @(promoCode: PromoCode, promotion: AnyPromotion, md: MarkdownRenderer)
 @Html(md.render(
 s"""
 1. The promotion (the “Promotion”) is open to new Digital Pack subscribers aged 18 and over ("you") subject to paragraph 2 below.
 2. Employees or agencies of Guardian News & Media Limited ("GNM", "We") and/or their group companies or their family members, or anyone else connected with the promotion may not enter the Promotion.
 3. By entering the promotion you are accepting these terms and conditions.
-4. To enter the promotion, you must: (i) either go to [subscribe.theguardian.com](https://subscribe.theguardian.com/) or call 0330 333 6767 and quote promotion code ${promoCode.get} (ii) purchase a Digital Pack subscription and maintain that subscription for at least three months.
+4. To enter the promotion, you must: (i) either go to [subscribe.theguardian.com](https://subscribe.theguardian.com/) or call +44 (0) 330 333 6767 and quote promotion code ${promoCode.get} (ii) purchase a Digital Pack subscription and maintain that subscription for at least three months.
 5. Entry to this promotion is available only to new subscribers: this means that you must not already have a subscription to the Digital Pack to be eligible to participate in this Promotion.
 6. Please note that purchasing a subscription as referred to in paragraph 4 above will also be subject to the terms and conditions for Guardian and Observer Digital subscriptions available at [theguardian.com/digital-subscriptions-terms-conditions](https://www.theguardian.com/digital-subscriptions-terms-conditions)
 7. The opening date and time of the Promotion is ${prettyLegalDate(promotion.starts)}. ${promotion.expires.map(expires => s"The closing date and time of the promotion is ${prettyLegalDate(expires)}. Purchases after that date and time will not be eligible for the promotion.").mkString}

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,11 +1,10 @@
 @import model.DigitalEdition.UK
-@import views.support.DigitalEdition._
 @import services.FlashSale
 @()
 
 @main(
     "Subscriptions | The Guardian",
-    Some("Subscribe to The Guardian & Observer. Support our independent, award-winning journalism."),
+    Some("Subscribe to The Guardian & The Observer. Support our independent, award-winning journalism."),
     edition = UK) {
 
     <main class="page-container gs-container">

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -1,12 +1,13 @@
 @import model.DigitalEdition
-@import views.support.DigitalEdition._
-
 @import services.FlashSale
+@import views.support.DigitalEdition._
 @(edition: DigitalEdition)
 
 @main(s"${edition.name} | Subscriptions and Membership | The Guardian",
     Some("Subscribe to The Guardian. Support our independent, award-winning journalism."),
-    edition = edition) {
+    edition = edition,
+    contactUsCountry = edition.countryGroup.defaultCountry
+) {
 
 <main class="page-container gs-container">
     @fragments.page.header("Subscriptions and Membership", Some("Select your preferred package"))

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,12 +1,8 @@
-@import com.gu.memsub.ProductFamily
-@import com.gu.memsub.Subscriptions
-@import utils.TestUsers.{PreSigninTestCookie, NameEnteredInForm, SignedInUsername}
-@import com.gu.memsub.subsv2.CatalogPlan
-@import com.gu.memsub.BillingPeriod
+@import com.gu.i18n.Country
 @import com.gu.memsub.Product
-@import model.DigitalEdition
-
 @import controllers.WeeklyLandingPage.Hreflangs
+@import model.DigitalEdition
+@import utils.TestUsers.{NameEnteredInForm, PreSigninTestCookie, SignedInUsername}
 @(
     title: String,
     description: Option[String] = None,
@@ -16,7 +12,8 @@
     product: Option[Product] = None,
     edition: DigitalEdition = DigitalEdition.INT,
     managementPage: Boolean = false,
-    hreflangs: Option[Hreflangs] = None
+    hreflangs: Option[Hreflangs] = None,
+    contactUsCountry: Option[Country] = None
 )(content: Html)
 
 <!DOCTYPE html>
@@ -47,7 +44,7 @@
             @content
         </div>
 
-        @fragments.global.footer(product, edition)
+        @fragments.global.footer(product, edition, contactUsCountry)
         @fragments.footerJavaScript()
     </body>
 </html>

--- a/app/views/offers/offers_international.scala.html
+++ b/app/views/offers/offers_international.scala.html
@@ -1,13 +1,12 @@
 @import model.DigitalEdition
-@import views.support.DigitalEdition._
-
 @import services.FlashSale
 @(edition: DigitalEdition)
 
 @main(s"${edition.name} | Subscriptions | The Guardian",
     Some("Subscribe to The Guardian. Support our independent, award-winning journalism."),
-    edition = edition) {
-
+    edition = edition,
+    contactUsCountry = edition.countryGroup.defaultCountry
+) {
     <main class="page-container gs-container">
         @fragments.page.header("Subscription offers", Some("Select your preferred package"))
         @fragments.productLists.productListInternational(edition, FlashSale.offersPromoCodes(edition))

--- a/app/views/promotion/weeklyLandingPage.scala.html
+++ b/app/views/promotion/weeklyLandingPage.scala.html
@@ -1,25 +1,13 @@
-@import com.gu.memsub.promo.PromoCode
-@import com.gu.memsub.promo.Promotion.PromoWithWeeklyLandingPage
-@import com.gu.memsub.promo.Promotion.asAnyPromotion
-@import views.support.LandingPageOps._
-@import configuration.Links
-@import model.DigitalEdition
-@import views.support.CommaSplit
-@import views.support.{MarkdownRenderer}
-@import com.gu.memsub.subsv2.Catalog
-@import model.Subscriptions._
-@import controllers.CachedAssets.hashedPathFor
 @import com.gu.i18n.Country
-@import views.support.WeeklyPromotion
-@import com.gu.memsub.promo.Grey
-@import com.gu.memsub.promo.Blue
-@import com.gu.memsub.promo.White
-@import com.gu.memsub.images.ResponsiveImageGroup
-@import com.gu.memsub.images.ResponsiveImageGenerator
 @import com.gu.memsub.BillingPeriod.SixWeeks
-
 @import com.gu.memsub.Product.WeeklyZoneA
+@import com.gu.memsub.images.{ResponsiveImageGenerator, ResponsiveImageGroup}
+@import com.gu.memsub.promo.PromoCode
+@import com.gu.memsub.promo.Promotion.{PromoWithWeeklyLandingPage, asAnyPromotion}
+@import com.gu.memsub.subsv2.Catalog
 @import controllers.WeeklyLandingPage.Hreflangs
+@import model.DigitalEdition
+@import views.support.{CommaSplit, MarkdownRenderer, WeeklyPromotion}
 @(
     country: Country,
     catalog: Catalog,
@@ -40,7 +28,8 @@
         bodyClasses = List("is-wide"),
         product = Some(WeeklyZoneA),// don't specifically need zone a, any weekly is fine
         hreflangs = Some(hreflangs),
-        edition = DigitalEdition.getForCountry(Some(country))
+        edition = DigitalEdition.getForCountry(Some(country)),
+        contactUsCountry = Some(country)
     ) {
 
         <script>

--- a/app/views/shipping/shipping.scala.html
+++ b/app/views/shipping/shipping.scala.html
@@ -1,7 +1,8 @@
+@import com.gu.i18n.Country
 @import model.DigitalEdition.UK
 @(subscription: model.Subscriptions.SubscriptionProduct, productSegment: String)
 
-@main(s"${subscription.capitalizedTitle} | Choose a Package | Subscriptions | The Guardian", edition = UK) {
+@main(s"${subscription.capitalizedTitle} | Choose a Package | Subscriptions | The Guardian", edition = UK, contactUsCountry = Some(Country.UK), product = Some(subscription.catalogProduct)) {
 
     <script>
         guardian.pageInfo.pageType = 'Landing';

--- a/app/views/support/ContactCentreOps.scala
+++ b/app/views/support/ContactCentreOps.scala
@@ -1,0 +1,54 @@
+package views.support
+
+import com.gu.i18n.Country
+import com.gu.i18n.Country.UK
+
+object ContactCentreOps {
+
+  private val countriesHandledByUSCallCentre = Set(Country.Canada, Country.US)            // Improvement: Add South America countries
+  private val countriesHandledByAUCallCentre = Set(Country.Australia, Country.NewZealand) // Improvement: Add Asia/Pacific countries
+
+  def phone(contactUsCountry: Country): String = phone(Some(contactUsCountry))
+
+  def phone(contactUsCountry: Option[Country] = None): String = {
+    if (contactUsCountry exists countriesHandledByUSCallCentre)
+      s"1-844-632-2010 (toll free); ${directLine(contactUsCountry)} (direct line). Lines are open 9:15am-6pm, Monday to Friday (EST/EDT)"
+    else if (contactUsCountry exists countriesHandledByAUCallCentre)
+      s"1800 773 766 (within Australia & toll free); ${directLine(contactUsCountry)} (direct line/outside Australia). Lines are open 9am-5pm, Monday to Friday (AEDT) excluding public holidays"
+    else if (contactUsCountry.contains(UK))
+      s"${directLine(UK)} (within UK). Lines are open 8am-8pm on weekdays, 8am-6pm at weekends (GMT/BST)"
+    else
+      s"${directLine()}. Lines are open 8am-8pm on weekdays, 8am-6pm at weekends (GMT/BST)"
+  }
+
+  def directLine(contactUsCountry: Country): String = directLine(Some(contactUsCountry))
+
+  def directLine(contactUsCountry: Option[Country] = None): String = {
+    if (contactUsCountry exists countriesHandledByUSCallCentre)
+      "917-900-4663"
+    else if (contactUsCountry exists countriesHandledByAUCallCentre)
+      "+61 2 8076 8599"
+    else if (contactUsCountry contains UK)
+      "0330 333 6767"
+    else
+      "+44 (0) 330 333 6767"
+  }
+
+  def hrefTelNumber(contactUsCountry: Country): String = hrefTelNumber(Some(contactUsCountry))
+
+  def hrefTelNumber(contactUsCountry: Option[Country] = None): String = {
+    s"tel:${directLine(contactUsCountry).replace(" (0) "," ")}"
+  }
+
+  def hrefMailto = "mailto:subscriptions@theguardian.com"
+
+  def email = "subscriptions@theguardian.com"
+
+  def weeklyEmail(contactUsCountry: Option[Country]): String = {
+    if (contactUsCountry exists countriesHandledByAUCallCentre) {
+      "gwsubsau@theguardian.com"
+    } else {
+      "gwsubs@theguardian.com"
+    }
+  }
+}

--- a/app/views/zuoraTransactionFailed.scala.html
+++ b/app/views/zuoraTransactionFailed.scala.html
@@ -3,7 +3,7 @@
         @fragments.page.header("Payment error", None)
         <p>
             Sorry, we were unable to process your payment. Please check your details and try again.
-            If this error persists, please contact support at <a href="mailto:customer.experience@@theguardian.com">customer.experience@@theguardian.com</a>.
+            If this error persists, please contact support at <a href="mailto:userhelp@@theguardian.com">userhelp@@theguardian.com</a>.
         </p>
     </main>
 }

--- a/assets/javascripts/modules/mma/updatePayment.jsx
+++ b/assets/javascripts/modules/mma/updatePayment.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom';
-import { Raven } from 'modules/raven';
+import {Raven} from 'modules/raven';
 
 const timeout = (t) => new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
@@ -58,9 +58,9 @@ const UNAVAILABLE = 'unavailable'
 const CardUpdate = ({ card, handler }) => (<div><button className="button button--primary button--large" onClick={handler}>•••• •••• •••• {card && card.last4 || '••••'} Update Card</button></div>)
 const Success = () => (<p>Thank you, we have successfully updated your payment details.</p>)
 const Failure = ({ phone }) => <p>Unfortunately, we are unable to update your payment details at this time, please contact the call centre. {phone}</p>
-const Unavailable = ({ phone }) => <span>
+const Unavailable = ({ phone }) => <div>
     <p>To update your payment details, please contact the call centre. {phone}</p>
-    </span>
+</div>
 
 const Waiting = () => (<div className="loader js-loader is-loading">Processing&hellip;</div>)
 

--- a/assets/javascripts/modules/react/directDebit.jsx
+++ b/assets/javascripts/modules/react/directDebit.jsx
@@ -43,8 +43,8 @@ export function DirectDebit(props: {
                 </p>
                 <div>
                     <div>The Guardian, Unit 16, Coalfield Way, Ashby Park, Ashby-De-La-Zouch, LE65 1JT United Kingdom</div>
-                    <div>Tel: +44 (0) 330 333 6767</div>
-                    <div><a href="mailto:gwsubs@theguardian.com">gwsubs@theguardian.com</a></div>
+                    <div>Tel: 0330 333 6767</div>
+                    <div><a href="mailto:subscriptions@theguardian.com">subscriptions@theguardian.com</a></div>
                 </div>
             </div>
         </dd>

--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ import com.typesafe.sbt.packager.archetypes.systemloader.ServerLoader.Systemd
 enablePlugins(SystemdPlugin)
 serverLoading in Debian := Some(Systemd)
 debianPackageDependencies := Seq("openjdk-8-jre-headless")
-maintainer := "Membership Dev <membership.dev@theguardian.com>"
+maintainer := "Subscriptions Dev <subscriptions.dev@theguardian.com>"
 packageSummary := "Subscription Frontend"
 packageDescription := """Subscription Frontend"""
 


### PR DESCRIPTION
More of a change relating to Q2's OKR than Q4's, however it makes things much better for customers so I took the opportunity, when developing the [request](https://trello.com/c/FMSO8MjV) just for the Australia contact centre to show on the https://subscribe.theguardian.com/weekly/NZ page.

This all-conquering pull request changes refactor how the contact centre details are stored and rendered. Extra information is passed through the templates to allow the correct rendering based on whether the page is showing an Australia/US product, or a that checkout has completed, or the customer has logged into /manage and so the billing country is used instead to determine which details to show.

The major functional change other than case-class and template refactoring is that the Edition has been taken out of the session and the billing country name added instead.

There are also now far fewer copies of the phone number and emails:

```
(make-contact-centre-details-responsive) $ pwd
~/subscriptions-frontend/app
(make-contact-centre-details-responsive) $ grep -r "@theguardian.com" *  | wc -;
11
(make-contact-centre-details-responsive) $ grep -r "333 6767" * | wc -l
4
```
vs before:
```
(master) $ pwd
 ~/subscriptions-frontend/app
(master) $ grep -r "@theguardian.com" * | wc -l
14
(master) $ grep -r "333 6767" * | wc -l
11
```

I also improved the copy on the /manage page.
Before:
![picture 366](https://user-images.githubusercontent.com/1515970/35972672-b70a6d4c-0cca-11e8-8340-004f0dd16cdf.png)
After:
![picture 353](https://user-images.githubusercontent.com/1515970/35972616-810f3b3c-0cca-11e8-9d60-13084084a514.png)

Screenshots of URLs and the improved footer - before they were all UK contact number and generic email address:

![picture 364](https://user-images.githubusercontent.com/1515970/35972707-dd75fd66-0cca-11e8-83ee-b8b11e57741a.png)
![picture 363](https://user-images.githubusercontent.com/1515970/35972708-dd8908a2-0cca-11e8-8dd8-5be1a31b914e.png)
![picture 362](https://user-images.githubusercontent.com/1515970/35972709-dd9f9388-0cca-11e8-91ec-80f966ec6823.png)
![picture 361](https://user-images.githubusercontent.com/1515970/35972710-ddb34edc-0cca-11e8-95c8-126d62d35708.png)
![picture 360](https://user-images.githubusercontent.com/1515970/35972711-ddc522e2-0cca-11e8-81c4-f3beb01af886.png)
![picture 359](https://user-images.githubusercontent.com/1515970/35972712-dddeb6ee-0cca-11e8-83ca-0f118a5248f1.png)
![picture 358](https://user-images.githubusercontent.com/1515970/35972713-ddfe8de8-0cca-11e8-89df-d2d1640cfc5a.png)
![picture 357](https://user-images.githubusercontent.com/1515970/35972714-de120e18-0cca-11e8-9651-bf64d1054be7.png)
![picture 356](https://user-images.githubusercontent.com/1515970/35972715-de24e290-0cca-11e8-8068-46b31f3790cc.png)

