### PR TITLE
Fix date picker for new GW rate plans

### DIFF
--- a/assets/javascripts/modules/checkout/planDateFilter.jsx
+++ b/assets/javascripts/modules/checkout/planDateFilter.jsx
@@ -28,6 +28,7 @@ define([
 
         let filters = validDays[deliveredProduct];
 
+        // This matching is based on the rate plan name
         switch (true) {
             case /Weekly/i.test(packageName) || /GW/i.test(packageName):
                 return filters;

--- a/assets/javascripts/modules/checkout/planDateFilter.jsx
+++ b/assets/javascripts/modules/checkout/planDateFilter.jsx
@@ -29,7 +29,7 @@ define([
         let filters = validDays[deliveredProduct];
 
         switch (true) {
-            case /Weekly/i.test(packageName):
+            case /Weekly/i.test(packageName) || /GW/i.test(packageName):
                 return filters;
             case /Saturday/i.test(packageName):
                 return filters.saturday;


### PR DESCRIPTION
We allow users to select their first paper/delivery date when purchasing the Guardian Weekly. As each issue is published/delivered on a Friday, this should be the only available day of the week when using the date picker.

Before:

![image](https://user-images.githubusercontent.com/19384074/46354543-c20e3c00-c656-11e8-9859-ec1d9f4bcd7f.png)

After:

![image](https://user-images.githubusercontent.com/19384074/46353891-27f9c400-c655-11e8-9885-2c5e730a6d9f.png)