### PR TITLE
Some fixes for the Awin implementation

### DIFF
--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -5,6 +5,7 @@
 @import model.DigitalEdition
 @import model.SubscriptionOps._
 @import views.support.PlanOps._
+
 @(  subscription: Subscription[ContentSubscription],
     guestAccountForm: Option[Form[model.GuestAccountData]] = None,
     touchpointBackendResolution: services.TouchpointBackends.Resolution,
@@ -15,7 +16,7 @@
 )(implicit request: RequestHeader)
 
 @main(s"Confirmation | Subscribe to the ${subscription.firstPlan.title} | The Guardian", bodyClasses=List("is-wide"), touchpointBackendResolutionOpt = Some(touchpointBackendResolution), product = Some(subscription.firstProduct), edition = edition, contactUsCountry = contactUsCountry) {
-
+@fragments.checkout.awinPixel(subscription, promotion)
 <script type="text/javascript">
     guardian.pageInfo.pageType = 'Thankyou';
     guardian.pageInfo.slug="GuardianDigiPack:Order Complete";

--- a/app/views/fragments/checkout/awinPixel.scala.html
+++ b/app/views/fragments/checkout/awinPixel.scala.html
@@ -1,0 +1,16 @@
+@import com.gu.memsub.subsv2.Subscription
+@import com.gu.memsub.subsv2.SubscriptionPlan.ContentSubscription
+@import model.SubscriptionOps._
+@import views.support.PlanOps._
+@import com.gu.memsub.promo.Promotion.AnyPromotion
+
+@(subscription: Subscription[ContentSubscription], promotion: Option[AnyPromotion] = None)
+<!-- Image Pixel Tracking - Mandatory -->
+<img src="https://www.awin1.com/sread.img?tt=ns&tv=2
+&merchant=11152
+&amount=@subscription.firstPrice
+&cr=@subscription.currency
+&ref=@subscription.id.get
+&parts=@{subscription.firstPlan.segment}:@subscription.firstPrice
+&vc=@promotion.map(_.description).getOrElse("")
+&ch=aw&testmode=0" border="0" width="0" height="0">

--- a/assets/javascripts/modules/analytics/awin.js
+++ b/assets/javascripts/modules/analytics/awin.js
@@ -11,7 +11,7 @@ define([
         AWIN.Tracking.Sale = {};
 
         /*** Set your transaction parameters ***/
-        var productData = guardian.pageInfo.productData
+        const productData = guardian.pageInfo.productData
         AWIN.Tracking.Sale.amount = productData.amount;
         AWIN.Tracking.Sale.orderRef = productData.subscriptionId;
         AWIN.Tracking.Sale.parts = productData.productSegment + ':' + productData.amount;

--- a/assets/javascripts/modules/analytics/awin.js
+++ b/assets/javascripts/modules/analytics/awin.js
@@ -11,7 +11,7 @@ define([
         AWIN.Tracking.Sale = {};
 
         /*** Set your transaction parameters ***/
-        const productData = guardian.pageInfo.productData
+        var productData = guardian.pageInfo.productData
         AWIN.Tracking.Sale.amount = productData.amount;
         AWIN.Tracking.Sale.orderRef = productData.subscriptionId;
         AWIN.Tracking.Sale.parts = productData.productSegment + ':' + productData.amount;
@@ -19,6 +19,7 @@ define([
         AWIN.Tracking.Sale.currency = productData.currency;
         AWIN.Tracking.Sale.test = '0';
         AWIN.Tracking.Sale.channel = 'aw';
+        window.AWIN = AWIN;
     }
 
     return {


### PR DESCRIPTION
We have finally got the go ahead to continue with the affiliate tracking work that was started with https://github.com/guardian/subscriptions-frontend/pull/1093

This PR adds a tracking pixel and sets the `Awin` javascript object on `window` so that it can be found by their tracking script (it was getting lost before).

Related docs are [here](https://drive.google.com/drive/folders/19AOGPkPbbFjqPJTdCcCba3EwpLiSHBwW)