### PR TITLE
Set the expiry of the `gu_referrer_channel` cookie to 30 days

### DIFF
--- a/assets/javascripts/modules/analytics/awin.js
+++ b/assets/javascripts/modules/analytics/awin.js
@@ -9,7 +9,7 @@ define([
         const utmSource = parsedUrl.searchParams.get('utm_source');
         const utmMedium = parsedUrl.searchParams.get('utm_medium');
         if (utmSource && utmMedium){
-            cookie.setCookie('gu_referrer_channel', `${utmSource}&${utmMedium}`);
+            cookie.setCookie('gu_referrer_channel', `${utmSource}&${utmMedium}`, 30);
         }
     }
 


### PR DESCRIPTION
Awin requires that we remember the last referrer for up to 30 days.