### PR TITLE
Move the AWIN javascript into the thank you page

### DIFF
--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -36,6 +36,47 @@
         currency: '@subscription.currency',
         subscriptionId: '@subscription.id.get'
     };
+
+    function getCookie(name) {
+        var nameEQ = name + '=';
+        var ca = document.cookie.split(';');
+        for (var i = 0; i < ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0) === ' ') { c = c.substring(1, c.length); }
+            if (c.indexOf(nameEQ) === 0) { return c.substring(nameEQ.length, c.length); }
+        }
+        return null;
+    }
+
+    function getAwinChannel() {
+        const channel = getCookie('gu_referrer_channel');
+        if (channel === null) {
+            return 'direct'; //No referrer the user came direct to the site
+        }
+
+        const values = channel ? channel.split('&') : null;
+        if (values && values[0] === 'afl' && values[1] === 'awin'){
+            return 'aw';
+        }
+        return 'na'; //A referrer other than Awin
+    }
+
+    //<![CDATA[ /*** Do not change ***/
+    var AWIN = {};
+    AWIN.Tracking = {};
+    AWIN.Tracking.Sale = {};
+
+    /*** Set your transaction parameters ***/
+    const productData = guardian.pageInfo.productData;
+    AWIN.Tracking.Sale.amount = productData.amount;
+    AWIN.Tracking.Sale.orderRef = productData.subscriptionId;
+    AWIN.Tracking.Sale.parts = productData.productSegment + ':' + productData.amount;
+    AWIN.Tracking.Sale.voucher = productData.promoCode;
+    AWIN.Tracking.Sale.currency = productData.currency;
+    AWIN.Tracking.Sale.test = '0';
+    AWIN.Tracking.Sale.channel = getAwinChannel();
+    //]]>
+
 </script>
 
 <main class="page-container gs-container gs-container--slim">

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -67,7 +67,7 @@
     AWIN.Tracking.Sale = {};
 
     /*** Set your transaction parameters ***/
-    const productData = guardian.pageInfo.productData;
+    var productData = guardian.pageInfo.productData;
     AWIN.Tracking.Sale.amount = productData.amount;
     AWIN.Tracking.Sale.orderRef = productData.subscriptionId;
     AWIN.Tracking.Sale.parts = productData.productSegment + ':' + productData.amount;

--- a/app/views/checkout/thankyou.scala.html
+++ b/app/views/checkout/thankyou.scala.html
@@ -37,8 +37,8 @@
         subscriptionId: '@subscription.id.get'
     };
 
-    function getCookie(name) {
-        var nameEQ = name + '=';
+    function getAwinChannelCookie() {
+        var nameEQ = 'gu_referrer_channel=';
         var ca = document.cookie.split(';');
         for (var i = 0; i < ca.length; i++) {
             var c = ca[i];
@@ -49,7 +49,7 @@
     }
 
     function getAwinChannel() {
-        const channel = getCookie('gu_referrer_channel');
+        const channel = getAwinChannelCookie();
         if (channel === null) {
             return 'direct'; //No referrer the user came direct to the site
         }
@@ -67,12 +67,11 @@
     AWIN.Tracking.Sale = {};
 
     /*** Set your transaction parameters ***/
-    var productData = guardian.pageInfo.productData;
-    AWIN.Tracking.Sale.amount = productData.amount;
-    AWIN.Tracking.Sale.orderRef = productData.subscriptionId;
-    AWIN.Tracking.Sale.parts = productData.productSegment + ':' + productData.amount;
-    AWIN.Tracking.Sale.voucher = productData.promoCode;
-    AWIN.Tracking.Sale.currency = productData.currency;
+    AWIN.Tracking.Sale.amount = guardian.pageInfo.productData.amount;
+    AWIN.Tracking.Sale.orderRef = guardian.pageInfo.productData.subscriptionId;
+    AWIN.Tracking.Sale.parts = guardian.pageInfo.productData.productSegment + ':' + productData.amount;
+    AWIN.Tracking.Sale.voucher = guardian.pageInfo.productData.promoCode;
+    AWIN.Tracking.Sale.currency = guardian.pageInfo.productData.currency;
     AWIN.Tracking.Sale.test = '0';
     AWIN.Tracking.Sale.channel = getAwinChannel();
     //]]>

--- a/assets/javascripts/modules/analytics/awin.js
+++ b/assets/javascripts/modules/analytics/awin.js
@@ -1,59 +1,19 @@
 //Implementation docs here: https://drive.google.com/drive/folders/19AOGPkPbbFjqPJTdCcCba3EwpLiSHBwW
 define([
-    'modules/analytics/analyticsEnabled',
-    'modules/analytics/dntEnabled',
     'utils/cookie'
-], function (analyticsEnabled, dntEnabled, cookie) {
+], function (cookie) {
     'use strict';
-
-    const referrerCookieName = 'gu_referrer_channel';
-
-    function init() {
-        storeChannel();
-
-        if (guardian.pageInfo.pageType !== 'Thankyou') {
-            return;
-        }
-
-        let AWIN = {};
-        AWIN.Tracking = {};
-        AWIN.Tracking.Sale = {};
-
-        /*** Set your transaction parameters ***/
-        const productData = guardian.pageInfo.productData;
-        AWIN.Tracking.Sale.amount = productData.amount;
-        AWIN.Tracking.Sale.orderRef = productData.subscriptionId;
-        AWIN.Tracking.Sale.parts = productData.productSegment + ':' + productData.amount;
-        AWIN.Tracking.Sale.voucher = productData.promoCode;
-        AWIN.Tracking.Sale.currency = productData.currency;
-        AWIN.Tracking.Sale.test = '0';
-        AWIN.Tracking.Sale.channel = getAwinChannel();
-        window.AWIN = AWIN;
-    }
-
-    function getAwinChannel() {
-        const channel = cookie.getCookie(referrerCookieName);
-        if (channel === null) {
-            return 'direct'; //No referrer the user came direct to the site
-        }
-
-        const values = channel ? channel.split('&') : null;
-        if (values && values[0] === 'afl' && values[1] === 'awin'){
-            return 'aw';
-        }
-        return 'na'; //A referrer other than Awin
-    }
 
     function storeChannel() {
         const parsedUrl = new URL(window.location.href);
         const utmSource = parsedUrl.searchParams.get('utm_source');
         const utmMedium = parsedUrl.searchParams.get('utm_medium');
         if (utmSource && utmMedium){
-            cookie.setCookie(referrerCookieName, `${utmSource}&${utmMedium}`);
+            cookie.setCookie('gu_referrer_channel', `${utmSource}&${utmMedium}`);
         }
     }
 
     return {
-        init: analyticsEnabled(dntEnabled(init))
+        init: storeChannel
     };
 });


### PR DESCRIPTION
Something is preventing the AWIN tracking code from firing properly when it is included via main.js.
It feels like a race condition because apparently it has worked on occasion. 

To try to work round this I'm including the code directly in the thank you page, if this works we can work out what the best route forward is from here...