### PR TITLE
Revert 1155 revert 1154 Be able to sell new GW plans

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import actions.CommonActions
 import cats.instances.future._
-import com.gu.i18n.CountryGroup.{UK, US}
+import com.gu.i18n.CountryGroup._
 import com.gu.i18n.Currency._
 import com.gu.i18n._
 import com.gu.memsub.Subscription.Name
@@ -74,7 +74,9 @@ class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions
 
         val productsWithIntroductoryPlans = List(
           catalog.weekly.zoneA.plansWithAssociations,
-          catalog.weekly.zoneC.plansWithAssociations
+          catalog.weekly.zoneC.plansWithAssociations,
+          catalog.weekly.domestic.plansWithAssociations,
+          catalog.weekly.restOfWorld.plansWithAssociations
         ) ++ testOnlyPlans
 
         val contentSubscriptionPlans = productsWithoutIntroductoryPlans ++ productsWithIntroductoryPlans
@@ -123,14 +125,30 @@ class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions
             case Product.Delivery => getSettings(UK.defaultCountry, UK.currency)
             case Product.Voucher => getSettings(UK.defaultCountry, UK.currency)
             case Product.WeeklyZoneA => {
-              if (Set(UK, US).contains(determinedCountryGroup)) {
+              if (GuardianWeeklyZones.zoneACountryGroups.contains(determinedCountryGroup)) {
                 getSettings(determinedCountryGroup.defaultCountry, determinedCountryGroup.currency)
               } else {
                 getSettings(UK.defaultCountry, UK.currency)
               }
             }
             case Product.WeeklyZoneB | Product.WeeklyZoneC => {
-              if (Set(UK, US).contains(determinedCountryGroup)) {
+              if (GuardianWeeklyZones.zoneACountryGroups.contains(determinedCountryGroup)) {
+                getSettings(None, USD)
+
+              } else {
+                getSettings(determinedCountryGroup.defaultCountry, determinedCountryGroup.currency)
+              }
+            }
+
+            case Product.WeeklyDomestic => {
+              if (GuardianWeeklyZones.domesticZoneCountryGroups.contains(determinedCountryGroup)) {
+                getSettings(determinedCountryGroup.defaultCountry, determinedCountryGroup.currency)
+              } else {
+                getSettings(UK.defaultCountry, UK.currency)
+              }
+            }
+            case Product.WeeklyRestOfWorld => {
+              if (GuardianWeeklyZones.domesticZoneCountryGroups.contains(determinedCountryGroup)) {
                 getSettings(None, USD)
               } else {
                 getSettings(determinedCountryGroup.defaultCountry, determinedCountryGroup.currency)

--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -3,10 +3,11 @@ import actions.{CommonActions, OAuthActions}
 import com.gu.i18n.CountryGroup.byCountryCode
 import com.gu.i18n.{Country, CountryGroup}
 import com.gu.memsub.Benefit.Digipack
+import com.gu.memsub.Subscription
 import com.gu.memsub.promo.Formatters.PromotionFormatters._
 import com.gu.memsub.promo.Promotion._
 import com.gu.memsub.promo._
-import com.gu.memsub.subsv2.Catalog
+import com.gu.memsub.subsv2.{Catalog, WeeklyPlans}
 import com.netaporter.uri.dsl._
 import configuration.Config
 import controllers.SessionKeys.PromotionTrackingCode

--- a/app/controllers/WeeklyLandingPage.scala
+++ b/app/controllers/WeeklyLandingPage.scala
@@ -24,8 +24,6 @@ class WeeklyLandingPage(tpBackend: TouchpointBackend, commonActions: CommonActio
 
   val international = "int"
 
-  val catalog = tpBackend.catalogService.catalog.map(_.valueOr(e => throw new IllegalStateException(s"$e while getting catalog")))
-
   def index(country: Option[Country]) = NoCacheAction { implicit request =>
     val maybeCountry = country orElse request.getFastlyCountry
     Redirect(routes.WeeklyLandingPage.withCountry(maybeCountry.map(_.alpha2).getOrElse(international)).url, request.queryString, TEMPORARY_REDIRECT)

--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -33,7 +33,9 @@ class SubscriptionsForm(catalog: Catalog) {
       catalog.voucher.list.toList ++
       catalog.weekly.zoneA.plans.filter(_.availableForCheckout) ++
       catalog.weekly.zoneB.plans.filter(_.availableForCheckout) ++
-      catalog.weekly.zoneC.plans
+      catalog.weekly.zoneC.plans ++
+      catalog.weekly.domestic.plans ++
+      catalog.weekly.restOfWorld.plans
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], CatalogPlan.Paper] =
       data.get(key).map(ProductRatePlanId).flatMap(prpId => validPlans.find(_.id == prpId)).toRight(Seq(FormError(key, "Bad plan")))
     override def unbind(key: String, value: CatalogPlan.Paper): Map[String, String] =

--- a/app/model/ContentSubscriptionPlanOps.scala
+++ b/app/model/ContentSubscriptionPlanOps.scala
@@ -24,6 +24,7 @@ object ContentSubscriptionPlanOps {
   val weeklyZoneCGroups = weeklyZoneBGroups
   val ukAndIsleOfMan = CountryGroup.UK.copy(countries = List(Country.UK, Country("IM", "Isle of Man")))
 
+
   implicit class EnrichedContentSubscriptionPlan[+A <: CatalogPlan.ContentSubscription](in: A) {
 
     case class LocalizationSettings(availableDeliveryCountriesWithCurrency: Option[List[CountryWithCurrency]], availableBillingCountriesWithCurrency: List[CountryWithCurrency])
@@ -42,9 +43,13 @@ object ContentSubscriptionPlanOps {
           val voucherCountries = CountryWithCurrency.fromCountryGroup(ukAndIsleOfMan)
           LocalizationSettings(Some(voucherCountries), voucherCountries)
 
+        case Product.WeeklyDomestic => LocalizationSettings(Some(CountryWithCurrency.whitelisted(supportedCurrencies, GBP, GuardianWeeklyZones.domesticZoneCountryGroups.toList)), allCountriesWithCurrencyOrGBP)
+
         case Product.WeeklyZoneA => LocalizationSettings(Some(CountryWithCurrency.whitelisted(supportedCurrencies, GBP, weeklyZoneAGroups)), allCountriesWithCurrencyOrGBP)
 
         case Product.WeeklyZoneB => LocalizationSettings(Some(CountryWithCurrency.whitelisted(supportedCurrencies, USD, weeklyZoneBGroups)), allCountriesWithCurrencyOrGBP)
+
+        case Product.WeeklyRestOfWorld => LocalizationSettings(Some(CountryWithCurrency.whitelisted(supportedCurrencies, USD, GuardianWeeklyZones.restOfWorldZoneCountryGroups.toList)), allCountriesWithCurrencyOrGBP)
 
         case Product.WeeklyZoneC => LocalizationSettings(Some(CountryWithCurrency.whitelisted(supportedCurrencies, USD, weeklyZoneCGroups)), allCountriesWithCurrencyOrGBP)
       }

--- a/app/model/GuardianWeeklyZones.scala
+++ b/app/model/GuardianWeeklyZones.scala
@@ -1,0 +1,27 @@
+package model
+
+import com.gu.i18n.CountryGroup
+
+object GuardianWeeklyZones {
+  private val allCountries = CountryGroup.allGroups.flatMap(_.countries).toSet
+
+  val zoneACountryGroups = Set(CountryGroup.UK, CountryGroup.US)
+  val zoneCCountryGroups = CountryGroup.allGroups.toSet.diff(zoneACountryGroups)
+
+  val domesticZoneCountryGroups = Set(
+    CountryGroup.UK,
+    CountryGroup.US,
+    CountryGroup.Australia,
+    CountryGroup.Canada,
+    CountryGroup.US,
+    CountryGroup.NewZealand,
+    CountryGroup.Europe
+  )
+  val restOfWorldZoneCountryGroups = CountryGroup.allGroups.toSet.diff(domesticZoneCountryGroups)
+
+  val zoneACountries = (CountryGroup.UK.countries ++ CountryGroup.US.countries).toSet
+  val zoneCCountries = allCountries.diff(zoneACountries)
+
+  val domesticZoneCountries = domesticZoneCountryGroups.flatMap(_.countries)
+  val restOfWorldZoneCountries = allCountries.diff(domesticZoneCountries)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= Seq(
     filters,
     jodaForms,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.523",
+    "com.gu" %% "membership-common" % "0.525",
     "com.gu.identity" %% "identity-play-auth" % "2.4",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.6",

--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -113,6 +113,159 @@ class CheckoutSpec extends FeatureSpec with Browser
         assert(Driver.cookiesSet.map(_.getName).contains(idCookie)) }
     }
 
+    /*
+          TESTS WITH OLD ZONES/RATES
+     */
+
+    scenario("Weekly quarterly sub purchase (old pricing - ZoneA) from UK for UK delivery", Acceptance) {
+      checkDependenciesAreAvailable
+      val testUser = new TestUser
+      val checkout = Checkout(testUser, "checkout/weeklyzonea-guardianweeklyquarterly?countryGroup=uk")
+      When("User hits checkout page ")
+      go.to(checkout)
+      assert(checkout.pageHasLoaded())
+
+      Then("the 'Product Payment' section should load")
+      assert(checkout.basketPreviewProductPaymentHasLoaded())
+
+      And("the payment amount and currency should be correct")
+      assert(checkout.basketPreviewProductPaymentContains("£30 every 3 months"))
+
+      And("the 'Pay in GBP' override should NOT load")
+      assert(!checkout.currencyOverrideHasLoaded())
+    }
+
+    scenario("Weekly quarterly sub purchase (old pricing - ZoneC) from EU for EU delivery", Acceptance) {
+      checkDependenciesAreAvailable
+      val testUser = new TestUser
+      val checkout = Checkout(testUser, "checkout/weeklyzonec-guardianweeklyquarterly?countryGroup=eu")
+      When("User hits checkout page ")
+      go.to(checkout)
+      assert(checkout.pageHasLoaded())
+
+      Then("the 'Product Payment' section should load")
+      assert(checkout.basketPreviewProductPaymentHasLoaded())
+
+      And("the payment amount and currency should be correct")
+      assert(checkout.basketPreviewProductPaymentContains("€49 every 3 months"))
+
+      And("the 'Pay in GBP' override should load")
+      assert(checkout.currencyOverrideHasLoaded())
+    }
+
+    scenario("Weekly quarterly sub purchase (old pricing - ZoneC) from ROW for ROW delivery", Acceptance) {
+      checkDependenciesAreAvailable
+      val testUser = new TestUser
+      val checkout = Checkout(testUser, "checkout/weeklyzonec-guardianweeklyquarterly?countryGroup=us")
+      When("User hits checkout page ")
+      go.to(checkout)
+      assert(checkout.pageHasLoaded())
+
+      Then("the 'Product Payment' section should load")
+      assert(checkout.basketPreviewProductPaymentHasLoaded())
+
+      And("the payment amount and currency should be correct")
+      assert(checkout.basketPreviewProductPaymentContains("US$65 every 3 months"))
+
+      And("the 'Pay in GBP' override should load")
+      assert(checkout.currencyOverrideHasLoaded())
+    }
+
+    scenario("Weekly quarterly sub purchase (old pricing - ZoneA) from ROW for UK delivery", Acceptance) {
+      checkDependenciesAreAvailable
+      val testUser = new TestUser
+      val checkout = Checkout(testUser, "checkout/weeklyzonea-guardianweeklyquarterly?countryGroup=uk")
+      When("User hits checkout page ")
+      go.to(checkout)
+      assert(checkout.pageHasLoaded())
+
+      Then("the 'Product Payment' section should load")
+      assert(checkout.basketPreviewProductPaymentHasLoaded())
+
+      And("the payment amount and currency should be correct")
+      assert(checkout.basketPreviewProductPaymentContains("£30 every 3 months"))
+
+      And("the 'Pay in GBP' override should NOT load")
+      assert(!checkout.currencyOverrideHasLoaded())
+    }
+
+    /*
+          TESTS WITH NEW ZONES/RATES
+     */
+
+    scenario("Weekly quarterly sub purchase (new pricing - domestic) from UK for UK delivery", Acceptance) {
+      checkDependenciesAreAvailable
+      val testUser = new TestUser
+      val checkout = Checkout(testUser, "checkout/weeklydomestic-gwoct18-quarterly-domestic?countryGroup=uk")
+      When("User hits checkout page ")
+      go.to(checkout)
+      assert(checkout.pageHasLoaded())
+
+      Then("the 'Product Payment' section should load")
+      assert(checkout.basketPreviewProductPaymentHasLoaded())
+
+      And("the payment amount and currency should be correct")
+      assert(checkout.basketPreviewProductPaymentContains("£37.50 every 3 months"))
+
+      And("the 'Pay in GBP' override should NOT load")
+      assert(!checkout.currencyOverrideHasLoaded())
+    }
+
+    scenario("Weekly quarterly sub purchase (new pricing - domestic) from EU for EU delivery", Acceptance) {
+      checkDependenciesAreAvailable
+      val testUser = new TestUser
+      val checkout = Checkout(testUser, "checkout/weeklydomestic-gwoct18-quarterly-domestic?countryGroup=eu")
+      When("User hits checkout page ")
+      go.to(checkout)
+      assert(checkout.pageHasLoaded())
+
+      Then("the 'Product Payment' section should load")
+      assert(checkout.basketPreviewProductPaymentHasLoaded())
+
+      And("the payment amount and currency should be correct")
+      assert(checkout.basketPreviewProductPaymentContains("€61.30 every 3 months"))
+
+      And("the 'Pay in GBP' override should NOT load")
+      assert(!checkout.currencyOverrideHasLoaded())
+    }
+
+    scenario("Weekly quarterly sub purchase (new pricing - restofworld) from ROW for ROW delivery", Acceptance) {
+      checkDependenciesAreAvailable
+      val testUser = new TestUser
+      val checkout = Checkout(testUser, "checkout/weeklyrestofworld-gwoct18-quarterly-row?countryGroup=us")
+      When("User hits checkout page ")
+      go.to(checkout)
+      assert(checkout.pageHasLoaded())
+
+      Then("the 'Product Payment' section should load")
+      assert(checkout.basketPreviewProductPaymentHasLoaded())
+
+      And("the payment amount and currency should be correct")
+      assert(checkout.basketPreviewProductPaymentContains("US$81.30 every 3 months"))
+
+      And("the 'Pay in GBP' override should load")
+      assert(checkout.currencyOverrideHasLoaded())
+    }
+
+    scenario("Weekly quarterly sub purchase (new pricing - domestic) from ROW for UK delivery", Acceptance) {
+      checkDependenciesAreAvailable
+      val testUser = new TestUser
+      val checkout = Checkout(testUser, "checkout/weeklydomestic-gwoct18-quarterly-domestic?countryGroup=uk")
+      When("User hits checkout page ")
+      go.to(checkout)
+      assert(checkout.pageHasLoaded())
+
+      Then("the 'Product Payment' section should load")
+      assert(checkout.basketPreviewProductPaymentHasLoaded())
+
+      And("the payment amount and currency should be correct")
+      assert(checkout.basketPreviewProductPaymentContains("£37.50 every 3 months"))
+
+      And("the 'Pay in GBP' override should NOT load")
+      assert(!checkout.currencyOverrideHasLoaded())
+    }
+
+
     //temporarily ignoring this until user details pre-fill is fixed
     ignore("Identity user subscribes to the Voucher Everyday package with direct debit", Acceptance) {
       withRegisteredIdentityUserFixture { testUser =>

--- a/test/acceptance/pages/Checkout.scala
+++ b/test/acceptance/pages/Checkout.scala
@@ -8,6 +8,14 @@ import org.scalatest.selenium.Page
 case class Checkout(testUser: TestUser, endpoint: String = "checkout") extends Page with Browser {
   val url = s"$baseUrl/$endpoint"
 
+  def basketPreviewProductPaymentHasLoaded(): Boolean = pageHasElement(BasketPreviewProductPayment.priceSummary)
+
+  def currencyOverrideHasLoaded(): Boolean = pageHasElement(BasketPreviewProductPayment.currencyOverride)
+
+  def basketPreviewProductPaymentContains(expected: String) = {
+    elementHasText(BasketPreviewProductPayment.priceSummary, expected)
+  }
+
   def fillInPersonalDetails(): Unit = PersonalDetails.fillIn()
 
   def clickPersonalDetailsContinueButton() = PersonalDetails.continue()
@@ -130,5 +138,10 @@ case class Checkout(testUser: TestUser, endpoint: String = "checkout") extends P
 
   private object ReviewSection {
     val submitPaymentButton = cssSelector(".js-checkout-submit")
+  }
+
+  private object BasketPreviewProductPayment {
+    val priceSummary = cssSelector(".basket-preview__product__payment")
+    val currencyOverride = cssSelector(".js-checkout-currency-override")
   }
 }

--- a/test/views/support/PlanPickerTest.scala
+++ b/test/views/support/PlanPickerTest.scala
@@ -1,0 +1,32 @@
+package views.support
+
+import com.gu.i18n.Country
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+
+class PlanPickerTest extends Specification with Mockito {
+
+  val countryInZoneA = Country.US
+  val countryInZoneC = Country.Australia
+  val countryinDomesticZone = Country.Australia
+  val countryInRestOfWorldZone = Country("ER", "Eritrea")
+
+  "isInRestOfWorldOrZoneC" should {
+    "return true for a country that is in both rest of world and zone C" in {
+      PlanPicker.isInRestOfWorldOrZoneC(countryInRestOfWorldZone, true) shouldEqual true
+      PlanPicker.isInRestOfWorldOrZoneC(countryInRestOfWorldZone, false) shouldEqual true
+    }
+
+    "return for false for Australia when updated prices are shown, and true for old prices" in {
+      //australia is Zone C, but moves to domestic with the price updates
+      PlanPicker.isInRestOfWorldOrZoneC(countryinDomesticZone, true) shouldEqual false
+      PlanPicker.isInRestOfWorldOrZoneC(countryInZoneC, false) shouldEqual true
+    }
+
+    "return false for countries that are in zone A and the domestic zone regardless of updated price switch" in {
+      PlanPicker.isInRestOfWorldOrZoneC(countryInZoneA, true) shouldEqual false
+      PlanPicker.isInRestOfWorldOrZoneC(countryInZoneA, false) shouldEqual false
+    }
+  }
+
+}


### PR DESCRIPTION
https://github.com/guardian/subscriptions-frontend/pull/1154 added the ability to pull in the new GW plans, but they are switched off (but if you have the checkout url for a new plan, you can buy a new plan)

But the deploy failed so it was reverted here: https://github.com/guardian/subscriptions-frontend/pull/1155

We determined the cause of the failed deploy, and put in a fix in the catalogue in Zuora. 

This PR puts back https://github.com/guardian/subscriptions-frontend/pull/1154.