### PR TITLE
Use SafeLogger to scrub PII from log messages

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -12,6 +12,8 @@ import com.gu.memsub.promo.{NormalisedPromoCode, PromoCode}
 import com.gu.memsub.subsv2.SubscriptionPlan._
 import com.gu.memsub.subsv2.{Catalog, ReaderType, Subscription}
 import com.gu.memsub.{BillingSchedule, PaymentCard, Product}
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import com.gu.subscriptions.suspendresume.SuspensionService
 import com.gu.subscriptions.suspendresume.SuspensionService.{BadZuoraJson, ErrNel, HolidayRefund, PaymentHoliday}
 import com.gu.zuora.rest.ZuoraRestService
@@ -124,8 +126,8 @@ class ManageDelivery(implicit val executionContext: ExecutionContext) extends Co
     */
   private def getAndLogRefundError(r: ErrNel): ErrNel = {
     r.foreach {
-      case e:BadZuoraJson => logger.error(s"Error when adding a new holiday - BadZuoraJson: ${e.got}")
-      case e => logger.error(s"Error when adding a new holiday: ${e.code}")
+      case e:BadZuoraJson => SafeLogger.error(scrub"Error when adding a new holiday - BadZuoraJson: ${e.got}")
+      case e => SafeLogger.error(scrub"Error when adding a new holiday: ${e.code}")
     }
     r
   }
@@ -148,7 +150,7 @@ class ManageDelivery(implicit val executionContext: ExecutionContext) extends Co
           logger.info(s"[${env}] Successfully raised a delivery issue for $deliveryProblem")
           Ok(views.html.account.reportDeliveryProblemSuccess())
         case -\/(message) =>
-          logger.error(s"[${env}] Failed to raise a delivery issue for ${deliveryProblem.subscriptionName}: $message")
+          SafeLogger.error(scrub"[${env}] Failed to raise a delivery issue for ${deliveryProblem.subscriptionName}: $message")
           Ok(views.html.account.reportDeliveryProblemFailure())
       }
     }

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -11,6 +11,8 @@ import com.gu.memsub.promo.{NormalisedPromoCode, PromoCode}
 import com.gu.memsub.subsv2.CatalogPlan.ContentSubscription
 import com.gu.memsub.subsv2.{CatalogPlan, PlansWithIntroductory}
 import com.gu.memsub.{Product, SupplierCode}
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import com.gu.tip.Tip
 import com.gu.zuora.soap.models.errors._
 import com.typesafe.scalalogging.LazyLogging
@@ -166,7 +168,7 @@ class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions
         }
       }
     }.valueOr { err =>
-      logger.error(s"failed renderCheckout: ${err.list.toList.mkString(", ")}")
+      SafeLogger.error(scrub"failed renderCheckout: ${err.list.toList.mkString(", ")}")
       Future.successful(InternalServerError("failed to render checkout due to catalog issues"))
     }
     }.flatMap(identity)
@@ -188,7 +190,7 @@ class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions
       val preliminarySubscribeRequest = {
         subsForm.bindFromRequest.valueOr {
           e =>
-            throw new Exception(s"Backend validation failed: identityId=${idUserOpt.map(_.user.id).mkString};" +
+            throw new Exception(scrub"Backend validation failed: identityId=${idUserOpt.map(_.user.id).mkString};" +
               s" JavaScriptEnabled=${request.headers.toMap.contains("X-Requested-With")};" +
               s" ${e.map(err => s"${err.key} ${err.message}").mkString(", ")}")
         }

--- a/app/controllers/DigitalPack.scala
+++ b/app/controllers/DigitalPack.scala
@@ -2,6 +2,8 @@ package controllers
 
 import actions.CommonActions
 import com.gu.i18n.CountryGroup.UK
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import com.typesafe.scalalogging.StrictLogging
 import model.DigitalEdition
 import model.DigitalEdition._
@@ -37,7 +39,7 @@ class DigitalPack(touchpointBackend: TouchpointBackend, commonActions: CommonAct
       val price = plan.charges.price.getPrice(digitalEdition.countryGroup.currency).getOrElse(plan.charges.gbpPrice)
       Ok(views.html.digitalpack.info(digitalEdition, price))
     }.valueOr { err =>
-      logger.error(s"Failed to load the Digital Pack landing page: ${err.list.toList.mkString(", ")}")
+      SafeLogger.error(scrub"Failed to load the Digital Pack landing page: ${err.list.toList.mkString(", ")}")
       InternalServerError("failed to read catalog, see the logs")
     })
   }

--- a/app/model/SubscriptionAcquisitionComponents.scala
+++ b/app/model/SubscriptionAcquisitionComponents.scala
@@ -5,6 +5,8 @@ import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
 import com.gu.memsub.Benefit.PaperDay
 import com.gu.memsub.BillingPeriod._
 import com.gu.memsub.promo.{PercentDiscount, Promotion}
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import com.typesafe.scalalogging.LazyLogging
 import ophan.thrift.event.PaymentProvider.{Gocardless, Stripe}
 import ophan.thrift.event._
@@ -103,7 +105,7 @@ object SubscriptionAcquisitionComponents {
       } yield PrintOptions(p, d)
 
       if (printOptions.isEmpty) {
-        logger.error("Could not determine PrintOptions from PaperData")
+        SafeLogger.error(scrub"Could not determine PrintOptions from PaperData")
       }
 
       printOptions
@@ -170,7 +172,7 @@ object SubscriptionAcquisitionComponents {
             case DirectDebitData(_, _, _) => Some(Gocardless)
             case CreditCardData(_) => Some(Stripe)
             case _ =>
-              logger.error("No payment provider for acquisition event")
+              SafeLogger.error(scrub"No payment provider for acquisition event")
               None
           },
 

--- a/app/model/error/SubsError.scala
+++ b/app/model/error/SubsError.scala
@@ -1,5 +1,7 @@
 package model.error
 
+import com.gu.monitoring.SafeLogger._
+
 trait SubsError {
   val message: String
   val request: Option[String]
@@ -8,9 +10,9 @@ trait SubsError {
   def toStringPretty(): String = {
     val line1  = s"\n---------------------------------------"
     val error  = s"\n${this.getClass.getSimpleName}\n"
-    val strMsg = s"\tMessage:  \t ${message}"
-    val strIn  = s"\n\tInput:    \t ${request}"
-    val strOut = s"\n\tOutput:   \t ${response.getOrElse("")}"
+    val strMsg = scrub"\tMessage:  \t ${message}"
+    val strIn  = scrub"\n\tInput:    \t ${request}"
+    val strOut = scrub"\n\tOutput:   \t ${response.getOrElse("")}"
     line1 + error + strMsg + strIn + strOut
   }
 }

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -14,6 +14,7 @@ import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads._
 import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan => Plan}
 import com.gu.memsub.{Subscription => _, _}
+import com.gu.monitoring.SafeLogger
 import com.gu.salesforce.Contact
 import com.gu.zuora.rest.ZuoraRestService
 import com.gu.zuora.api.ZuoraService
@@ -154,7 +155,7 @@ class ExactTargetService(
     } yield {
       response match {
         case Success(sendMsgResult) => logger.info(s"Successfully enqueued ${subscribeResult.subscriptionName} welcome email for user ${purchaserIds.identityId}.")
-        case Failure(e) => logger.error(s"Failed to enqueue ${subscribeResult.subscriptionName} welcome email for user ${purchaserIds.identityId}.", e)
+        case Failure(e) => SafeLogger.error(scrub"Failed to enqueue ${subscribeResult.subscriptionName} welcome email for user ${purchaserIds.identityId}.", e)
       }
     }
 
@@ -191,7 +192,7 @@ class ExactTargetService(
       })
     }.run.map {
       case \/-(()) => logger.info(s"Successfully enqueued ${subscription.name.get}'s updated billing schedule email.")
-      case -\/(e) => logger.error(s"Failed to enqueue ${subscription.name.get}'s updated billing schedule email. $e")
+      case -\/(e) => SafeLogger.error(scrub"Failed to enqueue ${subscription.name.get}'s updated billing schedule email. $e")
     }
   }
 

--- a/app/services/GocardlessService.scala
+++ b/app/services/GocardlessService.scala
@@ -4,6 +4,8 @@ import com.gocardless.GoCardlessClient
 import com.gocardless.GoCardlessClient.Environment.{LIVE, SANDBOX}
 import com.gocardless.errors.GoCardlessApiException
 import com.gocardless.resources.BankDetailsLookup.AvailableDebitScheme
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import com.typesafe.scalalogging.LazyLogging
 import model.DirectDebitData
 import touchpoint.GoCardlessToken
@@ -41,7 +43,7 @@ class GoCardlessService(goCardlessToken: GoCardlessToken)(implicit executionCont
       bdl.getAvailableDebitSchemes.contains(AvailableDebitScheme.BACS)
     } recover { case e: GoCardlessApiException =>
       if (e.getCode == 429) {
-        logger.error("Bypassing preliminary bank account check because the GoCardless rate limit has been reached for this endpoint. Someone might be using our website to proxy to GoCardless")
+        SafeLogger.error(scrub"Bypassing preliminary bank account check because the GoCardless rate limit has been reached for this endpoint. Someone might be using our website to proxy to GoCardless")
         true
       } else {
         false


### PR DESCRIPTION
Scrub any Personally Identifiable Information from Sentry error messages.

See [this PR](https://github.com/guardian/support-frontend/pull/494) for more info