### PR TITLE
send Identity id and salesforce account id on enqueued emails

### DIFF
--- a/app/model/PurchaserIdentifiers.scala
+++ b/app/model/PurchaserIdentifiers.scala
@@ -6,4 +6,5 @@ import com.gu.salesforce.ContactId
 case class PurchaserIdentifiers(contactId: ContactId, identityId: Option[IdMinimalUser]) {
   val description = (Seq(s"SalesforceContactID - ${contactId.salesforceContactId}") ++ identityId.map(id => s"IdentityID - $id")).mkString(" ")
   override def toString: String = description
+  lazy val identityIdWithFallback = identityId.map(_.id).getOrElse(contactId.salesforceContactId)
 }

--- a/cloud-formation/subscriptions-app.cf.yaml
+++ b/cloud-formation/subscriptions-app.cf.yaml
@@ -173,13 +173,13 @@ Resources:
           Statement:
           - Effect: Allow
             Action: sqs:*
-            Resource: arn:aws:sqs:eu-west-1:865473395570:subs-welcome-email
+            Resource: arn:aws:sqs:eu-west-1:865473395570:subs-welcome-email*
       - PolicyName: SQSHolidaySuspensionEmails
         PolicyDocument:
           Statement:
           - Effect: Allow
             Action: sqs:*
-            Resource: arn:aws:sqs:eu-west-1:865473395570:subs-holiday-suspension-email
+            Resource: arn:aws:sqs:eu-west-1:865473395570:subs-holiday-suspension-email*
       ManagedPolicyArns:
       - !Sub arn:aws:iam::${AWS::AccountId}:policy/guardian-ec2-role-for-ssm
   SubscriptionsAppInstanceProfile:

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -27,8 +27,8 @@ qa {
   passthrough-cookie-value = "qa-passthrough-dev"
 }
 
-aws.queue.welcome-email = "subs-welcome-email"
-aws.queue.holiday-suspension-email = "subs-holiday-suspension-email"
+aws.queue.welcome-email = "subs-welcome-email-dev"
+aws.queue.holiday-suspension-email = "subs-holiday-suspension-email-dev"
 
 google.analytics.tracking.id="UA-33592456-4"
 


### PR DESCRIPTION
Required for Braze integration.
If the identity Id is not found, the userId defaults to the sfContactId
sfContactId is set as a custom attribute in Braze
UserId is used when upserting a user to Braze before sending the email