### PR TITLE
Have the option of using a t2.small instead of t2.medium

### DIFF
--- a/cloud-formation/subscriptions-app.cf.yaml
+++ b/cloud-formation/subscriptions-app.cf.yaml
@@ -35,8 +35,8 @@ Parameters:
     Description: EC2 instance type
     AllowedValues:
     - t2.micro
+    - t2.small
     - t2.medium
-    - m3.medium
     ConstraintDescription: must be a valid EC2 instance type.
   ImageId:
     Description: AMI ID


### PR DESCRIPTION
Now that subscriptions. is getting less traffic in favour of support, lets have the option of using a t2.small instead of t2.medium.

cc @davidfurey 