### PR TITLE
Use SSM for ssh login

### DIFF
--- a/cloud-formation/subscriptions-app.cf.yaml
+++ b/cloud-formation/subscriptions-app.cf.yaml
@@ -205,6 +205,7 @@ Resources:
             Resource: arn:aws:sqs:eu-west-1:865473395570:subs-holiday-suspension-email
       ManagedPolicyArns:
       - !Ref 'LoggingPolicy'
+      - 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
   SubscriptionsAppInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:


### PR DESCRIPTION
Add the SSM managed policy to the EC2 role so that we can use that tool to login rather than our github public SSH keys.

```
paul_brown [~] $ ./ssm ssh -p membership -t 'frontend,subscriptions,CODE'
The specified instance(s) are not eligible targets (AWS said InvalidInstanceId)
paul_brown [~] $ ./ssm ssh -p membership -t 'frontend,subscriptions,CODE'
========= i-XXXXXXXXXXXXXXX =========
STDOUT:

 # Execute the following command within the next 30 seconds:
 ssh -i /private/var/folders/tc/64yqdxgx4jd7g7mvhlc62clj9hrltx/T/security_ssm-scala_temporary-rsa-private-key309173717339921795.tmp ubuntu@xxx.xxx.xxx.xxx;

paul_brown [~] $ 
```

cc @joelochlann @johnduffell @jacobwinch 