### PR TITLE
Prevent search engines indexing parameterised pages

### DIFF
--- a/app/controllers/Homepage.scala
+++ b/app/controllers/Homepage.scala
@@ -3,7 +3,10 @@ package controllers
 import actions.CommonActions
 import com.gu.i18n.CountryGroup
 import com.gu.memsub.SupplierCodeBuilder
+import configuration.Config
 import controllers.SessionKeys.SupplierTrackingCode
+import controllers.WeeklyLandingPage.Hreflangs
+import model.DigitalEdition
 import model.DigitalEdition._
 import play.api.mvc._
 import utils.RequestCountry._
@@ -19,12 +22,16 @@ class Homepage(commonActions: CommonActions, override protected val controllerCo
     Redirect(routes.Homepage.landingPage(digitalEdition.id).url, request.queryString, SEE_OTHER)
   }
 
+  def makeHrefLangs(forEdition: DigitalEdition): Hreflangs = {
+    Hreflangs(s"${Config.subscriptionsUrl}/${forEdition.id.toLowerCase}")
+  }
+
   def landingPage(code: String) = NoCacheAction {
     getById(code).fold {
       NotFound(views.html.error404())
     } {
-      case UK => Ok(views.html.index())
-      case digitalEdition => Ok(views.html.index_intl(digitalEdition))
+      case UK => Ok(views.html.index(Some(makeHrefLangs(UK))))
+      case digitalEdition => Ok(views.html.index_intl(digitalEdition, Some(makeHrefLangs(digitalEdition))))
     }
   }
 

--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -131,7 +131,7 @@ class PromoLandingPage(
         val hreflangs = CountryGroup.countries.map { country =>
           Hreflang(Config.subscriptionsUrl + routes.PromoLandingPage.render(promoCodeStr, Some(country)).url, s"en-${country.alpha2}")
         }
-        val hreflang = Hreflangs(Config.subscriptionsUrl + routes.PromoLandingPage.render(promoCodeStr, Some(country)).url, hreflangs)
+        val hreflang = Hreflangs(Config.subscriptionsUrl + routes.PromoLandingPage.render(promoCodeStr, Some(country)).url, Some(hreflangs))
 
         OptionT(eventualCatalogPromoLandingPage.map(catalogPromoLandingPage =>
           catalogPromoLandingPage.getLandingPage(promotion, country, hreflang).map(Ok(_))
@@ -165,7 +165,7 @@ class PromoLandingPage(
         val hreflangs = CountryGroup.countries.map { country =>
           Hreflang(Config.subscriptionsUrl + routes.PromoLandingPage.preview(Some(country)).url, s"en-${country.alpha2}")
         }
-        val hreflang = Hreflangs(Config.subscriptionsUrl + routes.PromoLandingPage.preview(Some(country)).url, hreflangs)
+        val hreflang = Hreflangs(Config.subscriptionsUrl + routes.PromoLandingPage.preview(Some(country)).url, Some(hreflangs))
 
         OptionT(eventualCatalogPromoLandingPage.map(_.getLandingPage(promotion, country, hreflang)(promoCode)))
       }

--- a/app/controllers/WeeklyLandingPage.scala
+++ b/app/controllers/WeeklyLandingPage.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Future
 
 object WeeklyLandingPage{
   case class Hreflang(href: String, lang: String)
-  case class Hreflangs(canonical: String, hreflangs: List[Hreflang])
+  case class Hreflangs(canonical: String, hreflangs: Option[List[Hreflang]] = None)
 }
 
 class WeeklyLandingPage(tpBackend: TouchpointBackend, commonActions: CommonActions, override protected val controllerComponents: ControllerComponents) extends BaseController {

--- a/app/views/fragments/head.scala.html
+++ b/app/views/fragments/head.scala.html
@@ -4,7 +4,7 @@
     description: Option[String],
     jsVars: model.JsVars,
     touchpointBackendResolutionOpt: Option[services.TouchpointBackends.Resolution],
-    hreflang: Option[Hreflangs]
+    maybeHrefLangs: Option[Hreflangs] = None
 )
 
 @import controllers.CachedAssets.hashedPathFor
@@ -23,12 +23,14 @@
 <meta property="og:title" content="@title"/>
 @description.map { d => <meta name="og:description" content="@d" /> }
 <meta property="og:type" content="website"/>
-    @hreflang.map { case Hreflangs(href, langMap) =>
-    <link rel="canonical" href="@href">
-        @langMap.map { case Hreflang(href, lang) =>
-        <link rel="alternate" href="@href" hreflang="@lang">
+@maybeHrefLangs.map { hrefLangs =>
+    <link rel="canonical" href="@hrefLangs.canonical">
+    @hrefLangs.hreflangs.map { alternates =>
+        @alternates.map { alternate =>
+            <link rel="alternate" href="@alternate.href" hreflang="@alternate.lang">
         }
     }
+}
 
 @fragments.javascriptFirstSteps(jsVars, touchpointBackendResolutionOpt)
 

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,11 +1,15 @@
 @import model.DigitalEdition.UK
 @import services.FlashSale
-@()
+@import controllers.WeeklyLandingPage.Hreflangs
+
+@(maybeHrefLangs: Option[Hreflangs] = None)
 
 @main(
     "Subscriptions | The Guardian",
     Some("Subscribe to The Guardian & The Observer. Support our independent, award-winning journalism."),
-    edition = UK) {
+    edition = UK,
+    hreflangs = maybeHrefLangs
+) {
 
     <main class="page-container gs-container">
         @fragments.page.header("Subscriptions")

--- a/app/views/index_intl.scala.html
+++ b/app/views/index_intl.scala.html
@@ -1,12 +1,15 @@
 @import model.DigitalEdition
 @import services.FlashSale
 @import views.support.DigitalEdition._
-@(edition: DigitalEdition)
+@import controllers.WeeklyLandingPage.Hreflangs
+
+@(edition: DigitalEdition, hreflangs: Option[Hreflangs])
 
 @main(s"${edition.name} | Subscriptions | The Guardian",
     Some("Subscribe to The Guardian. Support our independent, award-winning journalism."),
     edition = edition,
-    contactUsCountry = edition.countryGroup.defaultCountry
+    contactUsCountry = edition.countryGroup.defaultCountry,
+    hreflangs = hreflangs
 ) {
 
 <main class="page-container gs-container">

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,11 @@
 User-agent: *
 
-Disallow: /patterns
+Disallow: /checkout
+Disallow: /healthcheck
 Disallow: /manage
+Disallow: /management/manifest
+Disallow: /p/*
+Disallow: /patterns
+Disallow: /test-users
 
 Allow: /


### PR DESCRIPTION
Sometimes we use INTCMP parameters on our subscription index pages. If these are crawled and indexed by search engines, that can cause problems for us and for people searching for subscription-related pages.

This PR extends the use of the existing `Hreflangs` case classes so that we can include a `<link rel="canonical" href="the_canonical_link_here">` in the `<head>` section of those pages.

It also adds a few extra entries to `robots.txt` to prevent indexing of URLs that don't have a valid context as a direct hit from search results.
 
