### PR TITLE
Improve error handling for postcode lookups

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -417,7 +417,11 @@ class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions
       // should a client want not to proxy via this server.
       Ok(Json.obj("Addresses" -> result.Addresses))
     } recover {
-      case e => BadRequest(Json.obj("Message" -> e.getMessage))
+      case error if error.getMessage == "Bad Request" =>
+        BadRequest //The postcode was invalid
+      case error =>
+        SafeLogger.error(scrub"Failed to complete postcode lookup via getAddress.io due to: $error")
+        InternalServerError
     }
   }
 


### PR DESCRIPTION
This should help us to spot problems in production faster, as common failures (authentication problems, rate limiting) should now be logged to Sentry (and included in application logs).

This will be particularly useful when this app is not being worked on frequently (the test added here should catch these problems during development / on deployment: https://github.com/guardian/subscriptions-frontend/pull/1186).

