### PR TITLE
Add click tracking to the international landing page

### DIFF
--- a/app/views/fragments/productLists/digitalPack.scala.html
+++ b/app/views/fragments/productLists/digitalPack.scala.html
@@ -24,6 +24,6 @@
         </ul>
     </div>
     <div class="block__footer">
-        <a class="button button--large button--primary" href="@edition.getDestinationUrl(promoCodes(Digital), includeEditionInUrl)" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
+        <a class="button button--large button--primary js-index-intl-digipack-cta" href="@edition.getDestinationUrl(promoCodes(Digital), includeEditionInUrl)" data-test-id="subscriptions-@edition.id-digital">Subscribe now</a>
     </div>
 </div>

--- a/app/views/fragments/productLists/productListInternational.scala.html
+++ b/app/views/fragments/productLists/productListInternational.scala.html
@@ -15,7 +15,7 @@
             </ul>
         </div>
         <div class="block__footer">
-            <a class="button button--large button--primary" href="@routes.PromoLandingPage.render(promoCodes(GuardianWeekly), edition.countryGroup.defaultCountry).url">Subscribe now</a>
+            <a class="button button--large button--primary js-index-intl-weekly-cta" href="@routes.PromoLandingPage.render(promoCodes(GuardianWeekly), edition.countryGroup.defaultCountry).url">Subscribe now</a>
         </div>
     </div>
 </div>

--- a/assets/javascripts/main.js
+++ b/assets/javascripts/main.js
@@ -17,6 +17,7 @@ require([
     'modules/renew/loader',
     'modules/mma/loader',
     'modules/animatedDropdown',
+    'modules/index-intl',
     'object-fit-images'
 ], function (
     ajax,
@@ -37,6 +38,7 @@ require([
     renew,
     mma,
     dropdown,
+    indexIntl,
     objectFitImages
 ) {
     'use strict';
@@ -56,6 +58,7 @@ require([
     confirmation.init();
     cas.init();
     dropdown.init();
+    indexIntl.init();
     objectFitImages();
     patterns.init();
     renew.init();

--- a/assets/javascripts/modules/index-intl.js
+++ b/assets/javascripts/modules/index-intl.js
@@ -1,0 +1,36 @@
+/* global ga */
+define(['$',
+    'bean',
+], function (
+    $,
+    bean,
+) {
+    'use strict';
+
+    function trackClick(eventLabel) {
+        if (typeof(ga) === 'undefined') { return; }
+
+        var event = {
+            eventCategory: 'click',
+            eventAction:  'international_subs_landing_pages',
+            eventLabel: eventLabel,
+        };
+        ga('membershipPropertyTracker.send', 'event', event);
+    }
+
+    function addClickTracking(selector, eventLabel) {
+        var $actionEl = $(selector);
+        if ($actionEl.length) {
+            bean.on($actionEl[0], 'click', () => trackClick(eventLabel));
+        }
+    }
+
+    function init() {
+        addClickTracking('.js-index-intl-weekly-cta', 'weekly_cta');
+        addClickTracking('.js-index-intl-digipack-cta', 'digipack_cta');
+    }
+
+    return {
+        init: init
+    };
+});


### PR DESCRIPTION
We are launching new international subs landing pages on the support site and want to ensure that they perform as least as well as the existing ones on subscribe. 

To measure this we are using the number of onward clicks on the respective pages as a metric, so this PR adds tracking to support this.