### PR TITLE
Detect Google Adwords' `gclid` query param when looking for referrers

### DIFF
--- a/assets/javascripts/modules/analytics/awin.js
+++ b/assets/javascripts/modules/analytics/awin.js
@@ -5,12 +5,17 @@ define([
     'use strict';
 
     function storeChannel() {
+        const cookieExpiryDays = 30;
         const parsedUrl = new URL(window.location.href);
         const utmSource = parsedUrl.searchParams.get('utm_source');
         const utmMedium = parsedUrl.searchParams.get('utm_medium');
+        const gclid = parsedUrl.searchParams.get('gclid'); // Google AdWords
         if (utmSource && utmMedium){
-            cookie.setCookie('gu_referrer_channel', `${utmSource}&${utmMedium}`, 30);
+            cookie.setCookie('gu_referrer_channel', `${utmSource}&${utmMedium}`, cookieExpiryDays);
+        } else if (gclid) {
+            cookie.setCookie('gu_referrer_channel', 'google&adwords', cookieExpiryDays);
         }
+
     }
 
     return {


### PR DESCRIPTION
More Awin affiliate tracking work. 

When users arrive on the site with a `gclid` query param it means that they have come from a Google Adwords link, we need to record this in the `gu_referrer_channel` cookie so that we don't pay commission on purchases in the event that they have previously visited our site via an affiliate link.