### PR TITLE
Configure the Sentry appender and the filters in the code again

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -1,7 +1,6 @@
 package configuration
 
 
-import com.getsentry.raven.dsn.Dsn
 import com.github.nscala_time.time.Imports._
 import com.gu.cas.PrefixedTokens
 import com.gu.config._
@@ -68,7 +67,7 @@ object Config {
 
   val subscriptionsUrl = config.getString("subscriptions.url")
 
-  val sentryDsn = Try(new Dsn(config.getString("sentry.dsn")))
+  val sentryDsn = Try(config.getString("sentry.dsn"))
 
   object Logstash {
     private val param = Try{config.getConfig("param.logstash")}.toOption

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -43,7 +43,6 @@ object SentryLogging {
           case Success(_) => SafeLogger.debug("Sentry logging configured.")
           case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
-        SafeLogger.error(scrub"*TEST* Ignore me.")
     }
   }
 }

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -1,41 +1,49 @@
 package monitoring
 
+import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.filter.ThresholdFilter
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.classic.{Logger, LoggerContext}
 import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.spi.FilterReply
-import com.getsentry.raven.RavenFactory
-import com.getsentry.raven.logback.SentryAppender
 import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import configuration.Config
+import io.sentry.Sentry
+import io.sentry.logback.SentryAppender
 import org.slf4j.Logger.ROOT_LOGGER_NAME
 import org.slf4j.LoggerFactory
 
-import scala.util.{Failure, Success}
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
 
 object SentryLogging {
 
-  def init() {
+  def init(): Unit = {
     Config.sentryDsn match {
       case Failure(ex) =>
-        play.api.Logger.warn("No Sentry logging configured (OK for dev)", ex)
-      case Success(dsn) =>
-        play.api.Logger.info(s"Initialising Sentry logging for ${dsn.getHost}")
-        val buildInfo: Map[String, Any] = app.BuildInfo.toMap
-        val tags = Map("stage" -> Config.stage) ++ buildInfo
-        val tagsString = tags.map { case (key, value) => s"$key:$value"}.mkString(",")
+        SafeLogger.warn("No Sentry logging configured (OK for dev)", ex)
+      case Success(dsn: String) =>
+        SafeLogger.info(s"Initialising Sentry logging")
+        Try {
+          val sentryClient = Sentry.init(dsn)
+          val sentryAppender = new SentryAppender {
+            addFilter(SentryFilters.errorLevelFilter)
+            addFilter(SentryFilters.piiFilter)
+          }
 
+          sentryAppender.start()
 
-        val sentryAppender = new SentryAppender(RavenFactory.ravenInstance(dsn)) {
-          setRelease(app.BuildInfo.buildNumber)
-          addFilter(SentryFilters.errorLevelFilter)
-          addFilter(SentryFilters.piiFilter)
-          setTags(tagsString)
-          setContext(LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext])
+          val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
+          val tags = Map("stage" -> Config.stage.toString) ++ buildInfo
+          sentryClient.setTags(tags.asJava)
+
+          LoggerFactory.getLogger(ROOT_LOGGER_NAME).asInstanceOf[Logger].addAppender(sentryAppender)
+
+        } match {
+          case Success(_) => SafeLogger.debug("Sentry logging configured.")
+          case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
-        sentryAppender.start()
-        LoggerFactory.getLogger(ROOT_LOGGER_NAME).asInstanceOf[Logger].addAppender(sentryAppender)
+        SafeLogger.error(scrub"*TEST* Ignore me.")
     }
   }
 }
@@ -49,7 +57,6 @@ object SentryFilters {
 
   val errorLevelFilter = new ThresholdFilter { setLevel("ERROR") }
   val piiFilter = new PiiFilter
-
   errorLevelFilter.start()
   piiFilter.start()
 

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -43,7 +43,6 @@ object SentryLogging {
           case Success(_) => SafeLogger.debug("Sentry logging configured.")
           case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
-        SafeLogger.error(scrub"*TEST* you are simply the bee's knees!")
     }
   }
 }

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -43,6 +43,7 @@ object SentryLogging {
           case Success(_) => SafeLogger.debug("Sentry logging configured.")
           case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
+        SafeLogger.error(scrub"*TEST* you are simply the bee's knees!")
     }
   }
 }

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -23,18 +23,7 @@ https://www.playframework.com/documentation/2.4.x/SettingsLogger#Using-a-configu
 
     <logger name="com.google.api.client.http" level="WARN" />
 
-
-    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>ERROR</level>
-        </filter>
-        <filter class="monitoring.PiiFilter">
-            <level>ERROR</level>
-        </filter>
-    </appender>
-
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="Sentry"/>
     </root>
 </configuration>


### PR DESCRIPTION
Otherwise, we get ugly errors in the console when running in DEV mode. This was introduced when upgrading to sentry-logback 1.7.5 in https://github.com/guardian/subscriptions-frontend/pull/1107

Read more here:
https://github.com/guardian/support-frontend/pull/703

Tested Sentry config still works in CODE, and checked while running locally that this resolved the ClassNotFound exception.