### PR TITLE
Show GBP currency override when shipping to ROW

### DIFF
--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -9,6 +9,7 @@
 @import views.support.Pricing._
 @import views.support.{CountryAndCurrencySettings, ProductPopulationData}
 
+@import com.gu.memsub.Product.WeeklyRestOfWorld
 @(
     personalData: Option[PersonalData],
     productData: ProductPopulationData,
@@ -89,7 +90,7 @@
             <div class="checkout-container__sidebar js-basket">
                 @fragments.checkout.basketPreview(productData.plans.default)
 
-                @if(productData.plans.default.product == WeeklyZoneC) {
+                @if(productData.plans.default.product == WeeklyZoneC || productData.plans.default.product == WeeklyRestOfWorld) {
                     <div class="js-checkout-currency-override">
                         <label class="option">
                             <span class="option__input">

--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -229,7 +229,7 @@ class CheckoutSpec extends FeatureSpec with Browser
       assert(!checkout.currencyOverrideHasLoaded())
     }
 
-    scenario("Weekly quarterly sub purchase (new pricing - restofworld) from ROW for ROW delivery", Acceptance) {
+    scenario("Weekly quarterly sub purchase (new pricing - restofworld) from a domestic country group for ROW delivery", Acceptance) {
       checkDependenciesAreAvailable
       val testUser = new TestUser
       val checkout = Checkout(testUser, "checkout/weeklyrestofworld-gwoct18-quarterly-row?countryGroup=us")

--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -229,7 +229,7 @@ class CheckoutSpec extends FeatureSpec with Browser
       assert(!checkout.currencyOverrideHasLoaded())
     }
 
-    scenario("Weekly quarterly sub purchase (new pricing - restofworld) from a domestic country group for ROW delivery", Acceptance) {
+    scenario("Weekly quarterly sub purchase (new pricing - restofworld) for ROW delivery", Acceptance) {
       checkDependenciesAreAvailable
       val testUser = new TestUser
       val checkout = Checkout(testUser, "checkout/weeklyrestofworld-gwoct18-quarterly-row?countryGroup=us")


### PR DESCRIPTION
Currently, the checkout for a **zone C** plan (any countries other than UK/US) provides a currency override to pay in pounds like so:

![image](https://user-images.githubusercontent.com/3072877/46362556-795f7e80-c668-11e8-9e2e-84b6a5309753.png)

This change will make it so that after we switch to the new plans, that this currency override is available when in the checkout for a **rest of world** plan.