### PR TITLE
Stop Sending Identity ID To Stripe

### DIFF
--- a/app/services/PaymentService.scala
+++ b/app/services/PaymentService.scala
@@ -39,7 +39,7 @@ class PaymentService(val ukStripeService: StripeService, val auStripeService: St
     override def makeAccount = Account(purchaserIds.contactId, identityIdForAccount(purchaserIds), currency, autopay = true, stripeService.paymentGateway, overrideInvoiceTemplate)
 
     override def makePaymentMethod: Future[CreditCardReferenceTransaction] = {
-      stripeService.Customer.create(description = purchaserIds.description, card = paymentData.stripeToken)
+      stripeService.Customer.create(card = paymentData.stripeToken)
         .map(a => CreditCardReferenceTransaction(
           cardId = a.card.id,
           customerId = a.id,

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= Seq(
     filters,
     jodaForms,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.502",
+    "com.gu" %% "membership-common" % "0.509",
     "com.gu.identity" %% "identity-play-auth" % "2.1",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.2",


### PR DESCRIPTION
# Why are you doing this?

We want to stop sending the identity ID and any other user information through to Stripe in the description field.

[**Trello Card**](https://trello.com/c/hbYejygt/1427-stop-sending-personal-data-to-stripe-subscribe)

# Changes

- Bumped [membership-common](https://github.com/guardian/membership-common/pull/574).
- Stopped sending identity ID through to Stripe on Customer creation.
