### PR TITLE
Remove kindle and android daily edition links

### DIFF
--- a/app/model/Apps.scala
+++ b/app/model/Apps.scala
@@ -17,25 +17,11 @@ object Apps {
     "Get it on Google Play",
     "images/logos/google-play-store.png"
   )
-  val amazonAppStoreBadge = AppBadge(
-    "Available at Amazon",
-    "images/logos/amazon-app-store.png"
-  )
 
   object DailyEdition {
-    val links = Seq(
-      AppLink(
-        "https://play.google.com/store/apps/details?id=com.guardian.android.tabletedition.google",
-        googlePlayStoreBadge
-      ),
-      AppLink(
-        "https://itunes.apple.com/gb/app/guardian-observer-daily-edition/id452707806?mt=8&uo=4",
-        appleAppStoreBadge
-      ),
-      AppLink(
-        "http://www.amazon.co.uk/dp/B00H9I8MBK",
-        amazonAppStoreBadge
-      )
+    val iOSAppLink = AppLink(
+      "https://itunes.apple.com/gb/app/guardian-observer-daily-edition/id452707806?mt=8&uo=4",
+      appleAppStoreBadge
     )
   }
 

--- a/app/views/fragments/confirmation/appSteps.scala.html
+++ b/app/views/fragments/confirmation/appSteps.scala.html
@@ -5,11 +5,9 @@
 <h4 class="steps__title">You can use the links below to download the apps included in your subscription.</h4>
 
 <div class="app-package">
-    <h5 class="app-package__title">Guardian &amp; Observer Daily Edition (for your tablet)</h5>
+    <h5 class="app-package__title">Guardian &amp; Observer Daily Edition (for your iPad)</h5>
     <div class="badge-group">
-        @for(appLink <- Apps.DailyEdition.links) {
-            @fragments.common.appBadge(appLink)
-        }
+        @fragments.common.appBadge(Apps.DailyEdition.iOSAppLink)
     </div>
 </div>
 

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -42,9 +42,9 @@
                 <h2 class="block__title">From the app store</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">Subscribe to our daily edition or Guardian app from the appstore.</li>
+                        <li class="block__list-item">Subscribe to our iPad daily edition from the appstore.</li>
+                        <li class="block__list-item">Download the Guardian mobile app for your Apple or Android devices.</li>
                         <li class="block__list-item">Free trials available to new customers.</li>
-                        <li class="block__list-item">Available across iPad, Kindle Fire, Android and iPhone.</li>
                     </ul>
                 </div>
                 <div class="block__footer">

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -42,9 +42,9 @@
                 <h2 class="block__title">From the app store</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">Subscribe to our iPad daily edition from the appstore.</li>
-                        <li class="block__list-item">Download the Guardian mobile app for your Apple or Android devices.</li>
-                        <li class="block__list-item">Free trials available to new customers.</li>
+                        <li class="block__list-item">Subscribe to our iPad daily edition</li>
+                        <li class="block__list-item">Download the Guardian mobile app for your Apple or Android devices</li>
+                        <li class="block__list-item">Free trials available to new customers</li>
                     </ul>
                 </div>
                 <div class="block__footer">


### PR DESCRIPTION
We're no longer offering the daily edition on Kindle or Android, so we should remove the links to download those products from the subscription thank you page.

Trello card: [1298-remove-icons-for-kindle-fire-and-android-daily-edition-from-subs-confirmation-page](https://trello.com/c/Yijt5KiW/1298-remove-icons-for-kindle-fire-and-android-daily-edition-from-subs-confirmation-page)

Tested on CODE: Yes

**Before**
![subscription-no-android-or-kindle-upsell-before](https://user-images.githubusercontent.com/690395/36844084-2340c91e-1d49-11e8-95b6-ee9837ffac40.png)

**After**
![subscription-no-android-or-kindle-screencapture-subscribe-code-dev-theguardian-checkout-thank-you-1519905849844](https://user-images.githubusercontent.com/690395/36844118-4db9498c-1d49-11e8-8625-1ab0e584853b.png)

