### PR TITLE
Hide Quarterly Weekly Pricing

### DIFF
--- a/app/views/promotion/weeklyLandingPage.scala.html
+++ b/app/views/promotion/weeklyLandingPage.scala.html
@@ -67,11 +67,6 @@
                         <div class="weekly__package js-dropdown js-hide" data-dropdown-menu="@region.title.replaceAll(" ", "")">
                             <div class="weekly__package__info" title="@region.description">
                                 <span class="weekly__package__title">@region.title</span>
-                                @region.discountedPlans.headOption.map { plan =>
-                                    <span class="weekly__package__description weekly__package__supl">
-                                        @plan.headline
-                                    </span>
-                                }
                             </div>
                         </div>
                     } else {
@@ -79,9 +74,6 @@
                             <a href="@plan.url.toString" class="weekly__package" title="@region.description">
                                 <div class="weekly__package__info">
                                     <span class="weekly__package__title" >@region.title</span>
-                                    <span class="weekly__package__description weekly__package__supl">
-                                    @plan.headline
-                                    </span>
                                 </div>
                             </a>
                         }


### PR DESCRIPTION
## Why?

Having quarterly pricing on the region selector for Guardian Weekly makes it harder to tell that there's an annual option. This removes it, so that you see the price when you click through, and get quarterly and annual side-by-side.

cc @JustinPinner 

## Changes

- Removed template code showing pricing on the region buttons.

## Screenshots

### Before

![weekly-before-region](https://user-images.githubusercontent.com/5131341/42569746-7ea4e4c0-8509-11e8-8b3d-22dafda23e47.jpg)
![weekly-before-price](https://user-images.githubusercontent.com/5131341/42569745-7e87c520-8509-11e8-9f88-eb277b1c6321.jpg)

### After

![weekly-after-region](https://user-images.githubusercontent.com/5131341/42569758-86fa7662-8509-11e8-9d90-200c3e943cc5.jpg)
![weekly-after-price](https://user-images.githubusercontent.com/5131341/42569757-86e02a78-8509-11e8-89da-67d5c171fe73.jpg)
