### PR TITLE
Encode using wraparound-aware emergency token generator

### DIFF
--- a/app/forms/CASForm.scala
+++ b/app/forms/CASForm.scala
@@ -3,7 +3,7 @@ package forms
 import com.gu.cas.{SubscriptionCode, TokenPayload}
 import com.gu.memsub.Subscription.Name
 import model.CASLookup
-import org.joda.time.Weeks
+import org.joda.time.{LocalDate, Weeks}
 import play.api.data.Forms._
 import play.api.data._
 import play.api.data.format.Formatter
@@ -33,6 +33,6 @@ object CASForm {
     "cas" -> mapping(
       "period" -> number(min = 1, max = 52).transform[Weeks](Weeks.weeks, _.getWeeks),
       "subscriptionCode" -> of[SubscriptionCode]
-    )(TokenPayload.apply)(t => Some(t.period, t.subscriptionCode))
+    )(TokenPayload(LocalDate.now))(t => Some(t.period, t.subscriptionCode))
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.2",
     "com.gu" %% "identity-test-users" % "0.6",
-    "com.gu" %% "content-authorisation-common" % "0.1",
+    "com.gu" %% "content-authorisation-common" % "0.4-SNAPSHOT",
     "com.gu" %% "tip" % "0.1.1",
     "com.github.nscala-time" %% "nscala-time" % "2.16.0",
     "com.getsentry.raven" % "raven-logback" % "8.0.3",

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.2",
     "com.gu" %% "identity-test-users" % "0.6",
-    "com.gu" %% "content-authorisation-common" % "0.4-SNAPSHOT",
+    "com.gu" %% "content-authorisation-common" % "0.4",
     "com.gu" %% "tip" % "0.1.1",
     "com.github.nscala-time" %% "nscala-time" % "2.16.0",
     "com.getsentry.raven" % "raven-logback" % "8.0.3",

--- a/test/forms/CASFormTest.scala
+++ b/test/forms/CASFormTest.scala
@@ -3,7 +3,7 @@ package forms
 import com.gu.cas.{SevenDay, TokenPayload}
 import com.gu.memsub.Subscription.Name
 import model.CASLookup
-import org.joda.time.Weeks
+import org.joda.time.{LocalDate, Weeks}
 import org.specs2.mutable.Specification
 
 class CASFormTest extends Specification {
@@ -23,6 +23,6 @@ class CASFormTest extends Specification {
       "cas.subscriptionCode" -> "SevenDay"
     )
 
-    CASForm.emergencyToken.bind(formData).get must_=== TokenPayload(Weeks.weeks(5), SevenDay)
+    CASForm.emergencyToken.bind(formData).get must_=== TokenPayload(LocalDate.now/*!!*/)(Weeks.weeks(5), SevenDay)
   }
 }


### PR DESCRIPTION
This uses the wraparound aware emergency token provider to generate a cas token in https://github.com/guardian/content-authorisation-common/pull/5
@pvighi @paulbrown1982 @jacobwinch 
