### PR TITLE
Update Weekly Copy On Multi-Product Pages

### DIFF
--- a/app/views/fragments/productLists/productListInternational.scala.html
+++ b/app/views/fragments/productLists/productListInternational.scala.html
@@ -7,10 +7,11 @@
         <h2 class="block__title">Subscribe to the Guardian Weekly</h2>
         <div class="block__info">
             <ul class="block__list">
-                <li class="block__list-item">A selection of international editorial from the Guardian, Observer and Washington Post</li>
-                <li class="block__list-item">A unique blend of international news, politics, culture and comment</li>
-                <li class="block__list-item">Save on the retail price</li>
-                <li class="block__list-item">Free delivery to your door, wherever you are in the world</li>
+                <li class="block__list-item">A selection of the week's biggest international stories major world events, politics and culture from The Guardian and The Observer, in one comprehensive paper</li>
+                <li class="block__list-item">Saving on the retail cover price</li>
+                <li class="block__list-item">Free international delivery</li>
+                <li class="block__list-item">Access to the latest and archive editions at any time, on any device, via PressReader</li>
+                <li class="block__list-item">A weekly email newsletter from the editor</li>
             </ul>
         </div>
         <div class="block__footer">

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -15,10 +15,11 @@
                 <h2 class="block__title">Guardian Weekly</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">A selection of international editorial from the Guardian, Observer and Washington Post</li>
-                        <li class="block__list-item">A unique blend of international news, politics, culture and comment</li>
-                        <li class="block__list-item">Save on the retail price</li>
-                        <li class="block__list-item">Free delivery to your door, wherever you are in the world</li>
+                        <li class="block__list-item">A selection of the week's biggest international stories major world events, politics and culture from The Guardian and The Observer, in one comprehensive paper</li>
+                        <li class="block__list-item">Saving on the retail cover price</li>
+                        <li class="block__list-item">Free international delivery</li>
+                        <li class="block__list-item">Access to the latest and archive editions at any time, on any device, via PressReader</li>
+                        <li class="block__list-item">A weekly email newsletter from the editor</li>
                     </ul>
                 </div>
                 <div class="block__footer">

--- a/app/views/offers/offers_uk.scala.html
+++ b/app/views/offers/offers_uk.scala.html
@@ -15,10 +15,11 @@
                 <h2 class="block__title">Subscribe to the Guardian Weekly</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">A selection of international editorial from the Guardian, Observer and Washington Post</li>
-                        <li class="block__list-item">A unique blend of international news, politics, culture and comment</li>
-                        <li class="block__list-item">Save on the retail price</li>
-                        <li class="block__list-item">Free delivery to your door, wherever you are in the world</li>
+                        <li class="block__list-item">A selection of the week's biggest international stories major world events, politics and culture from The Guardian and The Observer, in one comprehensive paper</li>
+                        <li class="block__list-item">Saving on the retail cover price</li>
+                        <li class="block__list-item">Free international delivery</li>
+                        <li class="block__list-item">Access to the latest and archive editions at any time, on any device, via PressReader</li>
+                        <li class="block__list-item">A weekly email newsletter from the editor</li>
                     </ul>
                 </div>
                 <div class="block__footer">


### PR DESCRIPTION
## Why?

Updating the Guardian Weekly copy on the multi-product pages to be in-line with the new copy on the Weekly Landing Page.

cc @JustinPinner 

## Changes

- Updated the copy on the UK landing page, the international landing pages and the offers page.

## Screenshots

### UK Landing

![ukweekly-after](https://user-images.githubusercontent.com/5131341/42953014-6468b3b6-8b71-11e8-9d44-56bcdcd2e964.jpg)

### UK Offers

![ukoffers-after](https://user-images.githubusercontent.com/5131341/42953076-7f3a6cac-8b71-11e8-87d4-8a9cdcfe6a04.jpg)

### International Landing

![int-after](https://user-images.githubusercontent.com/5131341/42953137-a649ac54-8b71-11e8-8946-e74e42106ad6.jpg)
