### PR TITLE
Test against paid getAddress account

### DIFF
--- a/conf/getAddressIO.conf
+++ b/conf/getAddressIO.conf
@@ -1,4 +1,4 @@
 get-address-io-api {
     url = "https://api.getAddress.io/v2/uk/"
-    key = "M6lIXg7sQ06aUM4pINXItw12037"
+    key = "M6lIXg7sQ06aUM4pINXItw12037" // This is overriden by a private key when running in PROD
 }

--- a/test/acceptance/conf/acceptance-test.conf
+++ b/test/acceptance/conf/acceptance-test.conf
@@ -1,5 +1,4 @@
 include "DEV.public"
-include "getAddressIO.conf"
 
 // Travis CI environmental variables that override DEV.conf with PROD values
 stage=${?STAGE}
@@ -9,5 +8,10 @@ identity {
 }
 subscriptions.url= ${?SUBSCRIPTIONS_URL}
 webDriverRemoteUrl = ${?WEBDRIVER_REMOTE_URL}
+
+get-address-io-api {
+    url = "https://api.getAddress.io/v2/uk/"
+    key = ${?GET_ADDRESS_API_KEY}
+}
 
 play.crypto.secret="test"


### PR DESCRIPTION
Follow up to: https://github.com/guardian/subscriptions-frontend/pull/1186

This ensures that we are using the same API key that is used by the production app. We store it in a private environment variable in Travis.