### PR TITLE
Make terms pages sensitive to region and show correct contact details

### DIFF
--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -190,13 +190,13 @@ class PromoLandingPage(
     maybeLandingPage.run.map(_.map(OkWithPreviewHeaders).getOrElse(NotFound))
   }
 
-  def terms(promoCodeStr: String): Action[AnyContent] = CachedAction.async { _ =>
+  def terms(promoCodeStr: String, maybeCountry: Option[Country]): Action[AnyContent] = CachedAction.async { _ =>
     val promoCode = PromoCode(promoCodeStr)
 
     val maybeTermsPage = for {
       promotion <- OptionT(tpBackend.promoService.findPromotionFuture(promoCode))
       termsPage <- OptionT(eventualCatalogPromoLandingPage.map(_.catalog).map({ catalog =>
-        Some(Ok(views.html.promotion.termsPage(promoCode, promotion, PegdownMarkdownRenderer, catalog))): Option[Result]
+        Some(Ok(views.html.promotion.termsPage(promoCode, promotion, PegdownMarkdownRenderer, catalog, maybeCountry))): Option[Result]
       }))
     } yield termsPage
 

--- a/app/views/fragments/promotion/fullTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/fullTermsAndConditions.scala.html
@@ -3,8 +3,9 @@
 @import com.gu.memsub.subsv2.Catalog
 @import views.support.LandingPageOps._
 @import views.support.MarkdownRenderer
+@import com.gu.i18n.Country
 
-@(promoCode: PromoCode, catalog: Catalog, promotion: AnyPromotion, md: MarkdownRenderer)
+@(promoCode: PromoCode, catalog: Catalog, promotion: AnyPromotion, md: MarkdownRenderer, maybeCountry: Option[Country])
 @isDigipack = @{(catalog.digipack.plans.map(_.id).toSet intersect promotion.appliesTo.productRatePlanIds).nonEmpty}
 @isGuardianWeekly = @{(catalog.weekly.plans.flatten.map(_.id).toSet intersect promotion.appliesTo.productRatePlanIds).nonEmpty}
 @if(promotion.asIncentive.isDefined) {
@@ -14,7 +15,7 @@
         <p>@fragments.promotion.digitalpackLegalTerms(promoCode, promotion, md)</p>
     } else {
         @if(isGuardianWeekly) {
-            <p>@fragments.promotion.guardianWeeklyLegalTerms(promoCode, catalog, promotion, md)</p>
+            <p>@fragments.promotion.guardianWeeklyLegalTerms(promoCode, catalog, promotion, md, maybeCountry)</p>
         } else {
             <p>@fragments.promotion.newspaperLegalTerms(promoCode, promotion, md)</p>
         }

--- a/app/views/fragments/promotion/guardianWeeklyLegalTerms.scala.html
+++ b/app/views/fragments/promotion/guardianWeeklyLegalTerms.scala.html
@@ -3,23 +3,36 @@
 @import com.gu.memsub.promo.Promotion.AnyPromotion
 @import com.gu.memsub.subsv2.Catalog
 @import views.support.MarkdownRenderer
+@import com.gu.i18n.{Country, CountryGroup}
 
-@(promoCode: PromoCode, catalog: Catalog, promotion: AnyPromotion, md: MarkdownRenderer)
+@(promoCode: PromoCode, catalog: Catalog, promotion: AnyPromotion, md: MarkdownRenderer, maybeCountry: Option[Country])
 @isSixForSix = @{(catalog.weekly.plans.flatten.filter(_.charges.billingPeriod == SixWeeks).map(_.id).toSet intersect promotion.appliesTo.productRatePlanIds).nonEmpty}
+
+@ukSixForSixTerms = @{"**United Kingdom:** Offer is £6 for the first 6 issues followed by quarterly (13 weeks) subscription payments of £37.50 thereafter, saving 35% off the cover price."}
+@usSixForSixTerms = @{"**USA:** Offer is $6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $75, saving 31% off the cover price."}
+@caSixForSixTerms = @{"**Canada:** Offer is $6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $80, saving 16% off the cover price."}
+@auSixForSixTerms = @{"**Australia:** Offer is $6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $97.50 thereafter, saving 15% off the cover price."}
+@nzSixForSixTerms = @{"**New Zealand:** Offer is $6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $123 thereafter, saving 20% off the cover price."}
+@euSixForSixTerms = @{"**Europe:**  Offer is €6 for the first 6 issues followed by quarterly (13 weeks) subscription payments of €61.30, saving 26% off the cover price. Excluding Cyprus, Malta and Republic of Ireland."}
+@rowSixForSixTerms = @{"**Rest of World:** Offer is US$6 the first 6 issues, followed by quarterly (13 weeks) subscription payments of US$81.30."}
+
+@sixForSixGenericTerms = @{
+    ukSixForSixTerms.concat("\n\n") +
+    usSixForSixTerms.concat("\n\n") +
+    caSixForSixTerms.concat("\n\n") +
+    auSixForSixTerms.concat("\n\n") +
+    nzSixForSixTerms.concat("\n\n") +
+    euSixForSixTerms.concat("\n\n") +
+    rowSixForSixTerms.concat("\n\n")
+}
+
 @Html(md.render(
     (if (isSixForSix) {
 s"""
 Offer not available to current subscribers of Guardian Weekly. You must be 18+ to be eligible for this offer. Guardian Weekly reserve the right to end this offer at any time.
 
-**United Kingdom:** Offer is £6 for the first 6 issues followed by quarterly (13 weeks) subscription payments of £30 thereafter, saving 20% off the cover price.
+$sixForSixGenericTerms
 
-**USA and Canada:** Offer is $$6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $$60, saving 30% off the cover price ($$US) and 20% ($$CAN).
-
-**Australia and New Zealand:** Offer is $$6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $$78AUD (Australia) or $$98NZD (New Zealand) thereafter, saving 18% off the cover price.
-
-**Europe:**  Offer is €6 for the first 6 issues followed by quarterly (13 weeks) subscription payments of €49, saving 30% off the cover price. Excluding Cyprus, Malta and Republic of Ireland.
-
-**Rest of World:** Offer is £6 the first 6 issues, followed by quarterly (13 weeks) subscription payments of £48.
 """
     } else {
 s"""

--- a/app/views/fragments/promotion/guardianWeeklyLegalTerms.scala.html
+++ b/app/views/fragments/promotion/guardianWeeklyLegalTerms.scala.html
@@ -8,15 +8,68 @@
 @(promoCode: PromoCode, catalog: Catalog, promotion: AnyPromotion, md: MarkdownRenderer, maybeCountry: Option[Country])
 @isSixForSix = @{(catalog.weekly.plans.flatten.filter(_.charges.billingPeriod == SixWeeks).map(_.id).toSet intersect promotion.appliesTo.productRatePlanIds).nonEmpty}
 
-@ukSixForSixTerms = @{"**United Kingdom:** Offer is £6 for the first 6 issues followed by quarterly (13 weeks) subscription payments of £37.50 thereafter, saving 35% off the cover price."}
-@usSixForSixTerms = @{"**USA:** Offer is $6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $75, saving 31% off the cover price."}
-@caSixForSixTerms = @{"**Canada:** Offer is $6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $80, saving 16% off the cover price."}
-@auSixForSixTerms = @{"**Australia:** Offer is $6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $97.50 thereafter, saving 15% off the cover price."}
-@nzSixForSixTerms = @{"**New Zealand:** Offer is $6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $123 thereafter, saving 20% off the cover price."}
-@euSixForSixTerms = @{"**Europe:**  Offer is €6 for the first 6 issues followed by quarterly (13 weeks) subscription payments of €61.30, saving 26% off the cover price. Excluding Cyprus, Malta and Republic of Ireland."}
-@rowSixForSixTerms = @{"**Rest of World:** Offer is US$6 the first 6 issues, followed by quarterly (13 weeks) subscription payments of US$81.30."}
+@uk = @{"**United Kingdom:**"}
+@ukQuarterlyRate = @{"£37.50"}
+@ukAnnualRate = @{"£150"}
+@ukSavePercent = @{"35%"}
 
-@sixForSixGenericTerms = @{
+@us = @{"**USA:**"}
+@usQuarterlyRate = @{"US$75"}
+@usAnnualRate = @{"US$300"}
+@usSavePercent = @{"31%"}
+
+@ca = @{"**Canada:**"}
+@caQuarterlyRate = @{"CA$80"}
+@caAnnualRate = @{"CA$320"}
+@caSavePercent = @{"16%"}
+
+@au = @{"**Australia:**"}
+@auQuarterlyRate = @{"AU$97.50"}
+@auAnnualRate = @{"AU$390"}
+@auSavePercent = @{"15%"}
+
+@nz = @{"**New Zealand:**"}
+@nzQuarterlyRate = @{"NZ$123"}
+@nzAnnualRate = @{"NZ$490"}
+@nzSavePercent = @{"20%"}
+
+@eu = @{"**Europe:**"}
+@euQuarterlyRate = @{"€61.30"}
+@euAnnualRate = @{"€245"}
+@euSavePercent = @{"26%"}
+
+@row = @{"**Rest of World:**"}
+@rowQuarterlyRateGBP = @{"£60"}
+@rowQuarterlyRateUSD = @{"US$81.30"}
+@rowAnnualRate = @{"£240 or US$325"}
+
+@ukStandardTerms = @{s"$uk Quarterly (13 weeks) subscription rate $ukQuarterlyRate, or annual rate $ukAnnualRate, saving $ukSavePercent off the cover price."}
+@usStandardTerms = @{s"$us Quarterly (13 weeks) subscription rate $usQuarterlyRate, or annual rate $usAnnualRate, saving $usSavePercent off the cover price."}
+@caStandardTerms = @{s"$ca Quarterly (13 weeks) subscription rate $caQuarterlyRate, or annual rate $caAnnualRate, saving $caSavePercent off the cover price."}
+@auStandardTerms = @{s"$au Quarterly (13 weeks) subscription rate $auQuarterlyRate, or annual rate $auAnnualRate, saving $auSavePercent off the cover price."}
+@nzStandardTerms = @{s"$nz Quarterly (13 weeks) subscription rate $nzQuarterlyRate, or annual rate $nzAnnualRate, saving $nzSavePercent off the cover price."}
+@euStandardTerms = @{s"$eu Quarterly (13 weeks) subscription rate $euQuarterlyRate, or annual rate $euAnnualRate, saving $euSavePercent off the cover price. Excluding Cyprus, Malta and Republic of Ireland."}
+@rowStandardTerms = @{s"$row Quarterly (13 weeks) subscription payments of $rowQuarterlyRateGBP or $rowQuarterlyRateUSD, or annual payments of $rowAnnualRate."}
+
+@allStandardTerms = @{
+    ukStandardTerms.concat("\n\n") +
+    usStandardTerms.concat("\n\n") +
+    caStandardTerms.concat("\n\n") +
+    auStandardTerms.concat("\n\n") +
+    nzStandardTerms.concat("\n\n") +
+    euStandardTerms.concat("\n\n") +
+    rowStandardTerms.concat("\n\n")
+}
+
+@ukSixForSixTerms = @{s"$uk Offer is £6 for the first 6 issues followed by quarterly (13 weeks) subscription payments of $ukQuarterlyRate thereafter, saving $ukSavePercent off the cover price."}
+@usSixForSixTerms = @{s"$us Offer is US$$6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $usQuarterlyRate thereafter, saving $usSavePercent off the cover price."}
+@caSixForSixTerms = @{s"$ca Offer is CA$$6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $caQuarterlyRate thereafter, saving $caSavePercent off the cover price."}
+@auSixForSixTerms = @{s"$au Offer is AU$$6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $auQuarterlyRate thereafter, saving $auSavePercent off the cover price."}
+@nzSixForSixTerms = @{s"$nz Offer is NZ$$6 for the first 6 issues, followed by quarterly (13 weeks) subscription payments of $nzQuarterlyRate thereafter, saving $nzSavePercent off the cover price."}
+@euSixForSixTerms = @{s"$eu Offer is €6 for the first 6 issues followed by quarterly (13 weeks) subscription payments of $euQuarterlyRate thereafter, saving $euSavePercent off the cover price. Excluding Cyprus, Malta and Republic of Ireland."}
+@rowSixForSixTerms = @{s"$row Offer is US$$6 the first 6 issues, followed by quarterly (13 weeks) subscription payments of $rowQuarterlyRateUSD thereafter."}
+
+@allSixForSixTerms = @{
     ukSixForSixTerms.concat("\n\n") +
     usSixForSixTerms.concat("\n\n") +
     caSixForSixTerms.concat("\n\n") +
@@ -31,24 +84,13 @@
 s"""
 Offer not available to current subscribers of Guardian Weekly. You must be 18+ to be eligible for this offer. Guardian Weekly reserve the right to end this offer at any time.
 
-$sixForSixGenericTerms
-
+$allSixForSixTerms
 """
     } else {
 s"""
 You must be 18+ to be eligible for a Guardian Weekly subscription.
 
-**United Kingdom:** Quarterly (13 weeks) subscription rate £30 and annual rate £120, saving 20% off the cover price.
-
-**USA and Canada:** Quarterly (13 weeks) subscription rate $$60 and annual rate $$240, saving 30% off the cover price ($$US) and 20% ($$CAN).
-
-**Australia:** Quarterly (13 weeks) subscription payments of $$78 and annual rate $$312, saving 18% off the cover price.
-
-**New Zealand:** Quarterly (13 weeks) subscription rate of $$98 and annual rate $$392, saving 18% off the cover price.
-
-**Europe:** Quarterly (13 weeks) subscription rate of €49 and annual rate €196, saving 30% off the cover price. Excluding Cyprus, Malta and Republic of Ireland.
-
-**Rest of World:** Quarterly (13 weeks) subscription payments of £48 or US$$65 and annual rates £192 or US $$260.
+$allStandardTerms
 """
     }) +
 """

--- a/app/views/promotion/termsPage.scala.html
+++ b/app/views/promotion/termsPage.scala.html
@@ -3,10 +3,18 @@
 @import com.gu.memsub.subsv2.Catalog
 @import views.support.Dates.prettyDate
 @import views.support.MarkdownRenderer
-@(promoCode: PromoCode, promotion: AnyPromotion, md: MarkdownRenderer, catalog: Catalog)
+@import com.gu.i18n.Country
+
+@(promoCode: PromoCode, promotion: AnyPromotion, md: MarkdownRenderer, catalog: Catalog, maybeCountry: Option[Country])
 @title = @{s"Promo code: ${promoCode.get}"}
+@compatibleProductList = @{catalog.allSubs.flatten.filter(plan => promotion.appliesTo.productRatePlanIds.contains(plan.id))}
+@productNameList = @{compatibleProductList.map(_.name).distinct.sorted}
+@product = @{compatibleProductList.headOption.map{ plan => plan.product }.orElse(None)}
+
 @main(
-    title = s"$title | The Guardian"
+    title = s"$title | The Guardian",
+    product = product,
+    contactUsCountry = maybeCountry
 ) {
 
     <main class="page-container gs-container">
@@ -27,7 +35,7 @@
 
             <h4>Applies to products</h4>
             <ul class="promotion-applies-to">
-                @catalog.allSubs.flatten.filter(plan => promotion.appliesTo.productRatePlanIds.contains(plan.id)).map(_.name).distinct.sorted.map { name =>
+                @productNameList.map{ name =>
                     <li>@name</li>
                 }
             </ul>
@@ -52,7 +60,7 @@
         </section>
         <section class="section-slice promotion-terms">
             @fragments.promotion.promotionTermsAndConditions(promotion, md)
-            @fragments.promotion.fullTermsAndConditions(promoCode, catalog, promotion, md)
+            @fragments.promotion.fullTermsAndConditions(promoCode, catalog, promotion, md, maybeCountry)
             @fragments.promotion.copyrightNotice()
         </section>
     </main>

--- a/app/views/promotion/weeklyLandingPage.scala.html
+++ b/app/views/promotion/weeklyLandingPage.scala.html
@@ -108,9 +108,8 @@
             <section class="flexwrap promotion-terms">
                 <div class="flexwrap__inner">
                     @nonTrackingPromotion.map { promo =>
-
                         @fragments.promotion.promotionTermsAndConditions(promo, md)
-                    <p>For full promotion terms and conditions visit <a class="u-link" href="/p/@promoCode.map(_.get)/terms">
+                    <p>For full promotion terms and conditions visit <a class="u-link" href="/p/@promoCode.map(_.get)/terms?country=@{country.alpha2}">
                         subscribe.theguardian.com/p/@promoCode.map(_.get)/terms</a></p>
 
                         @fragments.promotion.subscriptionTermsAndConditions(catalog, promo)

--- a/app/views/support/ContactCentreOps.scala
+++ b/app/views/support/ContactCentreOps.scala
@@ -46,7 +46,7 @@ object ContactCentreOps {
 
   def weeklyEmail(contactUsCountry: Option[Country]): String = {
     if (contactUsCountry exists countriesHandledByAUCallCentre) {
-      "gwsubsau@theguardian.com"
+      "apac.help@theguardian.com"
     } else {
       "gwsubs@theguardian.com"
     }

--- a/conf/routes
+++ b/conf/routes
@@ -68,7 +68,7 @@ GET         /test-users                      controllers.Testing.testUser
 
 # Promotions
 GET         /p/:promoCodeStr                 controllers.PromoLandingPage.render(promoCodeStr: String, country: Option[Country])
-GET         /p/:promoCodeStr/terms           controllers.PromoLandingPage.terms(promoCodeStr: String)
+GET         /p/:promoCodeStr/terms           controllers.PromoLandingPage.terms(promoCodeStr: String, country: Option[Country])
 
 # NOCSRF
 POST        /q                               controllers.PromoLandingPage.preview(country: Option[Country])


### PR DESCRIPTION
We want to display the correct prices and discounts for the new Weekly product on the terms and conditions page, and we also want to display up-to-date contact information in the footer.

Primarily this is for Australia because they're using a different contact email address, but it should just work where possible for all territories.

See this [trello card](https://trello.com/c/8mHV9ug1/2017-update-tscs-for-gw-and-contact-details-for-au)

Update:
I've also taken the opportunity to capture the price and discount values (and country titles) into variables so they can be typed (or edited) once and used wherever they're needed.

**Screenshots**
**AU promo:**
![screencapture-subscribe-code-dev-theguardian-p-wwm99x-au-2018-10-17-16_34_38](https://user-images.githubusercontent.com/690395/47098344-f07d4100-d22a-11e8-9f5a-234411b58e87.png)

**AU terms:**
![screencapture-subscribe-code-dev-theguardian-p-wwm99x-terms-au-2018-10-17-16_34_54](https://user-images.githubusercontent.com/690395/47098367-fffc8a00-d22a-11e8-8c91-095f50d55876.png)

**US promo:**
![screencapture-subscribe-code-dev-theguardian-p-wwm99x-us-2018-10-17-16_38_47](https://user-images.githubusercontent.com/690395/47098452-29b5b100-d22b-11e8-8023-b3b0a32db3af.png)

**US terms:**
![screencapture-subscribe-code-dev-theguardian-p-wwm99x-terms-us-2018-10-17-16_39_33](https://user-images.githubusercontent.com/690395/47098513-44882580-d22b-11e8-903b-f7a0d72e7928.png)

**UK promo:**
![screencapture-subscribe-code-dev-theguardian-p-wwm99x-uk-2018-10-17-16_40_14](https://user-images.githubusercontent.com/690395/47098580-608bc700-d22b-11e8-872b-d7c11dcf8d36.png)

**UK terms:**
![screencapture-subscribe-code-dev-theguardian-p-wwm99x-terms-uk-2018-10-17-16_40_56](https://user-images.githubusercontent.com/690395/47098633-7ac5a500-d22b-11e8-969c-c6360423c8b9.png)

**Brucie Bonus Screenshot: Thank you page (AU)**
![screencapture-subscribe-code-dev-theguardian-checkout-thank-you-au-2018-10-17-16_53_30](https://user-images.githubusercontent.com/690395/47099805-fe809100-d22d-11e8-9deb-273054cad088.png)
