### PR TITLE
Start trial button tracking

### DIFF
--- a/app/views/digitalpack/info.scala.html
+++ b/app/views/digitalpack/info.scala.html
@@ -6,7 +6,7 @@
 
 @import model.Benefits
 
-@startTrial(edition: DigitalEdition, price: Price) = {
+@startTrial(edition: DigitalEdition, price: Price, startTrial: String) = {
     <div class="pricing-cta">
         <div class="pricing-cta__pricing">
             <h4 class="pricing-cta__pricing__title">Free for 14 days</h4>
@@ -14,7 +14,7 @@
         </div>
         <div class="pricing-cta__action">
             <a class="button button--large button--primary"
-               href="@edition.redirect"
+               href="@edition.redirect(startTrial)"
                data-test-id="digital-pack-@edition.id-trial-header"
             >Start your free trial</a>
         </div>
@@ -38,7 +38,7 @@
     <section class="page-slice">
         <div class="page-slice__content">
             @fragments.page.header(s"Digital Pack", Some("Digital access to our Daily Edition and Guardian App Premium Tier"))
-            @startTrial(edition, price)
+            @startTrial(edition, price, "subscribe_digipack_page_header")
         </div>
     </section>
 
@@ -60,7 +60,7 @@
                 controllers.CachedAssets.hashedPathFor("images/premium-tier-garnett.png"),
                 "more-premium-benefits"
             )
-            @startTrial(edition, price)
+            @startTrial(edition, price, "subscribe_digipack_page_what_do_i_get")
         </div>
     </section>
 
@@ -84,7 +84,7 @@
                     <p>You can download the Digital Pack on up to 10 devices. Share it with your friends and family or give it as a gift</p>
                 </li>
             </ol>
-            @startTrial(edition, price)
+            @startTrial(edition, price, "subscribe_digipack_page_why_subscribe")
         </div>
     </section>
 
@@ -114,7 +114,7 @@
                     </span>
                 </li>
             </ol>
-            @startTrial(edition, price)
+            @startTrial(edition, price, "subscribe_digipack_page_how_do_i_get_it")
         </div>
     </section>
 </main>

--- a/app/views/digitalpack/info.scala.html
+++ b/app/views/digitalpack/info.scala.html
@@ -6,7 +6,7 @@
 
 @import model.Benefits
 
-@startTrial(edition: DigitalEdition, price: Price, startTrial: String) = {
+@startTrial(edition: DigitalEdition, price: Price, referringButton: String) = {
     <div class="pricing-cta">
         <div class="pricing-cta__pricing">
             <h4 class="pricing-cta__pricing__title">Free for 14 days</h4>
@@ -14,7 +14,7 @@
         </div>
         <div class="pricing-cta__action">
             <a class="button button--large button--primary"
-               href="@edition.redirect(startTrial)"
+               href="@edition.redirect(referringButton)"
                data-test-id="digital-pack-@edition.id-trial-header"
             >Start your free trial</a>
         </div>

--- a/app/views/support/DigitalEdition.scala
+++ b/app/views/support/DigitalEdition.scala
@@ -12,8 +12,8 @@ object DigitalEdition {
 
     lazy val DEFAULT_CAMPAIGN_CODE = s"GU_SUBSCRIPTIONS_${edition.id.toUpperCase}_PROMO"
 
-    def redirect(startTrialButton: String): Uri = {
-      "/checkout" ? ("countryGroup" -> edition.countryGroup.id) & ("startTrialButton" -> startTrialButton)
+    def redirect(referringButton: String): Uri = {
+      "/checkout" ? ("countryGroup" -> edition.countryGroup.id) & ("startTrialButton" -> referringButton)
     }
 
     def membershipLandingPage = getMembershipLandingPage(DEFAULT_CAMPAIGN_CODE)

--- a/app/views/support/DigitalEdition.scala
+++ b/app/views/support/DigitalEdition.scala
@@ -12,8 +12,8 @@ object DigitalEdition {
 
     lazy val DEFAULT_CAMPAIGN_CODE = s"GU_SUBSCRIPTIONS_${edition.id.toUpperCase}_PROMO"
 
-    def redirect: Uri = {
-      "/checkout" ? ("countryGroup" -> edition.countryGroup.id)
+    def redirect(startTrialButton: String): Uri = {
+      "/checkout" ? ("countryGroup" -> edition.countryGroup.id) & ("startTrialButton" -> startTrialButton)
     }
 
     def membershipLandingPage = getMembershipLandingPage(DEFAULT_CAMPAIGN_CODE)

--- a/assets/javascripts/modules/analytics/ga.js
+++ b/assets/javascripts/modules/analytics/ga.js
@@ -7,16 +7,21 @@ define(['modules/analytics/analyticsEnabled',
 
     var _EVENT_QUEUE = [];
 
+    function queryParam(key){
+        return new RegExp(key + '=([^&]*)').exec(location.search);
+    }
+
     function init() {
 
         var identitySignedIn = user.isLoggedIn();
         var identitySignedOut = !!cookie.getCookie('GU_SO') && !identitySignedIn;
         var ophanBrowserId = cookie.getCookie('bwid');
         var productData = guardian.pageInfo ? guardian.pageInfo.productData : {};
-        var intcmp = new RegExp('INTCMP=([^&]*)').exec(location.search);
+        var intcmp = queryParam('INTCMP');
         var isCustomerAgent = !!guardian.supplierCode;
-        var camCodeBusinessUnit = new RegExp('CMP_BUNIT=([^&]*)').exec(location.search);
-        var camCodeTeam = new RegExp('CMP_TU=([^&]*)').exec(location.search);
+        var camCodeBusinessUnit = queryParam('CMP_BUNIT');
+        var camCodeTeam = queryParam('CMP_TU');
+        var startTrialButton = queryParam('startTrialButton');
         var experience = guardian.experience;
 
         /* Google analytics snippet */
@@ -60,6 +65,10 @@ define(['modules/analytics/analyticsEnabled',
 
         if (intcmp && intcmp[1]) {
             ga('membershipPropertyTracker.set', 'dimension12', intcmp[1]);  // internalCampCode
+        }
+
+        if (startTrialButton && startTrialButton[1]) {
+            ga('membershipPropertyTracker.set', 'dimension22', startTrialButton[1]);  // the referring 'start trial' button
         }
 
         ga('membershipPropertyTracker.set', 'dimension13', isCustomerAgent);  // customerAgent

--- a/test/model/DigitalEditionTest.scala
+++ b/test/model/DigitalEditionTest.scala
@@ -7,10 +7,10 @@ import play.api.test.PlaySpecification
 class DigitalEditionTest extends PlaySpecification {
   "getRedirect" should {
     "go straight to the checkout for all users" in {
-      UK.redirect.toString mustEqual "/checkout?countryGroup=uk"
-      US.redirect.toString mustEqual "/checkout?countryGroup=us"
-      AU.redirect.toString mustEqual "/checkout?countryGroup=au"
-      INT.redirect.toString mustEqual "/checkout?countryGroup=int"
+      UK.redirect("test_button").toString mustEqual "/checkout?countryGroup=uk&startTrialButton=test_button"
+      US.redirect("test_button").toString mustEqual "/checkout?countryGroup=us&startTrialButton=test_button"
+      AU.redirect("test_button").toString mustEqual "/checkout?countryGroup=au&startTrialButton=test_button"
+      INT.redirect("test_button").toString mustEqual "/checkout?countryGroup=int&startTrialButton=test_button"
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

It adds tracking for a new GA custom dimension 'start_trial_button' (dim 22) which allows us to track exactly which 'Start free trial' button the user clicked on to arrive at the checkout page. 
This will help us to analyse behaviour while A/B testing the new Digital pack product page.

## [Trello card](https://trello.com/c/eIw5HUyo/1752-add-tracking-to-new-product-page-and-old-subscribe-page-for-a-b-test)