### PR TITLE
Add Saturday To Checkout Dates

### DIFF
--- a/assets/javascripts/modules/checkout/planDateFilter.jsx
+++ b/assets/javascripts/modules/checkout/planDateFilter.jsx
@@ -11,12 +11,14 @@ define([
         let validDays = {
             voucher: {
                 sixday: (date) => date.day() === 1,
+                saturday: (date) => date.day() === 6,
                 sunday: (date) => date.day() === 0,
                 weekend: (date) => date.day() === 6,
                 allDays: (date) => date.day() === 1
             },
             paper: {
                 sixday: (date) => date.day() !== 0,
+                saturday: (date) => date.day() === 6,
                 sunday: (date) => date.day() === 0,
                 weekend: (date) => date.day() === 6 || date.day() === 0,
                 allDays: () => true
@@ -29,6 +31,8 @@ define([
         switch (true) {
             case /Weekly/i.test(packageName):
                 return filters;
+            case /Saturday/i.test(packageName):
+                return filters.saturday;
             case /Sunday/i.test(packageName):
                 return filters.sunday;
             case /Sixday/i.test(packageName):


### PR DESCRIPTION
# Why?

To add the new Saturday paper, the date picker on the checkout needs to be updated to include viable Saturday dates.

# Does it work?

As I understand it, there are four possible combinations of Saturday paper. These are what the date pickers look like for these packages:

## Collection/Voucher

Saturday | Saturday+
-|-
`/checkout/voucher-saturday` | `/checkout/voucher-saturday+`
-|-
![voucher-saturday](https://user-images.githubusercontent.com/5131341/37099127-88a26844-2217-11e8-8b0f-eb33c0e7b20c.png) | ![voucher-saturday](https://user-images.githubusercontent.com/5131341/37099186-a6426c50-2217-11e8-8879-2222bb07be16.png)

## Delivery

Saturday | Saturday+
-|-
`/checkout/delivery-saturday` | `/checkout/delivery-saturday+`
-|-
![delivery-saturday](https://user-images.githubusercontent.com/5131341/37099251-c421b762-2217-11e8-9af1-0de28f7f074a.png) | ![delivery-saturday](https://user-images.githubusercontent.com/5131341/37099308-dcce8e34-2217-11e8-804d-86b90ab2d33d.png)
