### PR TITLE
override jackson-databind to 2.9.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ libraryDependencies ++= Seq(
     jodaForms,
     PlayImport.specs2 % "test",
     "com.gu" %% "membership-common" % "0.525",
-    "com.gu.identity" %% "identity-play-auth" % "2.4",
+    "com.gu.identity" %% "identity-play-auth" % "2.5",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.6",
     "com.gu" %% "identity-test-users" % "0.6",
@@ -74,6 +74,7 @@ libraryDependencies ++= Seq(
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.9.2",
     "com.google.guava" % "guava" % "25.0-jre", //-- added explicitly - snyk report avoid logback vulnerability
     "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7", //added explicitly to avoid snyk vulnerability
+    "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7", //added explicitly to avoid snyk vulnerability
     "ch.qos.logback" % "logback-classic" % "1.2.3", //-- added explicitly - snyk report avoid logback vulnerability
     "org.scala-lang" % "scala-compiler" % "2.11.12",
     "org.bouncycastle" % "bcprov-jdk15on" % "1.60" // https://snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-32412

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ libraryDependencies ++= Seq(
     "net.logstash.logback" % "logstash-logback-encoder" % "4.11",
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.9.2",
     "com.google.guava" % "guava" % "25.0-jre", //-- added explicitly - snyk report avoid logback vulnerability
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7", //added explicitly to avoid snyk vulnerability
     "ch.qos.logback" % "logback-classic" % "1.2.3", //-- added explicitly - snyk report avoid logback vulnerability
     "org.scala-lang" % "scala-compiler" % "2.11.12",
     "org.bouncycastle" % "bcprov-jdk15on" % "1.60" // https://snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-32412


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507

We are pulling in old versions of jackson-databind primarily via aws-sdks. It's suggested [here](https://github.com/aws/aws-sdk-java) that overriding jackson-databind shouldn't be a breaking change. Indeed, when running the project locally after the version bump, that seems to be the case. 

We are also pulling in an old version of jackson-databind to support sign in.

I bumped the version, signed in with a test user, then bought a digital pack locally and that worked fine.

Any other suggested checks?