### PR TITLE
Fix acceptance tests

### DIFF
--- a/test/acceptance/util/Config.scala
+++ b/test/acceptance/util/Config.scala
@@ -25,7 +25,6 @@ object Config {
     logger.info(s"Stage: ${conf.getString("stage")}")
     logger.info(s"Subscriptions Frontend: ${baseUrl}")
     logger.info(s"Identity Frontend: ${identityFrontendUrl}")
-    logger.info(s"Screencast = https://saucelabs.com/tests/${Driver.sessionId}")
   }
 }
 

--- a/test/acceptance/util/Dependencies.scala
+++ b/test/acceptance/util/Dependencies.scala
@@ -12,7 +12,7 @@ import scala.util.Try
 object Dependencies {
 
   object SubscriptionFrontend extends Availability {
-    val url = Config.baseUrl
+    val url = s"${Config.baseUrl}/healthcheck"
   }
 
   object IdentityFrontend extends Availability {

--- a/test/acceptance/util/Driver.scala
+++ b/test/acceptance/util/Driver.scala
@@ -16,7 +16,7 @@ object Driver {
 
   def reset() = {
     Driver.manage().deleteAllCookies()
-    Driver.get(Config.baseUrl)
+    Driver.get(s"${Config.baseUrl}/healthcheck")
   }
 
   def cookiesSet: Set[Cookie] = manage().getCookies.asScala.toSet


### PR DESCRIPTION
The test user cookie is no longer being set correctly due to the redirect referenced here: https://github.com/guardian/subscriptions-frontend/pull/1157.

This redirect means that we are attempting to set the cookies whilst on support.theguardian.com instead of subscribe.theguardian.com, which doesn't work:

> you need to be on the domain that the cookie will be valid for.

https://docs.seleniumhq.org/docs/03_webdriver.jsp#cookies

