### PR TITLE
Remove ELK Kinesis stream refs

### DIFF
--- a/cloud-formation/subscriptions-app.cf.yaml
+++ b/cloud-formation/subscriptions-app.cf.yaml
@@ -41,12 +41,6 @@ Parameters:
     Description: Security group that grants access to the account's Vulnerability
       Scanner
     Type: AWS::EC2::SecurityGroup::Id
-  LoggingKinesisStream:
-    Description: Kinesis stream id to send logging to e.g. elk-stack-ElkKinesisStream-12345
-    Type: String
-  LoggingPolicy:
-    Description: Policy needed to access the kinesis stream
-    Type: String
 Mappings:
   StageVariables:
     PROD:
@@ -115,13 +109,6 @@ Resources:
           aws --region ${AWS::Region} s3 cp s3://subscriptions-dist/${Stack}/${Stage}/frontend/frontend_1.0-SNAPSHOT_all.deb /tmp
 
           aws --region ${AWS::Region} s3 cp s3://gu-reader-revenue-private/${Stack}/frontend/${Stage}/subscriptions-frontend.private.conf /etc/gu
-
-          cat <<EOF >>/etc/gu/subscriptions-frontend.private.conf
-          param.logstash {
-            stream="${LoggingKinesisStream}"
-            streamRegion="${AWS::Region}"
-          }
-          EOF
 
           dpkg -i /tmp/frontend_1.0-SNAPSHOT_all.deb
           chown frontend /etc/gu/subscriptions-frontend.private.conf
@@ -200,7 +187,6 @@ Resources:
             Action: sqs:*
             Resource: arn:aws:sqs:eu-west-1:865473395570:subs-holiday-suspension-email
       ManagedPolicyArns:
-      - !Ref 'LoggingPolicy'
       - 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
   SubscriptionsAppInstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
This is pretty much an exact copy of https://github.com/guardian/members-data-api/pull/326

### Why do we need this?
We're removing the ELK stack in the membership account, and this application is holding on to a policy reference, preventing the stack from being fully deleted

### The changes
Remove the cloudformation references that attach the application to the Kinesis publisher policy

### trello card/screenshot/json/related PRs etc
[delete-elk-stack-for-supporter-experience](https://trello.com/c/BPgeI0BP/1553-delete-elk-stack-for-supporter-experience)

### Tested on CODE
Yes