### PR TITLE
Set the awin cookie on .theguardian.com not subscribe.theguardian.com

### DIFF
--- a/assets/javascripts/modules/analytics/awin.js
+++ b/assets/javascripts/modules/analytics/awin.js
@@ -11,9 +11,9 @@ define([
         const utmMedium = parsedUrl.searchParams.get('utm_medium');
         const gclid = parsedUrl.searchParams.get('gclid'); // Google AdWords
         if (utmSource && utmMedium){
-            cookie.setCookie('gu_referrer_channel', `${utmSource}&${utmMedium}`, cookieExpiryDays);
+            cookie.setCookie('gu_referrer_channel', `${utmSource}&${utmMedium}`, cookieExpiryDays, false, true);
         } else if (gclid) {
-            cookie.setCookie('gu_referrer_channel', 'google&adwords', cookieExpiryDays);
+            cookie.setCookie('gu_referrer_channel', 'google&adwords', cookieExpiryDays, false, true);
         }
 
     }

--- a/assets/javascripts/utils/cookie.js
+++ b/assets/javascripts/utils/cookie.js
@@ -1,7 +1,7 @@
 define(['utils/base64'], function (base64) {
     'use strict';
 
-    function setCookie(name, value, days, isUnSecure) {
+    function setCookie(name, value, days, isUnSecure, trimSubdomain) {
         var date;
         var expires;
         // used for testing purposes, cookies are secure by default
@@ -15,7 +15,15 @@ define(['utils/base64'], function (base64) {
             expires = '';
         }
 
-        document.cookie = [name, '=', value, expires, '; path=/', secureCookieString ].join('');
+        var domain = trimSubdomain ? '; domain=' + getShortDomain() : '';
+
+        document.cookie = [name, '=', value, expires, '; path=/', secureCookieString, domain ].join('');
+    }
+
+    // Trim subdomains for prod, code and dev.
+    function getShortDomain() {
+        const domain = document.domain || '';
+        return domain.replace(/^(sub|subscribe)\./, '.');
     }
 
     function getCookie(name) {


### PR DESCRIPTION
Now that we are sending affiliate traffic via support.theguardian.com and setting the `gu_referrer_channel` cookie there we need to set it on `.theguardian.com` rather than `subscribe.theguardian.com` so that we share the cookie between the two sites.