### PR TITLE
Force productSegment to lowercase for segmentedPageCodes lookup

### DIFF
--- a/assets/javascripts/modules/analytics/appnexus.js
+++ b/assets/javascripts/modules/analytics/appnexus.js
@@ -32,7 +32,7 @@ define([
 
         var productSegment = guardian.pageInfo.productData.productSegment;
 
-        var pageCodes = segmentedPageCodes[productSegment];
+        var pageCodes = segmentedPageCodes[productSegment.toLowerCase()];
         if (!pageCodes) { return; }
 
         var pageType = guardian.pageInfo.pageType;


### PR DESCRIPTION
While testing [this PR](https://github.com/guardian/subscriptions-frontend/pull/1143) on prod, I found that the pixel wasn't firing on the thank-you page, I think because of this case mismatch;
![screen shot 2018-09-18 at 15 40 03](https://user-images.githubusercontent.com/690395/45696835-56a77300-bb5c-11e8-929a-bf82eee6d989.png)

I haven't been able to test this locally because the appNexus code isn't loaded it seems, so I'm opening a PR while I investigate on CODE.

EDIT: Hm. It seems the appNexus code isn't triggered on CODE either. That's annoying, so this is the only thing I can do to validate this before it goes to PROD;
![screen shot 2018-09-18 at 16 26 16](https://user-images.githubusercontent.com/690395/45698362-b6534d80-bb5f-11e8-9e50-af6ad1ba34cc.png)

