### PR TITLE
Actually add the custom intcmp valid during a flash sale to the button

### DIFF
--- a/app/views/fragments/productLists/productListUk.scala.html
+++ b/app/views/fragments/productLists/productListUk.scala.html
@@ -21,7 +21,12 @@
             </ul>
         </div>
         <div class="block__footer">
-            <a class="button button--large button--primary" href="@routes.PromoLandingPage.render(promoCodes(PaperAndDigital), None).url" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
+            @if(inOfferPeriod(PaperAndDigital)) {
+                <a class="button button--large button--primary" href="@routes.PromoLandingPage.render(promoCodes(PaperAndDigital), None).url?INTCMP=@intcmp(promoCodes(PaperAndDigital)).value" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
+
+            } else {
+                <a class="button button--large button--primary" href="@routes.PromoLandingPage.render(promoCodes(PaperAndDigital), None).url" data-test-id="subscriptions-uk-paper-digital">Subscribe now</a>
+            }
         </div>
     </div>
     <div class="row__item block block--primary block--paper">
@@ -42,7 +47,12 @@
             </ul>
         </div>
         <div class="block__footer">
-            <a class="button button--large button--primary" href="@routes.PromoLandingPage.render(promoCodes(Paper), None).url" data-test-id="subscriptions-uk-paper">Subscribe now</a>
+            @if(inOfferPeriod(Paper)) {
+                <a class="button button--large button--primary" href="@routes.PromoLandingPage.render(promoCodes(Paper), None).url?INTCMP=@intcmp(promoCodes(Paper)).value" data-test-id="subscriptions-uk-paper">Subscribe now</a>
+
+            } else {
+                <a class="button button--large button--primary" href="@routes.PromoLandingPage.render(promoCodes(Paper), None).url" data-test-id="subscriptions-uk-paper">Subscribe now</a>
+            }
         </div>
     </div>
 </div>


### PR DESCRIPTION
In https://github.com/guardian/subscriptions-frontend/pull/1133 I added a way to specify a custom intcmp value for each promo code during a flash sale.

However, for this to do anything to help track the flash sale promotions, I needed to add this custom intcmp value to the subscribe now button if the flash sale is on for that product. 