### PR TITLE
Update the default promo landing page (behind switch)

### DIFF
--- a/app/controllers/WeeklyLandingPage.scala
+++ b/app/controllers/WeeklyLandingPage.scala
@@ -2,15 +2,10 @@ package controllers
 
 import actions.CommonActions
 import com.gu.i18n.{Country, CountryGroup}
-import configuration.Config
 import play.api.mvc._
-import services.TouchpointBackend
+import services.{TouchpointBackend, WeeklyPicker}
 import utils.RequestCountry._
-import views.html.promotion.weeklyLandingPage
 import views.html.weekly.landing_description
-import views.support.PegdownMarkdownRenderer
-
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 object WeeklyLandingPage{
@@ -36,7 +31,9 @@ class WeeklyLandingPage(tpBackend: TouchpointBackend, commonActions: CommonActio
     parsedCountry.fold {
       Future.successful(Redirect(routes.WeeklyLandingPage.withCountry(international).url, request.queryString, PERMANENT_REDIRECT))
     } { country =>
-      Future.successful(Redirect(routes.PromoLandingPage.render("10ANNUAL", Some(country)).url, request.queryString, TEMPORARY_REDIRECT))
+      val forceNewPricing = WeeklyPicker.forceShowNewPricing(request.rawQueryString)
+      val defaultPromotion = if (WeeklyPicker.showUpdatedPrices(forceNewPricing)) "WWM99X" else "10ANNUAL"
+      Future.successful(Redirect(routes.PromoLandingPage.render(defaultPromotion, Some(country)).url, request.queryString, TEMPORARY_REDIRECT))
     }
   }
 

--- a/app/services/WeeklyPicker.scala
+++ b/app/services/WeeklyPicker.scala
@@ -1,0 +1,53 @@
+package services
+
+import com.gu.i18n.{Country, CountryGroup}
+import model.GuardianWeeklyZones
+import model.PurchasableWeeklyProducts._
+import org.joda.time.{DateTime, DateTimeZone}
+
+object WeeklyPicker {
+
+  import model.GuardianWeeklyZones._
+
+  def forceShowNewPricing(rawQueryString: String) = rawQueryString.contains("gwoct18")
+
+  val updateTime = DateTime.parse("2018-10-10T09:45:00").withZone(DateTimeZone.UTC)
+
+  def showUpdatedPrices(forceShowUpdatedPrices: Boolean, timeToUpdate: DateTime = updateTime): Boolean = {
+    val now = DateTime.now().withZone(DateTimeZone.UTC)
+    now.isAfter(timeToUpdate) || forceShowUpdatedPrices
+  }
+
+  def isInRestOfWorldOrZoneC(country: Country, showUpdatedPrices: Boolean): Boolean = {
+    if (showUpdatedPrices) GuardianWeeklyZones.restOfWorldZoneCountries.contains(country)
+    else GuardianWeeklyZones.zoneCCountries.contains(country)
+  }
+
+  def restOfWorldOrZoneC(showUpdatedPrices: Boolean): PurchasableWeeklyProduct = {
+    if (showUpdatedPrices) WeeklyRestOfWorld
+    else WeeklyZoneC
+  }
+
+  def product(country: Country, showUpdatedPrices: Boolean): PurchasableWeeklyProduct = {
+    if (showUpdatedPrices) {
+      if (domesticZoneCountries.contains(country)) WeeklyDomestic
+      else WeeklyRestOfWorld
+    }
+    else {
+      if (zoneACountries.contains(country)) WeeklyZoneA
+      else WeeklyZoneC
+    }
+  }
+
+  def productForCountryGroup(countryGroup: CountryGroup, showUpdatedPrices: Boolean): PurchasableWeeklyProduct = {
+    if (showUpdatedPrices) {
+      if (domesticZoneCountryGroups.contains(countryGroup)) WeeklyDomestic
+      else WeeklyRestOfWorld
+    }
+    else {
+      if (zoneACountryGroups.contains(countryGroup)) WeeklyZoneA
+      else WeeklyZoneC
+    }
+  }
+
+}

--- a/test/services/WeeklyPickerTest.scala
+++ b/test/services/WeeklyPickerTest.scala
@@ -1,4 +1,4 @@
-package views.support
+package services
 
 import com.gu.i18n.{Country, CountryGroup}
 import org.specs2.mock.Mockito


### PR DESCRIPTION
Currently hitting https://subscribe.theguardian.com/weekly redirects to a promo landing page which offers a 10% discount (on the annual plan).

This PR allows us to automatically start redirecting traffic to a new 6 for 6 promo landing page (once the new products are live). This will happen based on the showUpdatedPrices switch status, which we also use to determine whether to show new products or not.