### PR TITLE
Pick smaller crop for GW header

### DIFF
--- a/app/services/WeeklyPicker.scala
+++ b/app/services/WeeklyPicker.scala
@@ -64,7 +64,7 @@ object ImagePicker {
   def defaultHeaderImage(rawQueryString: String = ""): ResponsiveImageGroup = {
     WeeklyPicker.showUpdatedPrices(WeeklyPicker.forceShowNewPricing(rawQueryString)) match {
       case true => ResponsiveImageGroup(
-        availableImages = ResponsiveImageGenerator(guardianWeeklyRedesignHeaderId,Seq(9985), "png"),
+        availableImages = ResponsiveImageGenerator(guardianWeeklyRedesignHeaderId,Seq(2000), "png"),
         altText = Some("Selection of Guardian Weekly covers")
       )
       case false => ResponsiveImageGroup(


### PR DESCRIPTION
I picked the wrong crop for the GW header image. The one I initially picked is massive and loads slowly and looks naff on mobile. This picks the crop that is the same size as the header that was already in the page previously. 