### PR TITLE
Update footer for all checkouts.

### DIFF
--- a/app/views/fragments/global/footer.scala.html
+++ b/app/views/fragments/global/footer.scala.html
@@ -18,13 +18,13 @@
             By proceeding, you are agreeing to our
             <a href="@maybeProduct.getOrElse(Digipack).termsAndConditionsHref"
                 title="Terms and Conditions">
-                Terms and Conditions
-            </a>.
+                Terms and Conditions.
+            </a>
                 To find out what personal data we collect and how we use it, please visit our
                 <a href="https://www.theguardian.com/help/privacy-policy"
                     title="Privacy Policy">
-                    Privacy Policy
-                </a>.
+                    Privacy Policy.
+                </a>
             <p>
               For help with Guardian and Observer subscription services please email
                   <a href="mailto:@email">@email</a> or call @phone

--- a/app/views/fragments/global/footer.scala.html
+++ b/app/views/fragments/global/footer.scala.html
@@ -15,6 +15,16 @@
 
     <div class="global-footer__info">
         <div class="gs-container">
+            By proceeding, you are agreeing to our
+            <a href="@maybeProduct.getOrElse(Digipack).termsAndConditionsHref"
+                title="Terms and Conditions">
+                Terms and Conditions
+            </a>.
+                To find out what personal data we collect and how we use it, please visit our
+                <a href="https://www.theguardian.com/help/privacy-policy"
+                    title="Privacy Policy">
+                    Privacy Policy
+                </a>.
             <p>
               For help with Guardian and Observer subscription services please email
                   <a href="mailto:@email">@email</a> or call @phone
@@ -23,8 +33,13 @@
                 You may also find help in our
                 <a href="@maybeProduct.getOrElse(Digipack).faqHref"
                    title="Frequently Asked Questions">
-                   Frequently Asked Questions.
+                   Frequently Asked Questions
                 </a>
+                and the @maybeProduct.getOrElse(Digipack).productType
+                    <a href="@maybeProduct.getOrElse(Digipack).termsAndConditionsHref"
+                title="Terms and Conditions">
+                    Terms and Conditions
+                </a>.
             </p>
             <small class="global-footer__copyright">
                 &copy; @{new DateTime().year.getAsText} Guardian News and Media Limited or its affiliated companies.

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -126,6 +126,15 @@ object PlanOps {
         case _ => "https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
       }
 
+    def termsAndConditionsHref: String =
+      product match {
+        case Delivery => "delivery link"
+        case Voucher => "voucher link"
+        case Product.Digipack => "https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions"
+        case _: Product.Weekly => "https://www.theguardian.com/info/2014/jul/10/guardian-weekly-print-subscription-services-terms-conditions"
+        case _ => "Sensible default"
+      }
+
     def phone(contactUsCountry: Option[Country]): String = ContactCentreOps.phone(contactUsCountry)
 
     def productType: String = product match {

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -128,11 +128,9 @@ object PlanOps {
 
     def termsAndConditionsHref: String =
       product match {
-        case Delivery => "https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions"
-        case Voucher => "https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions"
         case Product.Digipack => "https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions"
         case _: Product.Weekly => "https://www.theguardian.com/info/2014/jul/10/guardian-weekly-print-subscription-services-terms-conditions"
-        case _ => "Sensible default" //TODO
+        case _ => "https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions"
       }
 
     def phone(contactUsCountry: Option[Country]): String = ContactCentreOps.phone(contactUsCountry)

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -128,11 +128,11 @@ object PlanOps {
 
     def termsAndConditionsHref: String =
       product match {
-        case Delivery => "delivery link"
-        case Voucher => "voucher link"
+        case Delivery => "https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions"
+        case Voucher => "https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions"
         case Product.Digipack => "https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions"
         case _: Product.Weekly => "https://www.theguardian.com/info/2014/jul/10/guardian-weekly-print-subscription-services-terms-conditions"
-        case _ => "Sensible default"
+        case _ => "Sensible default" //TODO
       }
 
     def phone(contactUsCountry: Option[Country]): String = ContactCentreOps.phone(contactUsCountry)


### PR DESCRIPTION
Just picking up from Luke's PR https://github.com/guardian/subscriptions-frontend/pull/1191 but making it more product specific.

Re: the links, I've put in a link to the privacy policy as https://www.theguardian.com/help/privacy-policy, assuming it is the same for all products. 

existing footer:
![image](https://user-images.githubusercontent.com/3072877/47230609-97e0ac00-d3c2-11e8-9f5a-1ed719113af0.png)

updated footer:
![image](https://user-images.githubusercontent.com/3072877/47230565-75e72980-d3c2-11e8-96f9-e4e89af5e2ad.png)

This also adds a privacy policy and T&C link to the other products (Home Delivery, Voucher, Guardian Weekly). I've got a Q about the reference to T&Cs below. 