### PR TITLE
Update regional email addresses for Weekly page footers

### DIFF
--- a/app/views/support/ContactCentreOps.scala
+++ b/app/views/support/ContactCentreOps.scala
@@ -45,10 +45,10 @@ object ContactCentreOps {
   def email = "subscriptions@theguardian.com"
 
   def weeklyEmail(contactUsCountry: Option[Country]): String = {
-    if (contactUsCountry exists countriesHandledByAUCallCentre) {
-      "apac.help@theguardian.com"
-    } else {
-      "gwsubs@theguardian.com"
+    contactUsCountry match {
+      case c: Some[Country] if c exists countriesHandledByAUCallCentre => "apac.help@theguardian.com"
+      case c: Some[Country] if c exists countriesHandledByUSCallCentre => "northamerica.help@theguardian.com"
+      case _ => "customer.help@theguardian.com"
     }
   }
 }


### PR DESCRIPTION
As per this [trello card](https://trello.com/c/HMOx07Zx/2026-footer-contact-detail-updates-for-gw), we have new email addresses to display in Guardian Weekly page footers for US and RoW support routes.

This PR replaces the old with the new.

Countries affected: US, CA, UK, RoW. AU and NZ were previously updated by https://github.com/guardian/subscriptions-frontend/pull/1182

**Screenshots**
**Before**
*US/CA*:
![screen shot 2018-10-18 at 16 43 11](https://user-images.githubusercontent.com/690395/47167027-74036480-d2f5-11e8-99c3-268849ca6e7c.png)

*UK/RoW*:
![screen shot 2018-10-18 at 16 43 49](https://user-images.githubusercontent.com/690395/47167043-7d8ccc80-d2f5-11e8-8055-a0af46cc3b60.png)

*AU/NZ*:
![screen shot 2018-10-18 at 16 44 24](https://user-images.githubusercontent.com/690395/47167063-8a112500-d2f5-11e8-8003-c1cc6a4573f9.png)

**After**
*US/CA*:
![screen shot 2018-10-18 at 16 48 57](https://user-images.githubusercontent.com/690395/47167152-bd53b400-d2f5-11e8-9928-cd903df9a353.png)

*UK/RoW*:
![screen shot 2018-10-18 at 16 50 51](https://user-images.githubusercontent.com/690395/47167280-00158c00-d2f6-11e8-9b83-f9eb2df37a92.png)

*AU/NZ*:
![screen shot 2018-10-18 at 16 49 47](https://user-images.githubusercontent.com/690395/47167226-e411ea80-d2f5-11e8-9659-4c32e81858a2.png)


