### PR TITLE
Play WS Headers function deprecation removal

### DIFF
--- a/app/MyApplicationLoader.scala
+++ b/app/MyApplicationLoader.scala
@@ -48,23 +48,25 @@ class MyComponents(context: Context)
 
   val httpClient = com.gu.okhttp.RequestRunners.futureRunner
 
+  implicit val cc = controllerComponents
+
   lazy val router: Routes = new Routes(
     httpErrorHandler,
-    new CachedAssets(assets),
-    new Homepage(commonActions),
+    new CachedAssets(assets, controllerComponents),
+    new Homepage(commonActions, controllerComponents),
     new Management(actorSystem = actorSystem, touchpointBackends, oAuthActions),
-    new DigitalPack(touchpointBackends.Normal, commonActions),
+    new DigitalPack(touchpointBackends.Normal, commonActions, controllerComponents),
     new Checkout(touchpointBackends, commonActions),
     new Promotion(touchpointBackends, commonActions),
     new Shipping(touchpointBackends.Normal, commonActions),
-    new WeeklyLandingPage(touchpointBackends.Normal, commonActions),
+    new WeeklyLandingPage(touchpointBackends.Normal, commonActions, controllerComponents),
     new OAuth(wsClient = wsClient, commonActions, oAuthActions),
     new CAS(oAuthActions),
-    new AccountManagement(touchpointBackends, commonActions, httpClient),
-    new PatternLibrary(commonActions),
-    new Testing(touchpointBackends.Test, commonActions, oAuthActions),
+    new AccountManagement(touchpointBackends, commonActions, httpClient, controllerComponents),
+    new PatternLibrary(commonActions, controllerComponents),
+    new Testing(touchpointBackends.Test, commonActions, oAuthActions, controllerComponents),
     new PromoLandingPage(touchpointBackends.Normal, commonActions, oAuthActions),
-    new Offers(commonActions)
+    new Offers(commonActions, controllerComponents)
   )
 
   override lazy val httpFilters: Seq[EssentialFilter] = Seq(

--- a/app/MyApplicationLoader.scala
+++ b/app/MyApplicationLoader.scala
@@ -48,8 +48,6 @@ class MyComponents(context: Context)
 
   val httpClient = com.gu.okhttp.RequestRunners.futureRunner
 
-  val cc = controllerComponents
-
   lazy val router: Routes = new Routes(
     httpErrorHandler,
     new CachedAssets(assets, controllerComponents),

--- a/app/MyApplicationLoader.scala
+++ b/app/MyApplicationLoader.scala
@@ -48,24 +48,24 @@ class MyComponents(context: Context)
 
   val httpClient = com.gu.okhttp.RequestRunners.futureRunner
 
-  implicit val cc = controllerComponents
+  val cc = controllerComponents
 
   lazy val router: Routes = new Routes(
     httpErrorHandler,
     new CachedAssets(assets, controllerComponents),
     new Homepage(commonActions, controllerComponents),
-    new Management(actorSystem = actorSystem, touchpointBackends, oAuthActions),
+    new Management(actorSystem = actorSystem, touchpointBackends, oAuthActions, executionContext, controllerComponents),
     new DigitalPack(touchpointBackends.Normal, commonActions, controllerComponents),
-    new Checkout(touchpointBackends, commonActions),
-    new Promotion(touchpointBackends, commonActions),
-    new Shipping(touchpointBackends.Normal, commonActions),
+    new Checkout(touchpointBackends, commonActions, executionContext, controllerComponents),
+    new Promotion(touchpointBackends, commonActions, executionContext, controllerComponents),
+    new Shipping(touchpointBackends.Normal, commonActions, controllerComponents),
     new WeeklyLandingPage(touchpointBackends.Normal, commonActions, controllerComponents),
-    new OAuth(wsClient = wsClient, commonActions, oAuthActions),
-    new CAS(oAuthActions),
+    new OAuth(wsClient = wsClient, commonActions, oAuthActions, executionContext, controllerComponents),
+    new CAS(oAuthActions, executionContext, controllerComponents),
     new AccountManagement(touchpointBackends, commonActions, httpClient, controllerComponents),
     new PatternLibrary(commonActions, controllerComponents),
     new Testing(touchpointBackends.Test, commonActions, oAuthActions, controllerComponents),
-    new PromoLandingPage(touchpointBackends.Normal, commonActions, oAuthActions),
+    new PromoLandingPage(touchpointBackends.Normal, commonActions, oAuthActions, executionContext, controllerComponents),
     new Offers(commonActions, controllerComponents)
   )
 

--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -330,7 +330,12 @@ class ManageWeekly(implicit val executionContext: ExecutionContext) extends Cont
 }
 
 
-class AccountManagement(touchpointBackends: TouchpointBackends, commonActions: CommonActions, httpClient: OKRequest => Future[Response])(implicit executionContext: ExecutionContext) extends Controller with ContextLogging {
+class AccountManagement(
+  touchpointBackends: TouchpointBackends,
+  commonActions: CommonActions,
+  httpClient: OKRequest => Future[Response],
+  override protected val controllerComponents: ControllerComponents
+)(implicit executionContext: ExecutionContext) extends BaseController with ContextLogging {
 
   import commonActions.NoCacheAction
 

--- a/app/controllers/CAS.scala
+++ b/app/controllers/CAS.scala
@@ -12,15 +12,15 @@ import configuration.Config
 import configuration.Config.{CAS, appName, stage}
 import forms.CASForm
 import play.api.libs.json.Json
-import play.api.mvc.Controller
 import play.api.mvc.Security.AuthenticatedRequest
+import play.api.mvc.{BaseController, ControllerComponents}
 import views.support.CASResultOps._
 import views.support.TokenPayloadOps._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Try}
 
-class CAS(oAuthActions: OAuthActions)(implicit executionContext: ExecutionContext) extends Controller with LazyLogging {
+class CAS(oAuthActions: OAuthActions)(implicit executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
 
   import oAuthActions._
 

--- a/app/controllers/CAS.scala
+++ b/app/controllers/CAS.scala
@@ -20,7 +20,7 @@ import views.support.TokenPayloadOps._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Try}
 
-class CAS(oAuthActions: OAuthActions)(implicit executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
+class CAS(oAuthActions: OAuthActions, implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
 
   import oAuthActions._
 

--- a/app/controllers/CachedAssets.scala
+++ b/app/controllers/CachedAssets.scala
@@ -3,7 +3,7 @@ package controllers
 import com.typesafe.scalalogging.LazyLogging
 import play.api.Logger
 import play.api.libs.json.Json
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{BaseController, ControllerComponents}
 
 import scala.concurrent.ExecutionContext
 
@@ -23,7 +23,7 @@ object CachedAssets extends LazyLogging  {
     */
   def hashedPathFor(path: String): String = "/assets/" + hashedPaths.getOrElse(path, path)
 }
-class CachedAssets(assets: Assets)(implicit executionContext: ExecutionContext) extends Controller with LazyLogging {
+class CachedAssets(assets: Assets, override protected val controllerComponents: ControllerComponents)(implicit executionContext: ExecutionContext) extends BaseController with LazyLogging {
   /**
    * Serves an asset, wrapping it with cache headers if appropriate
    */

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -38,7 +38,7 @@ import scala.util.Try
 import scalaz.std.scalaFuture._
 import scalaz.{NonEmptyList, OptionT}
 
-class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions)(implicit executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
+class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions, implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
 
   import SessionKeys.{Currency => _, UserId => _, _}
   import commonActions._

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -38,7 +38,7 @@ import scala.util.Try
 import scalaz.std.scalaFuture._
 import scalaz.{NonEmptyList, OptionT}
 
-class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions)(implicit executionContext: ExecutionContext) extends Controller with LazyLogging {
+class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions)(implicit executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
 
   import SessionKeys.{Currency => _, UserId => _, _}
   import commonActions._

--- a/app/controllers/DigitalPack.scala
+++ b/app/controllers/DigitalPack.scala
@@ -11,7 +11,7 @@ import utils.RequestCountry._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class DigitalPack(touchpointBackend: TouchpointBackend, commonActions: CommonActions) extends Controller with StrictLogging {
+class DigitalPack(touchpointBackend: TouchpointBackend, commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController with StrictLogging {
 
   import commonActions.NoCacheAction
   private val queryParamHint = "edition"

--- a/app/controllers/Homepage.scala
+++ b/app/controllers/Homepage.scala
@@ -9,7 +9,7 @@ import play.api.mvc._
 import utils.RequestCountry._
 import utils.Tracking.internalCampaignCode
 
-class Homepage(commonActions: CommonActions) extends Controller {
+class Homepage(commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions._
 

--- a/app/controllers/Management.scala
+++ b/app/controllers/Management.scala
@@ -18,7 +18,7 @@ import scalaz.syntax.std.boolean._
 import scalaz.syntax.std.option._
 import scalaz.{Semigroup, Validation, ValidationNel}
 
-class Management(actorSystem: ActorSystem, fBackendFactory: TouchpointBackends, oAuthActions: OAuthActions)(implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents)  extends BaseController with LazyLogging {
+class Management(actorSystem: ActorSystem, fBackendFactory: TouchpointBackends, oAuthActions: OAuthActions, implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents)  extends BaseController with LazyLogging {
 
   import oAuthActions._
 

--- a/app/controllers/Management.scala
+++ b/app/controllers/Management.scala
@@ -18,7 +18,7 @@ import scalaz.syntax.std.boolean._
 import scalaz.syntax.std.option._
 import scalaz.{Semigroup, Validation, ValidationNel}
 
-class Management(actorSystem: ActorSystem, fBackendFactory: TouchpointBackends, oAuthActions: OAuthActions)(implicit val executionContext: ExecutionContext)  extends Controller with LazyLogging {
+class Management(actorSystem: ActorSystem, fBackendFactory: TouchpointBackends, oAuthActions: OAuthActions)(implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents)  extends BaseController with LazyLogging {
 
   import oAuthActions._
 

--- a/app/controllers/OAuth.scala
+++ b/app/controllers/OAuth.scala
@@ -10,7 +10,7 @@ import play.api.mvc._
 
 import scala.concurrent.ExecutionContext
 
-class OAuth (val wsClient: WSClient, commonActions: CommonActions, oAuthActions: OAuthActions)(implicit executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController {
+class OAuth (val wsClient: WSClient, commonActions: CommonActions, oAuthActions: OAuthActions, implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions._
 

--- a/app/controllers/OAuth.scala
+++ b/app/controllers/OAuth.scala
@@ -10,7 +10,7 @@ import play.api.mvc._
 
 import scala.concurrent.ExecutionContext
 
-class OAuth (val wsClient: WSClient, commonActions: CommonActions, oAuthActions: OAuthActions)(implicit executionContext: ExecutionContext) extends Controller {
+class OAuth (val wsClient: WSClient, commonActions: CommonActions, oAuthActions: OAuthActions)(implicit executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions._
 

--- a/app/controllers/Offers.scala
+++ b/app/controllers/Offers.scala
@@ -3,10 +3,10 @@ package controllers
 import actions.CommonActions
 import com.gu.i18n.CountryGroup
 import model.DigitalEdition.{INT, UK, getById}
-import play.api.mvc.Controller
+import play.api.mvc.{BaseController, ControllerComponents}
 import utils.RequestCountry._
 
-class Offers(commonActions: CommonActions) extends Controller {
+class Offers(commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions._
 

--- a/app/controllers/PatternLibrary.scala
+++ b/app/controllers/PatternLibrary.scala
@@ -1,9 +1,9 @@
 package controllers
 
 import actions.CommonActions
-import play.api.mvc.Controller
+import play.api.mvc.{BaseController, ControllerComponents}
 
-class PatternLibrary(commonActions: CommonActions) extends Controller {
+class PatternLibrary(commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions.NoCacheAction
 

--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -31,7 +31,7 @@ class PromoLandingPage(
   tpBackend: TouchpointBackend,
   commonActions: CommonActions,
   oAuthActions: OAuthActions
-)(implicit val executionContext: ExecutionContext) extends Controller {
+)(implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions._
   import oAuthActions._

--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -30,8 +30,10 @@ import scalaz.std.scalaFuture._
 class PromoLandingPage(
   tpBackend: TouchpointBackend,
   commonActions: CommonActions,
-  oAuthActions: OAuthActions
-)(implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController {
+  oAuthActions: OAuthActions,
+  implicit val executionContext: ExecutionContext,
+  override protected val controllerComponents: ControllerComponents
+) extends BaseController {
 
   import commonActions._
   import oAuthActions._

--- a/app/controllers/Promotion.scala
+++ b/app/controllers/Promotion.scala
@@ -19,7 +19,7 @@ import views.support.{BillingPeriod => _}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class Promotion(fBackendFactory: TouchpointBackends, commonActions: CommonActions)(implicit val executionContext: ExecutionContext) extends Controller with LazyLogging {
+class Promotion(fBackendFactory: TouchpointBackends, commonActions: CommonActions)(implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
 
   import commonActions._
 

--- a/app/controllers/Promotion.scala
+++ b/app/controllers/Promotion.scala
@@ -19,7 +19,7 @@ import views.support.{BillingPeriod => _}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class Promotion(fBackendFactory: TouchpointBackends, commonActions: CommonActions)(implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
+class Promotion(fBackendFactory: TouchpointBackends, commonActions: CommonActions, implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
 
   import commonActions._
 

--- a/app/controllers/Shipping.scala
+++ b/app/controllers/Shipping.scala
@@ -9,7 +9,7 @@ import services.TouchpointBackend
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class Shipping(touchpointBackend: TouchpointBackend, commonActions: CommonActions)(implicit override protected val controllerComponents: ControllerComponents) extends BaseController {
+class Shipping(touchpointBackend: TouchpointBackend, commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions._
   // no need to support test users here really as plans seldom change

--- a/app/controllers/Shipping.scala
+++ b/app/controllers/Shipping.scala
@@ -9,7 +9,7 @@ import services.TouchpointBackend
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class Shipping(touchpointBackend: TouchpointBackend, commonActions: CommonActions)  extends Controller {
+class Shipping(touchpointBackend: TouchpointBackend, commonActions: CommonActions)(implicit override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions._
   // no need to support test users here really as plans seldom change

--- a/app/controllers/Testing.scala
+++ b/app/controllers/Testing.scala
@@ -3,7 +3,7 @@ package controllers
 import actions.{CommonActions, OAuthActions}
 import com.gu.memsub.subsv2.CatalogPlan.Paid
 import com.typesafe.scalalogging.LazyLogging
-import play.api.mvc.{Controller, Cookie}
+import play.api.mvc.{BaseController, ControllerComponents, Cookie}
 import services.TouchpointBackend
 import utils.TestUsers.testUsers
 
@@ -18,7 +18,12 @@ object Testing {
   val PreSigninTestCookieName = "pre-signin-test-user"
 }
 
-class Testing (touchpointBackend: TouchpointBackend, commonActions: CommonActions, oAuthActions: OAuthActions)  extends Controller with LazyLogging {
+class Testing (
+  touchpointBackend: TouchpointBackend,
+  commonActions: CommonActions,
+  oAuthActions: OAuthActions,
+  override protected val controllerComponents: ControllerComponents
+) extends BaseController with LazyLogging {
 
   import commonActions._
   import oAuthActions._

--- a/app/controllers/WeeklyLandingPage.scala
+++ b/app/controllers/WeeklyLandingPage.scala
@@ -18,7 +18,7 @@ object WeeklyLandingPage{
   case class Hreflangs(canonical: String, hreflangs: List[Hreflang])
 }
 
-class WeeklyLandingPage(tpBackend: TouchpointBackend, commonActions: CommonActions) extends Controller {
+class WeeklyLandingPage(tpBackend: TouchpointBackend, commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController {
 
   import commonActions._
 

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -185,16 +185,16 @@ class IdentityApiClientImpl(wsClient: WSClient)(implicit executionContext: Execu
     val endpoint = authoriseCall(wsClient.url(s"$identityEndpoint/user"))
 
     email =>
-      endpoint.withQueryString(("emailAddress", email)).execute()
+      endpoint.addQueryStringParameters(("emailAddress", email)).execute()
         .withWSFailureLogging(endpoint)
         .withCloudwatchMonitoringOfGet
   }
 
   override val userLookupByCookies: AccessCredentials.Cookies => Future[WSResponse] = {
-    val endpoint = authoriseCall(wsClient.url(s"$identityEndpoint/user/me").withHeaders(("Referer", s"$identityEndpoint/")))
+    val endpoint = authoriseCall(wsClient.url(s"$identityEndpoint/user/me").addHttpHeaders(("Referer", s"$identityEndpoint/")))
 
     cookies =>
-      endpoint.withHeaders(cookies.forwardingHeader).execute()
+      endpoint.addHttpHeaders(cookies.forwardingHeader).execute()
         .withWSFailureLogging(endpoint)
         .withCloudwatchMonitoringOfGet
   }
@@ -217,7 +217,7 @@ class IdentityApiClientImpl(wsClient: WSClient)(implicit executionContext: Execu
     val json = Json.obj("password" -> password)
 
     endpoint
-      .withHeaders("X-Guest-Registration-Token" -> token.toString)
+      .addHttpHeaders("X-Guest-Registration-Token" -> token.toString)
       .put(json)
       .withWSFailureLogging(endpoint)
       .withCloudwatchMonitoringOfPut
@@ -229,7 +229,7 @@ class IdentityApiClientImpl(wsClient: WSClient)(implicit executionContext: Execu
     val updatedFields =
       createOnlyFields.foldLeft(userJson) { (map, field) => map - field }
 
-    endpoint.withHeaders(authCookies.forwardingHeader).post(updatedFields)
+    endpoint.addHttpHeaders(authCookies.forwardingHeader).post(updatedFields)
       .withWSFailureLogging(endpoint)
       .withCloudwatchMonitoringOfPost
   }
@@ -291,7 +291,7 @@ object IdentityApiClient extends LazyLogging {
   lazy val identityEndpoint = Config.Identity.baseUri
 
   val authoriseCall = (request: WSRequest) =>
-    request.withHeaders(("X-GU-ID-Client-Access-Token", s"Bearer ${Config.Identity.apiToken}"))
+    request.addHttpHeaders(("X-GU-ID-Client-Access-Token", s"Bearer ${Config.Identity.apiToken}"))
 
 }
 


### PR DESCRIPTION
commit to review:
https://github.com/guardian/subscriptions-frontend/pull/1076/commits/a331c0f71bd9ffd4b79835ce396c1891d4fec7e6

this pr removes the deprecated withHeaders calls from identity service.

https://www.playframework.com/documentation/2.6.x/WSMigration26#api-changes

Separate PR as it's a little more risky than the controller changes, but see the last commit as all the rest are reviewed in the other PR

@paulbrown1982 @davidfurey @jacobwinch @pvighi @lmath 