### PR TITLE
Stop publishing identity id for email send

### DIFF
--- a/app/model/PurchaserIdentifiers.scala
+++ b/app/model/PurchaserIdentifiers.scala
@@ -6,5 +6,4 @@ import com.gu.salesforce.ContactId
 case class PurchaserIdentifiers(contactId: ContactId, identityId: Option[IdMinimalUser]) {
   val description = (Seq(s"SalesforceContactID - ${contactId.salesforceContactId}") ++ identityId.map(id => s"IdentityID - $id")).mkString(" ")
   override def toString: String = description
-  lazy val identityIdWithFallback = identityId.map(_.id).getOrElse(contactId.salesforceContactId)
 }


### PR DESCRIPTION
Stop publishing identity id for email send. It is now retrieved in membership-workflow.
Identity Id is used when setting the external_id in Braze. see https://github.com/guardian/membership-workflow/pull/143