### PR TITLE
Fix broken build

### DIFF
--- a/test/acceptance/GetAddressIOServiceTest.scala
+++ b/test/acceptance/GetAddressIOServiceTest.scala
@@ -9,9 +9,8 @@ import scala.concurrent.duration._
 
 class GetAddressIOServiceTest extends FreeSpec with Matchers {
 
-  val getAddressIOService: GetAddressIOService = new GetAddressIOService()
-
 	"getAddressIOService should successfully retrieve a correct postcode'" taggedAs AcceptanceTest in {
+    val getAddressIOService: GetAddressIOService = new GetAddressIOService()
     noException should be thrownBy Await.result(getAddressIOService.find("N1 9AG"), 2.seconds)
 	}
 

--- a/test/acceptance/conf/acceptance-test.conf
+++ b/test/acceptance/conf/acceptance-test.conf
@@ -1,4 +1,5 @@
 include "DEV.public"
+include "getAddressIO.conf"
 
 // Travis CI environmental variables that override DEV.conf with PROD values
 stage=${?STAGE}
@@ -9,9 +10,6 @@ identity {
 subscriptions.url= ${?SUBSCRIPTIONS_URL}
 webDriverRemoteUrl = ${?WEBDRIVER_REMOTE_URL}
 
-get-address-io-api {
-    url = "https://api.getAddress.io/v2/uk/"
-    key = ${?GET_ADDRESS_API_KEY}
-}
+get-address-io-api.key = ${?GET_ADDRESS_API_KEY}
 
 play.crypto.secret="test"


### PR DESCRIPTION
My previous change (https://github.com/guardian/subscriptions-frontend/pull/1192) broke the TeamCity build, and meant that the Acceptance Tests would not run locally.

This fixes those issues.