### PR TITLE
Simplify acceptance tests.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,10 +121,8 @@ javaOptions in Universal ++= Seq(
 
 addCommandAlias("devrun", "run  9200")
 addCommandAlias("prodrun", "run 9200")
-addCommandAlias("fast-test", "testOnly -- -l Acceptance -l WeeklyCheckoutAcceptance -l WeeklyPromoAcceptance -l GetAddressIOServiceAcceptance")
-addCommandAlias("acceptance-test", "testOnly acceptance.CheckoutSpec acceptance.GetAddressIOServiceTest")
-addCommandAlias("get-address-io-service-test", "testOnly acceptance.GetAddressIOServiceTest")
-addCommandAlias("weekly-promo-acceptance-test", "testOnly acceptance.WeeklyPromoSpec")
+addCommandAlias("fast-test", "testOnly -- -l AcceptanceTest")
+addCommandAlias("acceptance-test", "testOnly -- -n AcceptanceTest")
 addCommandAlias("play-artifact", "riffRaffNotifyTeamcity")
 
 

--- a/test/acceptance/CheckoutSpec.scala
+++ b/test/acceptance/CheckoutSpec.scala
@@ -53,7 +53,7 @@ class CheckoutSpec extends FeatureSpec with Browser
 
   feature("Subscription checkout") {
 
-    scenario("Guest user subscribes for the Digital Pack with direct debit", Acceptance) {
+    scenario("Guest user subscribes for the Digital Pack with direct debit", AcceptanceTest) {
       checkDependenciesAreAvailable
       val testUser = new TestUser
 
@@ -117,7 +117,7 @@ class CheckoutSpec extends FeatureSpec with Browser
           TESTS WITH OLD ZONES/RATES
      */
 
-    scenario("Weekly quarterly sub purchase (old pricing - ZoneA) from UK for UK delivery", WeeklyCheckoutAcceptance) {
+    scenario("Weekly quarterly sub purchase (old pricing - ZoneA) from UK for UK delivery", AcceptanceTest) {
       checkDependenciesAreAvailable
       val testUser = new TestUser
       val checkout = Checkout(testUser, "checkout/weeklyzonea-guardianweeklyquarterly?countryGroup=uk")
@@ -135,7 +135,7 @@ class CheckoutSpec extends FeatureSpec with Browser
       assert(!checkout.currencyOverrideHasLoaded())
     }
 
-    scenario("Weekly quarterly sub purchase (old pricing - ZoneC) from EU for EU delivery", WeeklyCheckoutAcceptance) {
+    scenario("Weekly quarterly sub purchase (old pricing - ZoneC) from EU for EU delivery", AcceptanceTest) {
       checkDependenciesAreAvailable
       val testUser = new TestUser
       val checkout = Checkout(testUser, "checkout/weeklyzonec-guardianweeklyquarterly?countryGroup=eu")
@@ -153,7 +153,7 @@ class CheckoutSpec extends FeatureSpec with Browser
       assert(checkout.currencyOverrideHasLoaded())
     }
 
-    scenario("Weekly quarterly sub purchase (old pricing - ZoneC) from ROW for ROW delivery", WeeklyCheckoutAcceptance) {
+    scenario("Weekly quarterly sub purchase (old pricing - ZoneC) from ROW for ROW delivery", AcceptanceTest) {
       checkDependenciesAreAvailable
       val testUser = new TestUser
       val checkout = Checkout(testUser, "checkout/weeklyzonec-guardianweeklyquarterly?countryGroup=us")
@@ -171,7 +171,7 @@ class CheckoutSpec extends FeatureSpec with Browser
       assert(checkout.currencyOverrideHasLoaded())
     }
 
-    scenario("Weekly quarterly sub purchase (old pricing - ZoneA) from ROW for UK delivery", WeeklyCheckoutAcceptance) {
+    scenario("Weekly quarterly sub purchase (old pricing - ZoneA) from ROW for UK delivery", AcceptanceTest) {
       checkDependenciesAreAvailable
       val testUser = new TestUser
       val checkout = Checkout(testUser, "checkout/weeklyzonea-guardianweeklyquarterly?countryGroup=uk")
@@ -193,7 +193,7 @@ class CheckoutSpec extends FeatureSpec with Browser
           TESTS WITH NEW ZONES/RATES
      */
 
-    scenario("Weekly quarterly sub purchase (new pricing - domestic) from UK for UK delivery", WeeklyCheckoutAcceptance) {
+    scenario("Weekly quarterly sub purchase (new pricing - domestic) from UK for UK delivery", AcceptanceTest) {
       checkDependenciesAreAvailable
       val testUser = new TestUser
       val checkout = Checkout(testUser, "checkout/weeklydomestic-gwoct18-quarterly-domestic?countryGroup=uk")
@@ -211,7 +211,7 @@ class CheckoutSpec extends FeatureSpec with Browser
       assert(!checkout.currencyOverrideHasLoaded())
     }
 
-    scenario("Weekly quarterly sub purchase (new pricing - domestic) from EU for EU delivery", WeeklyCheckoutAcceptance) {
+    scenario("Weekly quarterly sub purchase (new pricing - domestic) from EU for EU delivery", AcceptanceTest) {
       checkDependenciesAreAvailable
       val testUser = new TestUser
       val checkout = Checkout(testUser, "checkout/weeklydomestic-gwoct18-quarterly-domestic?countryGroup=eu")
@@ -229,7 +229,7 @@ class CheckoutSpec extends FeatureSpec with Browser
       assert(!checkout.currencyOverrideHasLoaded())
     }
 
-    scenario("Weekly quarterly sub purchase (new pricing - restofworld) for ROW delivery", WeeklyCheckoutAcceptance) {
+    scenario("Weekly quarterly sub purchase (new pricing - restofworld) for ROW delivery", AcceptanceTest) {
       checkDependenciesAreAvailable
       val testUser = new TestUser
       val checkout = Checkout(testUser, "checkout/weeklyrestofworld-gwoct18-quarterly-row?countryGroup=us")
@@ -247,7 +247,7 @@ class CheckoutSpec extends FeatureSpec with Browser
       assert(checkout.currencyOverrideHasLoaded())
     }
 
-    scenario("Weekly quarterly sub purchase (new pricing - domestic) from ROW for UK delivery", WeeklyCheckoutAcceptance) {
+    scenario("Weekly quarterly sub purchase (new pricing - domestic) from ROW for UK delivery", AcceptanceTest) {
       checkDependenciesAreAvailable
       val testUser = new TestUser
       val checkout = Checkout(testUser, "checkout/weeklydomestic-gwoct18-quarterly-domestic?countryGroup=uk")
@@ -267,7 +267,7 @@ class CheckoutSpec extends FeatureSpec with Browser
 
 
     //temporarily ignoring this until user details pre-fill is fixed
-    ignore("Identity user subscribes to the Voucher Everyday package with direct debit", Acceptance) {
+    ignore("Identity user subscribes to the Voucher Everyday package with direct debit", AcceptanceTest) {
       withRegisteredIdentityUserFixture { testUser =>
 
       Given("a registered and signed in Identity user selects the Everyday package")

--- a/test/acceptance/GetAddressIOServiceTest.scala
+++ b/test/acceptance/GetAddressIOServiceTest.scala
@@ -1,6 +1,6 @@
 package acceptance
 
-import acceptance.util.GetAddressIOServiceAcceptance
+import acceptance.util.AcceptanceTest
 import org.scalatest.{FreeSpec, Matchers}
 import services.GetAddressIOService
 import scala.concurrent.Await
@@ -11,7 +11,7 @@ class GetAddressIOServiceTest extends FreeSpec with Matchers {
 
   val getAddressIOService: GetAddressIOService = new GetAddressIOService()
 
-	"getAddressIOService should successfully retrieve a correct postcode'" taggedAs GetAddressIOServiceAcceptance in {
+	"getAddressIOService should successfully retrieve a correct postcode'" taggedAs AcceptanceTest in {
     noException should be thrownBy Await.result(getAddressIOService.find("N1 9AG"), 2.seconds)
 	}
 

--- a/test/acceptance/WeeklyPromoSpec.scala
+++ b/test/acceptance/WeeklyPromoSpec.scala
@@ -29,7 +29,7 @@ class WeeklyPromoSpec extends FeatureSpec with Browser
 
   feature("Weekly Promotion Page") {
 
-    scenario("UK user lands on Guardian Weekly promotion page", WeeklyPromoAcceptance) {
+    scenario("UK user lands on Guardian Weekly promotion page", AcceptanceTest) {
       val promoCode = "/p/10ANNUAL"
 
       When("The user is in the UK")
@@ -91,7 +91,7 @@ class WeeklyPromoSpec extends FeatureSpec with Browser
 
     }
 
-    scenario("ZA user lands on GW promo page", WeeklyPromoAcceptance) {
+    scenario("ZA user lands on GW promo page", AcceptanceTest) {
       val promoCode = "/p/10ANNUAL"
 
       When("The user is in South Africa")
@@ -155,7 +155,7 @@ class WeeklyPromoSpec extends FeatureSpec with Browser
 
     // NEW PRICE/PRODUCT TEST
 
-    scenario("UK user lands on Guardian Weekly promotion page AFTER 10:45 on 10/10/18", WeeklyPromoAcceptance) {
+    scenario("UK user lands on Guardian Weekly promotion page AFTER 10:45 on 10/10/18", AcceptanceTest) {
       val promoCode = "/p/10ANNUAL"
       val params = Some("gwoct18")
 
@@ -218,7 +218,7 @@ class WeeklyPromoSpec extends FeatureSpec with Browser
 
     }
 
-    scenario("FR user lands on Guardian Weekly promotion page AFTER 10:45 on 10/10/18", WeeklyPromoAcceptance) {
+    scenario("FR user lands on Guardian Weekly promotion page AFTER 10:45 on 10/10/18", AcceptanceTest) {
       val promoCode = "/p/10ANNUAL"
       val country = "FR"
       val params = Some("gwoct18")
@@ -282,7 +282,7 @@ class WeeklyPromoSpec extends FeatureSpec with Browser
 
     }
 
-    scenario("ZA user lands on GW promo page AFTER 10:45 on 10/10/18", WeeklyPromoAcceptance) {
+    scenario("ZA user lands on GW promo page AFTER 10:45 on 10/10/18", AcceptanceTest) {
       val promoCode = "/p/10ANNUAL"
       val country = "ZA"
       val params = Some("gwoct18")

--- a/test/acceptance/util/Tags.scala
+++ b/test/acceptance/util/Tags.scala
@@ -2,8 +2,5 @@ package acceptance.util
 
 import org.scalatest.Tag
 
-object Acceptance extends Tag("Acceptance")
-object WeeklyCheckoutAcceptance extends Tag("WeeklyCheckoutAcceptance")
-object WeeklyPromoAcceptance extends Tag("WeeklyPromoAcceptance")
-object GetAddressIOServiceAcceptance extends Tag("GetAddressIOServiceAcceptance")
+object AcceptanceTest extends Tag("AcceptanceTest")
 


### PR DESCRIPTION
We want two scenarios:
1. Unit test suite to run and acceptances tests not to.
2. Acceptance tests to run and unit test suite not to.

By providing a single tag `AcceptanceTest`, we can run all tests without it in the first scenario, and all tests with it in the second scenario.
This also means that when adding a new acceptance test you simply add the same tag and don't have to modify the sbt commands as these are something we don't want to care about during development.

I've removed the individual commands to run individual acceptance tests as these are more boilerplate and unlikely to be used individually given there is a very small number of acceptance tests.