### PR TITLE
don't give up waiting for the catalog too soon thus condemning the instance

### DIFF
--- a/app/services/TouchpointBackends.scala
+++ b/app/services/TouchpointBackends.scala
@@ -86,7 +86,8 @@ class TouchpointBackends(actorSystem: ActorSystem, wsClient: WSClient, execution
       implicit val simpleRestClient: SimpleClient[Future] = new rest.SimpleClient[Future](config.zuoraRest, futureRunner)
       lazy val environmentName: String = config.environmentName
       lazy val salesforceService = new SalesforceServiceImp(sfSimpleContactRepo)
-      lazy val catalogService = new subsv2.services.CatalogService[Future](newProductIds, simpleRestClient, Await.result(_, 10.seconds), backendType.name)
+      val catalogRestClient: SimpleClient[Future] = new rest.SimpleClient[Future](config.zuoraRest, configurableFutureRunner(60.seconds))
+      lazy val catalogService = new subsv2.services.CatalogService[Future](newProductIds, catalogRestClient, Await.result(_, 10.seconds), backendType.name)
       private val slightlyUnsafeCatalog: Future[Catalog] = catalogService.catalog.map(_.valueOr(e => throw new IllegalStateException(s"$e while getting catalog")))
       lazy val zuoraService = new zuora.ZuoraSoapService(soapClient)
       private val map = this.catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.toList.mkString}"); Map()}, _.map))


### PR DESCRIPTION
At present we only wait 10 seconds for the catalog to come in from zuora.

Sometimes it takes over 10 seconds to come back.  This means that okhttp3  throws a Socket timeout exception which then gets stored in the catalog service.  This is a problem because we create one catalog service for each instance, so once it has a failed future, that's it, it's shared between all requests.

This means that if a machine fails once, it will fail all healthchecks and the only way to revocer is wait for the health check to fail and a new instance to be started.

This has other negative effects apart from slow deploys - prout only waits for one healthy instance, so the prout post deploy tests can run on the previous build if the majority of new instances fail to start.

@jacobwinch @paulbrown1982 @pvighi @lmath @davidfurey 