### PR TITLE
Restore Guardian Weekly Packshots

### DIFF
--- a/app/views/promotion/weeklyLandingPage.scala.html
+++ b/app/views/promotion/weeklyLandingPage.scala.html
@@ -21,7 +21,7 @@
     @isSixForSix = @{anyPromotion.filter(p => (catalog.weekly.plans.flatten.filter(_.charges.billingPeriod == SixWeeks).map(_.id).toSet intersect p.appliesTo.productRatePlanIds).nonEmpty)}
     @nonTrackingPromotion = @{anyPromotion.flatMap(p => p.asDiscount orElse p.asFreeTrial orElse p.asIncentive) orElse isSixForSix}
     @title = @{"The Guardian Weekly Subscriptions"}
-    @defaultImage = @{ResponsiveImageGroup(None,None,None,ResponsiveImageGenerator("021b11f82c8fb43da5ef308dc6d6c5bf2fecb9c8/0_0_2560_300",Seq(2560)))}
+    @defaultImage = @{ResponsiveImageGroup(None,None,None,ResponsiveImageGenerator("c7c76ffe9b2abe16b5d914dd7a9a23db9b32840b/0_0_14400_1680",Seq(2000)))}
     @discountedRegions = @{WeeklyPromotion.validRegionsForPromotion(promotion, promoCode, country)(catalog)}
     @main(
         title = s"$title | The Guardian",

--- a/assets/stylesheets/garnett.scss
+++ b/assets/stylesheets/garnett.scss
@@ -101,15 +101,6 @@ body {
   }
 }
 
-// Hides the weekly images on the weekly landing page, and changes the colour of the banner.
-.hero-banner {
-  background-color: #efefec;
-}
-
-.hero-banner__image {
-  visibility: hidden;
-}
-
 @include mq($from: tablet) {
   .digipack__shots {
     margin-left: 15%;


### PR DESCRIPTION
# Why?

Restoring the Guardian Weekly hero image on the Weekly landing page, updated with new Garnett packshots.

cc @JustinPinner @CPKING

# Changes

- Removed CSS hiding the hero image.
- Added new packshot from the Grid.

# Screenshots

**Before**

![weekly-before](https://user-images.githubusercontent.com/5131341/42289569-31a0a44e-7fb8-11e8-86ab-ca786e0a3e81.png)

**After**

![weekly-after](https://user-images.githubusercontent.com/5131341/42321120-b394fe86-804f-11e8-8b4c-41eec4a0ee02.png)
