### PR TITLE
Use the right name for a domestic country group at the top of the GW page

### DIFF
--- a/app/views/support/WeeklyPromotion.scala
+++ b/app/views/support/WeeklyPromotion.scala
@@ -123,12 +123,11 @@ object WeeklyPromotion {
     // If the request country is a domestic country then it is still the prioritised country, but we should not duplicate it
     val prioritisedRegion: DiscountedRegion = {
       val currency = CountryGroup.byCountryCode(requestCountry.alpha2).map(_.currency).getOrElse(Currency.USD)
-
       val maybeDomesticDiscountedRegion = for {
         domesticCountryGroup <- GuardianWeeklyZones.getDomesticCountryGroup(requestCountry)
         domesticDiscountedRegion <- domesticDiscountedRegions.get(domesticCountryGroup)
       } yield {
-        domesticDiscountedRegion
+        domesticDiscountedRegion.copy(requestCountry.name)
       }
 
       maybeDomesticDiscountedRegion.getOrElse(


### PR DESCRIPTION
https://github.com/guardian/subscriptions-frontend/pull/1180 made it so that if we have a country query param, that it is displayed at the top of the list of regions. 

However, if it is a country was contained in a domestic country group this introduced a bug so that the right regions would not be displayed. 

the bug
<img src="https://user-images.githubusercontent.com/3072877/47152139-bfa51680-d2d3-11e8-99e4-7b9aa230c94b.png" width="700">

when fixed
<img src="https://user-images.githubusercontent.com/3072877/47152266-1f9bbd00-d2d4-11e8-8708-b18287bf7547.png" width="700">

