### PR TITLE
Only one managed group should have access to the CAS tool

### DIFF
--- a/app/actions/OAuthActions.scala
+++ b/app/actions/OAuthActions.scala
@@ -46,13 +46,6 @@ final class OAuthActions(
   ))
 
   val StaffAuthorisedForCASAction = GoogleAuthenticatedStaffAction andThen requireGroup[GoogleAuthRequest](Set(
-    "customer.operations@guardian.co.uk",
-    "directteam@guardian.co.uk",
-    "userhelp@guardian.co.uk",
-    "dig.qa@guardian.co.uk",
-    "subscriptions.dev@guardian.co.uk",
-    "subscriptions.cas@guardian.co.uk",
-    "ios@guardian.co.uk",
     "subscriptions-staff-cas@guardian.co.uk"
   ))
 }

--- a/app/actions/OAuthActions.scala
+++ b/app/actions/OAuthActions.scala
@@ -52,6 +52,7 @@ final class OAuthActions(
     "dig.qa@guardian.co.uk",
     "subscriptions.dev@guardian.co.uk",
     "subscriptions.cas@guardian.co.uk",
-    "ios@guardian.co.uk"
+    "ios@guardian.co.uk",
+    "subscriptions-staff-cas@guardian.co.uk"
   ))
 }


### PR DESCRIPTION
As part of GDPR CyberEssentials we are encouraged to manage access to systems at a personal level via a documented process, rather than adding Google groups which are then in the control of other people.

cc @davidfurey @jacobwinch 