### PR TITLE
Update Guardian Weekly copy

### DIFF
--- a/app/views/weekly/landing_description.scala.html
+++ b/app/views/weekly/landing_description.scala.html
@@ -2,14 +2,19 @@
 
 <div>
   <p>
-    Subscribe to the Guardian Weekly and you'll get seven days of international news in one comprehensive paper, delivered for free wherever you are in the world. The paper offers a considered, international perspective on major world events with insights and analysis from The Guardian and The Observer.
-  </p>
-  <p>Our subscribers enjoy:</p>
+      Get closer to the moments that have made the world’s week. Enjoy seven days of international news in one magazine, curated to give you a clearer global perspective. Subscribe today and get leading insights, brilliant analysis and free delivery, wherever you are in the world.  </p>
+  <p>As a subscriber, you’ll enjoy:</p>
   <ul>
-      <li>Saving on the retail cover price</li>
+      <li>A saving of up to 30% on the retail cover price</li>
       <li>Free international delivery</li>
+      <li>Localised content for our Australian and North American subscribers</li>
       <li>A weekly email newsletter from the editor</li>
-      <li>Access to the latest and archive editions at any time, on any device, via PressReader</li>
-      <li>Being part of our global community of Guardian Weekly readers</li>
+      <li>Access to the latest and archive editions at any time, on any device, through PressReader</li>
   </ul>
+
+  <p>If you'd like to buy a Guardian Weekly subscription as a gift, just get in touch with your local customer service team. You’ll find all the details that you need to know below: </p>
+  <p>UK, Europe and ROW: +44 (0) 330 333 6767</p>
+  <p>Australia and New Zealand: +61 2 8076 8599 (direct line)</p>
+  <p>USA and Canada: +1 917-900-4663 (direct line)</p>
+
 </div>


### PR DESCRIPTION
The copy currently displayed on the Guardian Weekly product page is up to date. However, it's been put there via the promo code tool. 

This updates the default copy so that we don't need the override via the promo code tool.

**Trello card** [[here]](https://trello.com/c/3UlEppHr/1990-update-default-guardian-weekly-product-page-copy)

### Screenshots

Page displaying new default copy. 
![image](https://user-images.githubusercontent.com/3072877/46815279-7d7b5280-cd72-11e8-8eed-8f28287be8e9.png)
