### PR TITLE
Light Copy Editing On Landing Pages

### DIFF
--- a/app/views/fragments/productLists/productListInternational.scala.html
+++ b/app/views/fragments/productLists/productListInternational.scala.html
@@ -7,7 +7,7 @@
         <h2 class="block__title">Subscribe to the Guardian Weekly</h2>
         <div class="block__info">
             <ul class="block__list">
-                <li class="block__list-item">A selection of the week's biggest international stories major world events, politics and culture from The Guardian and The Observer, in one comprehensive paper</li>
+                <li class="block__list-item">A selection of the week's biggest international stories, major world events, politics and culture from The Guardian and The Observer, in one comprehensive paper</li>
                 <li class="block__list-item">Saving on the retail cover price</li>
                 <li class="block__list-item">Free international delivery</li>
                 <li class="block__list-item">Access to the latest and archive editions at any time, on any device, via PressReader</li>

--- a/app/views/fragments/productLists/productListUk.scala.html
+++ b/app/views/fragments/productLists/productListUk.scala.html
@@ -36,7 +36,7 @@
             }
                 <li class="block__list-item">Pick the package you want: Everyday, Sixday, Weekend and The Observer</li>
                 <li class="block__list-item">All supplements Monday to Sunday</li>
-                <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or delivery within the M25</li>
+                <li class="block__list-item">Receive newspaper vouchers to use at over 1,000 retailers across the UK, or home delivery within the M25</li>
             </ul>
         </div>
         <div class="block__footer">

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -15,7 +15,7 @@
                 <h2 class="block__title">Guardian Weekly</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">A selection of the week's biggest international stories major world events, politics and culture from The Guardian and The Observer, in one comprehensive paper</li>
+                        <li class="block__list-item">A selection of the week's biggest international stories, major world events, politics and culture from The Guardian and The Observer, in one comprehensive paper</li>
                         <li class="block__list-item">Saving on the retail cover price</li>
                         <li class="block__list-item">Free international delivery</li>
                         <li class="block__list-item">Access to the latest and archive editions at any time, on any device, via PressReader</li>

--- a/app/views/offers/offers_uk.scala.html
+++ b/app/views/offers/offers_uk.scala.html
@@ -15,7 +15,7 @@
                 <h2 class="block__title">Subscribe to the Guardian Weekly</h2>
                 <div class="block__info">
                     <ul class="block__list">
-                        <li class="block__list-item">A selection of the week's biggest international stories major world events, politics and culture from The Guardian and The Observer, in one comprehensive paper</li>
+                        <li class="block__list-item">A selection of the week's biggest international stories, major world events, politics and culture from The Guardian and The Observer, in one comprehensive paper</li>
                         <li class="block__list-item">Saving on the retail cover price</li>
                         <li class="block__list-item">Free international delivery</li>
                         <li class="block__list-item">Access to the latest and archive editions at any time, on any device, via PressReader</li>


### PR DESCRIPTION
## Why?

Tweaks for grammar and clarity.

cc @JustinPinner 

## Changes

Added comma to weekly copy and added the word "home" to the M25 delivery description.
