### PR TITLE
Change the weekly landing page redirects to retain any query params

### DIFF
--- a/app/controllers/WeeklyLandingPage.scala
+++ b/app/controllers/WeeklyLandingPage.scala
@@ -28,7 +28,7 @@ class WeeklyLandingPage(tpBackend: TouchpointBackend, commonActions: CommonActio
 
   def index(country: Option[Country]) = NoCacheAction { implicit request =>
     val maybeCountry = country orElse request.getFastlyCountry
-    Redirect(routes.WeeklyLandingPage.withCountry(maybeCountry.map(_.alpha2).getOrElse(international)))
+    Redirect(routes.WeeklyLandingPage.withCountry(maybeCountry.map(_.alpha2).getOrElse(international)).url, request.queryString, TEMPORARY_REDIRECT)
   }
 
   val description = landing_description()
@@ -36,7 +36,7 @@ class WeeklyLandingPage(tpBackend: TouchpointBackend, commonActions: CommonActio
   def withCountry(country: String) = NoCacheAction.async { implicit request =>
     val parsedCountry = if (country == international) Some(Country.UK) else CountryGroup.countryByCode(country)
     parsedCountry.fold {
-      Future.successful(MovedPermanently(routes.WeeklyLandingPage.withCountry(international).url))
+      Future.successful(Redirect(routes.WeeklyLandingPage.withCountry(international).url, request.queryString, PERMANENT_REDIRECT))
     } { country =>
       Future.successful(Redirect(routes.PromoLandingPage.render("10ANNUAL", Some(country)).url, request.queryString, TEMPORARY_REDIRECT))
     }


### PR DESCRIPTION
Currently if you go to `https://subscribe.theguardian.com/weekly?foo=bar` you get redirected to `https://subscribe.theguardian.com/p/10ANNUAL?country=GB` and the `foo` query param is lost.

This PR changes the behaviour so that you now end up on `https://subscribe.theguardian.com/p/10ANNUAL?country=GB&foo=bar`