### PR TITLE
Put the request country at the top of the list of regions for Guardian Weekly

### DIFF
--- a/app/model/GuardianWeeklyZones.scala
+++ b/app/model/GuardianWeeklyZones.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.i18n.CountryGroup
+import com.gu.i18n.{Country, CountryGroup}
 import com.gu.memsub.subsv2.{CatalogPlan, WeeklyPlans}
 
 object GuardianWeeklyZones {
@@ -8,19 +8,21 @@ object GuardianWeeklyZones {
 
   val zoneACountryGroups = Set(CountryGroup.UK, CountryGroup.US)
 
-  val domesticZoneCountryGroups = Set(
+  val domesticZoneCountryGroups = Seq(
     CountryGroup.UK,
     CountryGroup.US,
+    CountryGroup.Europe,
     CountryGroup.Australia,
-    CountryGroup.Canada,
-    CountryGroup.US,
     CountryGroup.NewZealand,
-    CountryGroup.Europe
+    CountryGroup.Canada
   )
-  val restOfWorldZoneCountryGroups = CountryGroup.allGroups.toSet.diff(domesticZoneCountryGroups)
+  val restOfWorldZoneCountryGroups = CountryGroup.allGroups.toSet.diff(domesticZoneCountryGroups.toSet)
 
   val domesticZoneCountries = domesticZoneCountryGroups.flatMap(_.countries)
-  val restOfWorldZoneCountries = allCountries.diff(domesticZoneCountries)
+  val restOfWorldZoneCountries = allCountries.diff(domesticZoneCountries.toSet)
+
+  def getDomesticCountryGroup(country: Country): Option[CountryGroup] =
+    domesticZoneCountryGroups.find(countryGroup => countryGroup.countries.contains(country))
 }
 
 object PurchasableWeeklyProducts {

--- a/app/views/support/WeeklyPromotion.scala
+++ b/app/views/support/WeeklyPromotion.scala
@@ -8,6 +8,7 @@ import com.gu.memsub.promo.{PromoCode, WeeklyLandingPage}
 import com.gu.memsub.subsv2.{CatalogPlan, WeeklyPlans}
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
+import model.GuardianWeeklyZones
 import model.PurchasableWeeklyProducts._
 import services.WeeklyPicker
 import views.support.Pricing._
@@ -23,34 +24,12 @@ object WeeklyPromotion {
 
   case class DiscountedRegion(title: String, description: String, discountedPlans: List[DiscountedPlan])
 
-  def validRegionsForPromotion(promotion: Option[PromoWithWeeklyLandingPage],
-                               promoCode: Option[PromoCode],
-                               requestCountry: Country)(implicit weeklyPlans: WeeklyPlans): Seq[DiscountedRegion] = {
+  def domesticRegions(promotion: Option[PromoWithWeeklyLandingPage],
+                               promoCode: Option[PromoCode])(implicit weeklyPlans: WeeklyPlans): Map[CountryGroup, DiscountedRegion] = {
 
     val promotionCountries = promotion.map(_.appliesTo.countries).getOrElse(allCountries)
 
-    // If a user does not qualify for domestic delivery (e.g. if the user is based in South Africa),
-    // we want to explicitly call out their (likely) delivery country on the landing page
-    val promotedRegion: Seq[DiscountedRegion] = {
-      if (WeeklyPicker.isInRestOfWorld(requestCountry: Country)) {
-        val currency = CountryGroup.byCountryCode(requestCountry.alpha2).map(_.currency).getOrElse(Currency.USD)
-        Seq(DiscountedRegion(
-          title = requestCountry.name,
-          description = "Posted to you by air mail",
-          discountedPlans = plansForPromotion(promotion, promoCode, WeeklyPicker.product(requestCountry), currency)
-        ))
-      } else {
-        Seq()
-      }
-    }
-
-    val restOfWorldRegion = Seq(DiscountedRegion(
-      title = "Rest of the world",
-      description = "Posted to you by air mail",
-      discountedPlans = plansForPromotion(promotion, promoCode, WeeklyRestOfWorld, Currency.USD)
-    ))
-
-    val UKregion: Set[DiscountedRegion] = {
+    val UKregion: DiscountedRegion = {
 
       val productForUK = WeeklyPicker.product(Country.UK)
 
@@ -72,43 +51,109 @@ object WeeklyPromotion {
       val countries = promotionCountries intersect UK
       val includesUKDomestic = (countries intersect UKdomestic).nonEmpty
       val includesUKOverseas = (countries intersect UKoverseas).nonEmpty
+
       if(includesUKDomestic && includesUKOverseas){
-        Set(all)
+        all
       } else if (includesUKDomestic) {
-        Set(domestic)
-      } else if (includesUKOverseas) {
-        Set(overseas)
+        domestic
       } else {
-        Set()
+        overseas
       }
     }
-    val USregion = Seq(DiscountedRegion(
+    val USregion = DiscountedRegion(
       title = "United States",
       description = "Includes Alaska and Hawaii",
       discountedPlans = plansForPromotion(promotion, promoCode, WeeklyPicker.product(Country.US), Currency.USD)
-    ))
-    val AUSregion = Seq(DiscountedRegion(
+    )
+    val AUSregion = DiscountedRegion(
       title = "Australia",
       description = "Posted to you by air mail",
       discountedPlans = plansForPromotion(promotion, promoCode, WeeklyPicker.product(Country.Australia), Currency.AUD)
-    ))
-    val NZregion = Seq(DiscountedRegion(
+    )
+    val NZregion = DiscountedRegion(
       title = "New Zealand",
       description = "Posted to you by air mail",
       discountedPlans = plansForPromotion(promotion, promoCode, WeeklyPicker.product(Country.NewZealand), Currency.NZD)
-    ))
-    val CAregion = Seq(DiscountedRegion(
+    )
+    val CAregion = DiscountedRegion(
       title = "Canada",
       description = "Posted to you by air mail",
       discountedPlans = plansForPromotion(promotion, promoCode, WeeklyPicker.product(Country.Canada), Currency.CAD)
-    ))
-    val EUregion = Seq(DiscountedRegion(
+    )
+    val EUregion = DiscountedRegion(
       title = "Europe",
       description = "Posted to you by air mail",
       discountedPlans = plansForPromotion(promotion, promoCode, WeeklyPicker.productForCountryGroup(CountryGroup.Europe), Currency.EUR)
+    )
+
+    Map(
+      CountryGroup.UK -> UKregion,
+      CountryGroup.US -> USregion,
+      CountryGroup.Europe -> EUregion,
+      CountryGroup.Australia -> AUSregion,
+      CountryGroup.NewZealand -> NZregion,
+      CountryGroup.Canada -> CAregion
+    )
+  }
+
+  //If the request country belongs to a domestic country group, we still still display that country at the top of the list
+  //However, if it corresponds to a region that is always displayed then we need to ensure we don't show it twice
+  //e.g. if the request country is the US, then it is the prioritised country and we need to not show it again in the
+  //list of domestic countries. A rest of world country should always be at the top, and then all the domestic country groups after.
+  def domesticCountryGroupsToDisplay(requestCountry: Country): List[CountryGroup] = {
+    val dedupedRegions = requestCountry match {
+      case Country.UK => GuardianWeeklyZones.domesticZoneCountryGroups.filterNot(_ == CountryGroup.UK)
+      case Country.US => GuardianWeeklyZones.domesticZoneCountryGroups.filterNot(_ == CountryGroup.US)
+      case Country.Australia => GuardianWeeklyZones.domesticZoneCountryGroups.filterNot(_ == CountryGroup.Australia)
+      case Country.NewZealand => GuardianWeeklyZones.domesticZoneCountryGroups.filterNot(_ == CountryGroup.NewZealand)
+      case Country.Canada => GuardianWeeklyZones.domesticZoneCountryGroups.filterNot(_ == CountryGroup.Canada)
+      case _ => GuardianWeeklyZones.domesticZoneCountryGroups
+    }
+
+    dedupedRegions.toList
+  }
+
+  def validRegionsForPromotion(promotion: Option[PromoWithWeeklyLandingPage],
+                               promoCode: Option[PromoCode],
+                               requestCountry: Country)(implicit weeklyPlans: WeeklyPlans): Seq[DiscountedRegion] = {
+
+    val domesticDiscountedRegions: Map[CountryGroup, DiscountedRegion] = domesticRegions(promotion, promoCode)
+
+    // If there is a request country passed by query string, we want it to be at the top.
+    // If the request country is a domestic country then it is still the prioritised country, but we should not duplicate it
+    val prioritisedRegion: Seq[DiscountedRegion] = {
+      val currency = CountryGroup.byCountryCode(requestCountry.alpha2).map(_.currency).getOrElse(Currency.USD)
+
+      val maybeDomesticDiscountedRegion = for {
+        domesticCountryGroup <- GuardianWeeklyZones.getDomesticCountryGroup(requestCountry)
+        domesticDiscountedRegion <- domesticDiscountedRegions.get(domesticCountryGroup)
+      } yield {
+        domesticDiscountedRegion
+      }
+
+      Seq(maybeDomesticDiscountedRegion.getOrElse(
+          DiscountedRegion(
+            title = requestCountry.name,
+            description = "Posted to you by air mail",
+            discountedPlans = plansForPromotion(promotion, promoCode, WeeklyPicker.product(requestCountry), currency)
+          )
+        )
+      )
+
+    }
+
+    val restOfWorldRegion = Seq(DiscountedRegion(
+    title = "Rest of the world",
+    description = "Posted to you by air mail",
+    discountedPlans = plansForPromotion(promotion, promoCode, WeeklyRestOfWorld, Currency.USD)
     ))
 
-    val regions: Seq[DiscountedRegion] = promotedRegion ++ UKregion ++ USregion ++ EUregion ++ AUSregion ++  NZregion ++ CAregion  ++ restOfWorldRegion
+
+    val domesticDiscountedRegionsDeduped = domesticCountryGroupsToDisplay(requestCountry) map { countryGroup =>
+      domesticDiscountedRegions(countryGroup)
+    }
+
+    val regions: Seq[DiscountedRegion] = prioritisedRegion ++ domesticDiscountedRegionsDeduped ++ restOfWorldRegion
     regions.filter(_.discountedPlans.nonEmpty)
   }
 

--- a/test/views/support/WeeklyPromotionTest.scala
+++ b/test/views/support/WeeklyPromotionTest.scala
@@ -1,0 +1,39 @@
+package views.support
+
+import com.gu.i18n.{Country, CountryGroup}
+import model.GuardianWeeklyZones
+import org.specs2.mutable.Specification
+
+class WeeklyPromotionTest extends Specification {
+
+  //On the GW page, if we get a requestCountry, it will be first in the list
+  //If this would cause a duplicate, we remove it.
+  "domesticCountryGroupsToDisplay" should {
+
+    val countryInRestOfWorldZone = Country("ER", "Eritrea")
+    val countryInAustraliaCountryGroup = Country("KI", "Kiribati")
+    val countryInEuropeCountryGroup = Country("FR", "France")
+
+    "return all of the domestic regions when the request country is rest of world" in {
+      val domesticPlansToDisplay = WeeklyPromotion.domesticCountryGroupsToDisplay(countryInRestOfWorldZone)
+      domesticPlansToDisplay must contain (GuardianWeeklyZones.domesticZoneCountryGroups.toSet)
+    }
+
+    "return all other domestic regions other than US when the request country is US" in {
+      val domesticPlansToDisplay = WeeklyPromotion.domesticCountryGroupsToDisplay(Country.US)
+      val expected = GuardianWeeklyZones.domesticZoneCountryGroups.toSet.filterNot(_ == CountryGroup.US)
+      domesticPlansToDisplay.toSet mustEqual (expected)
+    }
+
+    "still return all other domestic regions when the request country is in the Australia CountryGroup" in {
+      val domesticPlansToDisplay = WeeklyPromotion.domesticCountryGroupsToDisplay(countryInAustraliaCountryGroup)
+      domesticPlansToDisplay must contain (GuardianWeeklyZones.domesticZoneCountryGroups.toSet)
+    }
+
+    "still return all domestic regions when the request country is in Europe" in {
+      val domesticPlansToDisplay = WeeklyPromotion.domesticCountryGroupsToDisplay(countryInEuropeCountryGroup)
+      domesticPlansToDisplay must contain (GuardianWeeklyZones.domesticZoneCountryGroups.toSet)
+    }
+
+  }
+}


### PR DESCRIPTION
Before we switched to use new plans after the Guardian Weekly relaunch, https://subscribe.theguardian.com/p/WWM99X?country=AU would shown Australia to be the first region in the list (and same for other countries that were previously zone C).

So, this makes it so that the request country (either passed as a query param, or else if we have country info from Fastly, or else the UK is default see [here](https://github.com/guardian/subscriptions-frontend/blob/master/app/controllers/PromoLandingPage.scala#L145)) is at the top of the list. 

We always show:
* United Kingdom
* United States
* Europe
* Australia
* New Zealand
* Canada

So, if the request country is any of these, then it is still the prioritised country but we make sure we don't display it twice: 
https://github.com/guardian/subscriptions-frontend/compare/lm-request-country-is-top?expand=1#diff-f5ccd2106078cafb58e6ec7887268e56R103 

This might be a convoluted way to go about it, so alternative approaches definitely welcome. 

e.g. before:
![image](https://user-images.githubusercontent.com/3072877/47033896-d92c4e00-d16d-11e8-9f63-0a31bda3d89c.png)

e.g. after:
![image](https://user-images.githubusercontent.com/3072877/47033943-f6f9b300-d16d-11e8-8b9e-a1340201fdb2.png)

