### PR TITLE
use encrypted private bucket and restrict s3 permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ depending on your system.
    region = eu-west-1
    ```
 
-1. Download our private keys from the `subscriptions-private` S3 bucket. If you have the AWS CLI set up you can run:
+1. Download our private keys from the `gu-reader-revenue-private` S3 bucket. If you have the AWS CLI set up you can run:
 
     ```
-    aws s3 cp s3://subscriptions-private/DEV/subscriptions-frontend.private.conf /etc/gu  --profile membership
+    aws s3 cp s3://gu-reader-revenue-private/subscriptions/frontend/DEV/subscriptions-frontend.private.conf /etc/gu  --profile membership
     ```
 
 1. Run ``` sbt devrun ``` and navigate to ```sub.thegulocal.com```

--- a/cloud-formation/subscriptions-app.cf.yaml
+++ b/cloud-formation/subscriptions-app.cf.yaml
@@ -118,7 +118,7 @@ Resources:
 
           aws --region ${AWS::Region} s3 cp s3://subscriptions-dist/${Stack}/${Stage}/frontend/frontend_1.0-SNAPSHOT_all.deb /tmp
 
-          aws --region ${AWS::Region} s3 cp s3://subscriptions-private/${Stage}/subscriptions-frontend.private.conf /etc/gu
+          aws --region ${AWS::Region} s3 cp s3://gu-reader-revenue-private/${Stack}/frontend/${Stage}/subscriptions-frontend.private.conf /etc/gu
 
           cat <<EOF >>/etc/gu/subscriptions-frontend.private.conf
           param.logstash {
@@ -156,7 +156,8 @@ Resources:
           Statement:
           - Effect: Allow
             Action: s3:GetObject
-            Resource: arn:aws:s3:::subscriptions-private/*
+            Resource: !Sub 'arn:aws:s3:::gu-reader-revenue-private/${Stack}/frontend/${Stage}/*'
+
           - Effect: Allow
             Action: s3:GetObject
             Resource: arn:aws:s3:::membership-private/membership_directory_cert.p12


### PR DESCRIPTION
move private configuration to the gu-reader-revenue-private bucket
pretty much the same as https://github.com/guardian/membership-workflow/pull/129
