### PR TITLE
Reduce the number of metrics sent to CloudWatch

### DIFF
--- a/app/controllers/CAS.scala
+++ b/app/controllers/CAS.scala
@@ -3,20 +3,18 @@ package controllers
 import actions.OAuthActions
 import com.gu.cas.{TokenPayload, Valid}
 import com.gu.googleauth.UserIdentity
-import com.gu.monitoring.ServiceMetrics
 import com.gu.okhttp.RequestRunners
 import com.gu.subscriptions.CAS.{CASError, CASSuccess}
 import com.gu.subscriptions.{CASApi, CASService}
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
-import configuration.Config.{CAS, appName, stage}
+import configuration.Config.CAS
 import forms.CASForm
 import play.api.libs.json.Json
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc.{BaseController, ControllerComponents}
 import views.support.CASResultOps._
 import views.support.TokenPayloadOps._
-
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Try}
 
@@ -31,8 +29,7 @@ class CAS(oAuthActions: OAuthActions, implicit val executionContext: ExecutionCo
   }
 
   lazy val casService = {
-    val metrics = new ServiceMetrics(stage, appName, "CAS service")
-    val api = new CASApi(CAS.url, RequestRunners.loggingRunner(metrics))
+    val api = new CASApi(CAS.url, RequestRunners.futureRunner)
     new CASService(api)
   }
 

--- a/app/monitoring/Metrics.scala
+++ b/app/monitoring/Metrics.scala
@@ -1,9 +1,0 @@
-package monitoring
-
-import com.gu.monitoring.CloudWatch
-import configuration.Config
-
-trait Metrics extends CloudWatch {
-  val stage = Config.stage
-  val application = Config.appName
-}

--- a/app/services/GetAddressIOService.scala
+++ b/app/services/GetAddressIOService.scala
@@ -1,21 +1,14 @@
 package services
 
 import com.gu.memsub.util.WebServiceHelper
-import com.gu.monitoring.StatusMetrics
 import com.gu.okhttp.RequestRunners
 import com.typesafe.scalalogging.LazyLogging
-import monitoring.Metrics
 import services.GetAddressIOModel.{FindAddressResult, FindAddressResultError}
-
 import scala.concurrent.{ExecutionContext, Future}
 
 object GetAddressIOModel {
   case class FindAddressResult(Latitude: Float, Longitude: Float, Addresses: Seq[String])
   case class FindAddressResultError(Message: String) extends RuntimeException(s"$Message")
-}
-
-object GetAddressIOMetrics extends Metrics with StatusMetrics {
-  override val service: String = "GetAddressIO"
 }
 
 class GetAddressIOService()(implicit executionContext: ExecutionContext) extends WebServiceHelper[FindAddressResult, FindAddressResultError] with LazyLogging {
@@ -29,6 +22,6 @@ class GetAddressIOService()(implicit executionContext: ExecutionContext) extends
     )(FindAddressResult)
 
   override val wsUrl: String = Config.getAddressIOApiUrl
-  override val httpClient = RequestRunners.loggingRunner(GetAddressIOMetrics)
+  override val httpClient = RequestRunners.futureRunner
   def find(postcode: String): Future[FindAddressResult] = get[FindAddressResult](postcode, "api-key" -> Config.getAddressIOApiKey).transform(x => x, y => y)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= Seq(
     filters,
     jodaForms,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.1-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.519",
     "com.gu.identity" %% "identity-play-auth" % "2.1",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.2",

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= Seq(
     filters,
     jodaForms,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.509",
+    "com.gu" %% "membership-common" % "0.1-SNAPSHOT",
     "com.gu.identity" %% "identity-play-auth" % "2.1",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.2",


### PR DESCRIPTION
This PR upgrades to the latest membership-common version, which uses futureRunner over loggingRunner for a number of services in order to cut down on the number of metrics that we are sending to CloudWatch.

See also: https://github.com/guardian/membership-frontend/pull/1828