### PR TITLE
Fix custom intcmp values during a flash sale

### DIFF
--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -141,13 +141,13 @@ class PromoLandingPage(
       }
     } yield landingPage
     maybeLandingPage.run.map(_.getOrElse {
-      Redirect(routes.Homepage.index().url ? (internalCampaignCode -> intcmp(promoCode.get)), request.queryString)
+      Redirect(routes.Homepage.index().url ? (internalCampaignCode -> intcmp(promoCode.get).value), request.queryString)
     })
 
   }
 
   def preview(maybeCountry: Option[Country]) = GoogleAuthenticatedStaffAction.async { implicit request =>
-    //User can preview a promotion before assigning it a code.
+    //User can preview a promotion before assigning it a code
     val undefinedPromoCode = PromoCode("PromoCode")
     //This appears in a frame in the promoTool.
     def OkWithPreviewHeaders(html: Html) = Ok(html).withHeaders(HandleXFrameOptionsOverrideHeader.HEADER_KEY -> s"ALLOW-FROM ${Config.previewXFrameOptionsOverride}")

--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -147,7 +147,7 @@ class PromoLandingPage(
   }
 
   def preview(maybeCountry: Option[Country]) = GoogleAuthenticatedStaffAction.async { implicit request =>
-    //User can preview a promotion before assigning it a code
+    //User can preview a promotion before assigning it a code.
     val undefinedPromoCode = PromoCode("PromoCode")
     //This appears in a frame in the promoTool.
     def OkWithPreviewHeaders(html: Html) = Ok(html).withHeaders(HandleXFrameOptionsOverrideHeader.HEADER_KEY -> s"ALLOW-FROM ${Config.previewXFrameOptionsOverride}")


### PR DESCRIPTION
https://github.com/guardian/subscriptions-frontend/pull/1133 added the capability to set a custom intcmp value during a flash sale. 

However, in https://github.com/guardian/subscriptions-frontend/pull/1133 I also introduced a bug that where say there is a custom intcmp value 'really-special-value' that during the flash sale I set the query param to be like  [url]?INTCMP=Intcmp(really-special-value) rather than [url]?INTCMP=really-special-value. I needed to use the intcmp as a string when setting it as a query param.
