### PR TITLE
Fresh Sentry projects and use sentry-logback

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -1,7 +1,6 @@
 package configuration
 
 
-import com.getsentry.raven.dsn.Dsn
 import com.github.nscala_time.time.Imports._
 import com.gu.cas.PrefixedTokens
 import com.gu.config._
@@ -68,7 +67,7 @@ object Config {
 
   val subscriptionsUrl = config.getString("subscriptions.url")
 
-  val sentryDsn = Try(new Dsn(config.getString("sentry.dsn")))
+  val sentryDsn = Try(config.getString("sentry.dsn"))
 
   object Logstash {
     private val param = Try{config.getConfig("param.logstash")}.toOption

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -13,7 +13,7 @@ import scala.util.{Failure, Success, Try}
 
 object SentryLogging {
 
-  def init() {
+  def init()= {
     Config.sentryDsn match {
       case Failure(ex) =>
         SafeLogger.warn("No Sentry logging configured (OK for dev)", ex)
@@ -29,7 +29,6 @@ object SentryLogging {
           case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
     }
-    SafeLogger.error(scrub"*TEST* Leigh-Anne says sorry for the spam. This is going to be the start of a great week!")
   }
 }
 

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -13,7 +13,7 @@ import scala.util.{Failure, Success, Try}
 
 object SentryLogging {
 
-  def init()= {
+  def init(): Unit = {
     Config.sentryDsn match {
       case Failure(ex) =>
         SafeLogger.warn("No Sentry logging configured (OK for dev)", ex)

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -1,56 +1,40 @@
 package monitoring
 
-import ch.qos.logback.classic.filter.ThresholdFilter
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.classic.{Logger, LoggerContext}
 import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.spi.FilterReply
-import com.getsentry.raven.RavenFactory
-import com.getsentry.raven.logback.SentryAppender
 import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import configuration.Config
-import org.slf4j.Logger.ROOT_LOGGER_NAME
-import org.slf4j.LoggerFactory
+import io.sentry.Sentry
+import scala.collection.JavaConverters._
 
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 object SentryLogging {
 
   def init() {
     Config.sentryDsn match {
       case Failure(ex) =>
-        play.api.Logger.warn("No Sentry logging configured (OK for dev)", ex)
-      case Success(dsn) =>
-        play.api.Logger.info(s"Initialising Sentry logging for ${dsn.getHost}")
-        val buildInfo: Map[String, Any] = app.BuildInfo.toMap
-        val tags = Map("stage" -> Config.stage) ++ buildInfo
-        val tagsString = tags.map { case (key, value) => s"$key:$value"}.mkString(",")
-
-
-        val sentryAppender = new SentryAppender(RavenFactory.ravenInstance(dsn)) {
-          setRelease(app.BuildInfo.buildNumber)
-          addFilter(SentryFilters.errorLevelFilter)
-          addFilter(SentryFilters.piiFilter)
-          setTags(tagsString)
-          setContext(LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext])
+        SafeLogger.warn("No Sentry logging configured (OK for dev)", ex)
+      case Success(dsn: String) =>
+        SafeLogger.info(s"Initialising Sentry logging")
+        Try {
+          val sentryClient = Sentry.init(dsn)
+          val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
+          val tags = Map("stage" -> Config.stage.toString) ++ buildInfo
+          sentryClient.setTags(tags.asJava)
+        } match {
+          case Success(_) => SafeLogger.debug("Sentry logging configured.")
+          case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
-        sentryAppender.start()
-        LoggerFactory.getLogger(ROOT_LOGGER_NAME).asInstanceOf[Logger].addAppender(sentryAppender)
     }
+    SafeLogger.error(scrub"*TEST* Leigh-Anne says sorry for the spam. This is going to be the start of a great week!")
   }
 }
 
+// This filter is referenced in logback.xml
 class PiiFilter extends Filter[ILoggingEvent] {
   override def decide(event: ILoggingEvent): FilterReply = if (event.getMarker.contains(SafeLogger.sanitizedLogMessage)) FilterReply.ACCEPT
   else FilterReply.DENY
-}
-
-object SentryFilters {
-
-  val errorLevelFilter = new ThresholdFilter { setLevel("ERROR") }
-  val piiFilter = new PiiFilter
-
-  errorLevelFilter.start()
-  piiFilter.start()
-
 }

--- a/assets/javascripts/main.js
+++ b/assets/javascripts/main.js
@@ -42,7 +42,7 @@ require([
     'use strict';
 
     ajax.init({page: {ajaxUrl: ''}});
-    raven.init('https://6dd79da86ec54339b403277d8baac7c8@app.getsentry.com/47380');
+    raven.init('https://df7232e9685946ce965f2098ac3bdab2@sentry.io/1218847');
     analytics.init();
     toggle.init();
     appendAround.init();

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "content-authorisation-common" % "0.4",
     "com.gu" %% "tip" % "0.1.1",
     "com.github.nscala-time" %% "nscala-time" % "2.16.0",
-    "com.getsentry.raven" % "raven-logback" % "8.0.3",
+    "io.sentry" % "sentry-logback" % "1.7.5",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
     "org.scalatest" %% "scalatest" % scalatestVersion % "test",
     "org.scalactic" %% "scalactic" % scalatestVersion % "test",

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -23,7 +23,18 @@ https://www.playframework.com/documentation/2.4.x/SettingsLogger#Using-a-configu
 
     <logger name="com.google.api.client.http" level="WARN" />
 
+
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <filter class="monitoring.PiiFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="Sentry"/>
     </root>
 </configuration>


### PR DESCRIPTION
### Why do we need this? 
We scrubbed PII here: https://github.com/guardian/subscriptions-frontend/pull/1100
As we stop sending PII, to sentry, we are also deleting old sentry projects and starting anew. 

While we're starting anew, we might as well use sentry-logback rather than raven-logback (deprecated).

Both subscriptions and subscriptions-client-side shall point to new projects in conjunction with this PR. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
* Pointing to the DSN of the new project for subscriptions-client-side
* Update the DSN configured in the config for the new sentry project for subscriptions
* Move to using sentry-logback (raven-logback is deprecated). 
* Wrap Sentry.init in a try 

TODO:
Pre-merge
- [x] Test in CODE that error logs go to the new project
- [x] Add the DSN for the new sentry project to the PROD config 
- [x] Remove the DSN from the CODE config

Post-merge
- [ ] Delete the existing sentry project
- [ ] Rename the new sentry projects back to support and support-client-side as before


### trello card/screenshot/json/related PRs etc
[**Trello Card**](https://trello.com/c/LiojyKYR/1555-delete-all-projects-which-contain-pii-from-sentry-and-replace-with-a-clean-project)
[Scrub PII from logs sent to sentry](https://github.com/guardian/subscriptions-frontend/pull/1100)