### PR TITLE
Set the correct Scala version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-- 2.11.7
+- 2.12.6
 jdk:
 - oraclejdk8
 sudo: false


### PR DESCRIPTION
Acceptance tests are failing at the moment due to Travis using the wrong version of Scala