### PR TITLE
Turn off logstash while we decommission the RR ELK stack

### DIFF
--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -34,6 +34,6 @@ google.analytics.tracking.id="UA-33592456-4"
 
 stripe.checkout.flag = true
 
-logstash.enabled=true
+logstash.enabled=false
 
 members-data-api.url = "https://members-data-api.code.dev-theguardian.com"

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -23,6 +23,6 @@ google.analytics.tracking.id = "UA-51507017-5"
 
 stripe.checkout.flag = true
 
-logstash.enabled=true
+logstash.enabled=false
 
 members-data-api.url = "https://members-data-api.theguardian.com"


### PR DESCRIPTION
## Why are you doing this?
We're going to remove the ELK stack that we're shipping logs because of GDPR changes. This PR stops the application from attempting to communicate with the Kinesis stream that will disappear when the stack is deleted.

Later on, we'll have created a new Kinesis stream that sends fully GDPR-compliant data to a new backend. Then we can re-enable (or revert this PR) when the new stream is available and configured for this application.

## Trello card: [Here](https://trello.com/c/BPgeI0BP/1553-delete-elk-stack-for-supporter-experience)

## Changes
* Change `logstash.enabled` to `false` in PROD and CODE conf files 

## Screenshots
N/A