### PR TITLE
Allow Prout to hit subscriptions-frontend instances

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,7 +1,7 @@
 {
     "checkpoints": {
         "PROD": {
-            "url": "https://subscribe.theguardian.com/",
+            "url": "https://subscribe.theguardian.com/management/manifest",
             "overdue": "14M",
             "afterSeen": {
                 "travis": {


### PR DESCRIPTION
We have recently added a redirect in Fastly for https://subscribe.theguardian.com/. This means that Prout will never get a response which contains subscriptions-frontend's commit id, and all deploys will be [marked as overdue](https://github.com/guardian/subscriptions-frontend/pull/1156#issuecomment-425938262).

There's an explanation of how Prout works [here](https://github.com/guardian/prout#add-config-file).