### PR TITLE
Remove Date Input Field

### DIFF
--- a/assets/javascripts/modules/react/customDatePicker.jsx
+++ b/assets/javascripts/modules/react/customDatePicker.jsx
@@ -15,6 +15,7 @@ export default class CustomDatePick extends React.Component {
         return <DatePicker
             selected={this.state.startDate}
             onChange={this.handleChange}
+            inline
             {...this.props} />
     }
     


### PR DESCRIPTION
# Why?

@CPKING discovered that the current date input field for vouchers and paper delivery allows the user to enter any value they want, including incorrect dates and invalid values. The fix is to remove the manual input field altogether, replacing it with an embedded date picker. Does anyone have thoughts on whether this could cause any problems?

cc @JustinPinner 

# Screenshots

**Before**

![broken-input](https://user-images.githubusercontent.com/5131341/37165561-d8c439be-22f4-11e8-8956-7d7fc0b58a15.png)

**After**

![embedded-input](https://user-images.githubusercontent.com/5131341/37165568-df928908-22f4-11e8-9999-19fb6def27ac.png)
