### PR TITLE
Hide AppNexus Pixel

### DIFF
--- a/assets/javascripts/modules/analytics/appnexus.js
+++ b/assets/javascripts/modules/analytics/appnexus.js
@@ -44,7 +44,6 @@ define([
         var parameterValue = pageCodes[pageType];
 
         var oImg = document.createElement('img');
-        oImg.setAttribute('alt', 'AppNexus pixel');
         oImg.setAttribute('height', '0');
         oImg.setAttribute('width', '0');
         document.body.appendChild(oImg);


### PR DESCRIPTION
# Why?

If the AppNexus pixel fails to load in, the alt text "AppNexus pixel" is shown to the user instead. This is probably not the best UX, as this isn't an image that they are aware of in the normal flow of the page. This PR removes that alt text.

**Note:** I can't figure out how to get the pixel to appear in DEV or CODE.

# Screenshots

![subscribe-appnexus](https://user-images.githubusercontent.com/5131341/36149092-62bdc05a-10b6-11e8-89dd-8c89344cf24b.png)
