### PR TITLE
Custom intcmp values that are valid during a flash sale

### DIFF
--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -17,6 +17,7 @@ import play.api.libs.json.Json
 import play.api.mvc._
 import play.twirl.api.Html
 import services.TouchpointBackend
+import services.FlashSale._
 import utils.RequestCountry._
 import utils.Tracking.internalCampaignCode
 import views.html.promotion._
@@ -140,7 +141,7 @@ class PromoLandingPage(
       }
     } yield landingPage
     maybeLandingPage.run.map(_.getOrElse {
-      Redirect(routes.Homepage.index().url ? (internalCampaignCode -> s"FROM_P_${promoCode.get}"), request.queryString)
+      Redirect(routes.Homepage.index().url ? (internalCampaignCode -> intcmp(promoCode.get)), request.queryString)
     })
 
   }

--- a/app/services/FlashSale.scala
+++ b/app/services/FlashSale.scala
@@ -10,12 +10,12 @@ object FlashSale extends FlashSale {
   val startTime = new DateTime(2018, 8, 20, 0, 0)
   val endTime = new DateTime(2018, 9, 3, 0, 0)
 
-  val flashSaleIntcmp: Map[String, String] =
+  val flashSaleIntcmp: Map[String, Intcmp] =
     Map(
-      "GFS80H" -> "gdnwb_macqn_other_subs_SupporterLandingPagePrintOnlySubscribeLandingPagePrint+digital_",
-      "GFS80F" -> "gdnwb_macqn_other_subs_guardianarticleSubscribeLandingPagePrintOnly_",
-      "GFS80K" -> "gdnwb_macqn_other_subs_SubPromotionsLandingPagePrintOnlySubsPromotionsLandingPagePrint+digital_",
-      "GFS80J" -> "gdnwb_macqn_other_subs_SupporterLandingPagePrint+digitalSubPromotionsLandingPagePrintOnly_"
+      "GFS80H" -> Intcmp("gdnwb_macqn_other_subs_SupporterLandingPagePrintOnlySubscribeLandingPagePrint+digital_"),
+      "GFS80F" -> Intcmp("gdnwb_macqn_other_subs_guardianarticleSubscribeLandingPagePrintOnly_"),
+      "GFS80K" -> Intcmp("gdnwb_macqn_other_subs_SubPromotionsLandingPagePrintOnlySubsPromotionsLandingPagePrint+digital_"),
+      "GFS80J" -> Intcmp("gdnwb_macqn_other_subs_SupporterLandingPagePrint+digitalSubPromotionsLandingPagePrintOnly_")
     )
 }
 
@@ -24,7 +24,7 @@ trait FlashSale {
   val startTime: DateTime
   val endTime: DateTime
 
-  val flashSaleIntcmp: Map[String, String]
+  val flashSaleIntcmp: Map[String, Intcmp]
 
   //The offer is valid between 20th August 2018 & 2nd September 2018
   //The current sale is paper & paper + digital only. Digital only is unaffected.
@@ -72,12 +72,15 @@ trait FlashSale {
     else
       defaultCode
 
-  def intcmp(promoCode: String): String =
+  def intcmp(promoCode: String): Intcmp =
     if(inFlashSaleDateRange)
       flashSaleIntcmp.getOrElse(promoCode, defaultIntcmp(promoCode))
     else
       defaultIntcmp(promoCode)
 
 
-  private def defaultIntcmp(promoCode: String) = s"FROM_P_${promoCode}"
+  private def defaultIntcmp(promoCode: String): Intcmp = Intcmp(s"FROM_P_${promoCode}")
+
 }
+
+case class Intcmp(value: String) extends AnyVal

--- a/app/services/FlashSale.scala
+++ b/app/services/FlashSale.scala
@@ -2,26 +2,46 @@ package services
 
 import configuration.Config
 import model.DigitalEdition
-import model.promoCodes.{GuardianWeekly, _}
+import model.promoCodes.{GuardianWeekly, PaperAndDigital, _}
 import org.joda.time.DateTime
 
-object FlashSale {
+object FlashSale extends FlashSale {
 
-  def inOfferPeriod(promoCodeKey: PromoCodeKey) = {
-    //The offer is valid between 20th August 2018 & 2nd September 2018
-    //The current sale is paper & paper + digital only. Digital only is unaffected.
-    val included: Map[PromoCodeKey, Boolean] = Map(
-      Digital -> false,
-      Paper -> true,
-      PaperAndDigital -> true
+  val startTime = new DateTime(2018, 8, 20, 0, 0)
+  val endTime = new DateTime(2018, 9, 3, 0, 0)
+
+  val flashSaleIntcmp: Map[String, String] =
+    Map(
+      "GFS80H" -> "gdnwb_macqn_other_subs_SupporterLandingPagePrintOnlySubscribeLandingPagePrint+digital_",
+      "GFS80F" -> "gdnwb_macqn_other_subs_guardianarticleSubscribeLandingPagePrintOnly_",
+      "GFS80K" -> "gdnwb_macqn_other_subs_SubPromotionsLandingPagePrintOnlySubsPromotionsLandingPagePrint+digital_",
+      "GFS80J" -> "gdnwb_macqn_other_subs_SupporterLandingPagePrint+digitalSubPromotionsLandingPagePrintOnly_"
     )
+}
 
-    val startTime = new DateTime(2018, 8, 20, 0, 0)
-    val endTime = new DateTime(2018, 9, 3, 0, 0)
+trait FlashSale {
+
+  val startTime: DateTime
+  val endTime: DateTime
+
+  val flashSaleIntcmp: Map[String, String]
+
+  //The offer is valid between 20th August 2018 & 2nd September 2018
+  //The current sale is paper & paper + digital only. Digital only is unaffected.
+  val included: Map[PromoCodeKey, Boolean] = Map(
+    Digital -> false,
+    Paper -> true,
+    PaperAndDigital -> true
+  )
+
+  private def inFlashSaleDateRange: Boolean = {
     val now = new DateTime()
 
-    now.isAfter(startTime) &&
-      now.isBefore(endTime) &&
+    now.isAfter(startTime) && now.isBefore(endTime)
+  }
+
+  def inOfferPeriod(promoCodeKey: PromoCodeKey) = {
+    inFlashSaleDateRange &&
       included(promoCodeKey) ||
       (included(promoCodeKey) && !Config.stageProd) //allow testing on CODE
   }
@@ -51,4 +71,13 @@ object FlashSale {
       offerCode
     else
       defaultCode
+
+  def intcmp(promoCode: String): String =
+    if(inFlashSaleDateRange)
+      flashSaleIntcmp.getOrElse(promoCode, defaultIntcmp(promoCode))
+    else
+      defaultIntcmp(promoCode)
+
+
+  private def defaultIntcmp(promoCode: String) = s"FROM_P_${promoCode}"
 }

--- a/test/services/FlashSaleTest.scala
+++ b/test/services/FlashSaleTest.scala
@@ -4,10 +4,10 @@ import org.joda.time.DateTime
 import org.specs2.mutable.Specification
 
 object TestPromoCodes {
-  val flashSaleIntcmp: Map[String, String] =
+  val flashSaleIntcmp: Map[String, Intcmp] =
     Map(
-      "promocode1" -> "super_special_value",
-      "promocode2" -> "super_special_value2"
+      "promocode1" -> Intcmp("super_special_value"),
+      "promocode2" -> Intcmp("super_special_value2")
     )
 }
 
@@ -35,17 +35,17 @@ class FlashSaleTest extends Specification {
   "intcmp" should {
 
     "return the default promo code-based value when not in a flash sale period" in {
-      val expected = "FROM_P_promocode1"
+      val expected = Intcmp("FROM_P_promocode1")
       FlashSaleExpired.intcmp("promocode1") shouldEqual (expected)
     }
 
     "return the custom value when in a flash sale period" in {
-      val expected = "super_special_value"
+      val expected = Intcmp("super_special_value")
       FlashSaleEffectiveNow.intcmp("promocode1") shouldEqual (expected)
     }
 
     "return the default in a flash sale period if the promo code doesn't have a custom intcmp value" in {
-      val expected = "FROM_P_ABCD"
+      val expected = Intcmp("FROM_P_ABCD")
       FlashSaleEffectiveNow.intcmp("ABCD") shouldEqual (expected)
     }
   }

--- a/test/services/FlashSaleTest.scala
+++ b/test/services/FlashSaleTest.scala
@@ -1,0 +1,54 @@
+package services
+
+import org.joda.time.DateTime
+import org.specs2.mutable.Specification
+
+object TestPromoCodes {
+  val flashSaleIntcmp: Map[String, String] =
+    Map(
+      "promocode1" -> "super_special_value",
+      "promocode2" -> "super_special_value2"
+    )
+}
+
+object FlashSaleEffectiveNow extends FlashSale {
+  val now = new DateTime()
+
+  override val startTime = now.minusWeeks(1)
+  override val endTime = now.plusWeeks(1)
+
+  override val flashSaleIntcmp = TestPromoCodes.flashSaleIntcmp
+}
+
+object FlashSaleExpired extends FlashSale {
+  val now = new DateTime()
+
+  override val startTime = now.minusWeeks(2)
+  override val endTime = now.minusWeeks(1)
+
+  override val flashSaleIntcmp = TestPromoCodes.flashSaleIntcmp
+
+}
+
+class FlashSaleTest extends Specification {
+
+  "intcmp" should {
+
+    "return the default promo code-based value when not in a flash sale period" in {
+      val expected = "FROM_P_promocode1"
+      FlashSaleExpired.intcmp("promocode1") shouldEqual (expected)
+    }
+
+    "return the custom value when in a flash sale period" in {
+      val expected = "super_special_value"
+      FlashSaleEffectiveNow.intcmp("promocode1") shouldEqual (expected)
+    }
+
+    "return the default in a flash sale period if the promo code doesn't have a custom intcmp value" in {
+      val expected = "FROM_P_ABCD"
+      FlashSaleEffectiveNow.intcmp("ABCD") shouldEqual (expected)
+    }
+  }
+}
+
+


### PR DESCRIPTION
During a flash sale, it is useful to be able to set a custom value for the internal campaign code to more easily track the promotion in GA. 

This adds that capability. 

This does mean that there is a map of intcmp values that are valid during the flash sale that needs to be manually updated whenever we set up another flash sale. 