### PR TITLE
Upgrade acquisition-event-producer library & make it easier to test

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -106,6 +106,8 @@ object Config {
 
   val googleAnalyticsTrackingId = config.getString("google.analytics.tracking.id")
 
+  val analyticsOnInDev = config.getBoolean("analytics.onInDev")
+
   val suspendableWeeks = 6
 
   val getAddressIOApiUrl = config.getString("get-address-io-api.url")

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -306,8 +306,8 @@ class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions
           request.remoteAddress
         )
 
-        //This service is mocked unless it's running in PROD, change to test acquisition events are working
-        AcquisitionService(isTestService = tpBackend.environmentName != "PROD")
+        //This service is mocked unless it's running in PROD or analytics.onInDev=true in application.config
+        AcquisitionService(tpBackend.environmentName)
           .submit(SubscriptionAcquisitionComponents(subscribeRequest, promotion, acquisitionData, clientBrowserInfo))
           .leftMap(
             err => logger.warn(s"Error submitting acquisition data. $err")

--- a/app/services/AcquisitionService.scala
+++ b/app/services/AcquisitionService.scala
@@ -1,15 +1,17 @@
 package services
 
+import com.gu.acquisition.services.MockAcquisitionService
 import com.gu.okhttp.RequestRunners
+import configuration.Config
 
 object AcquisitionService {
 
   private val prodService = com.gu.acquisition.services.AcquisitionService.prod(RequestRunners.client)
 
-  def apply(isTestService: Boolean): com.gu.acquisition.services.AcquisitionService =
-    if (isTestService) {
-      com.gu.acquisition.services.MockAcquisitionService
-    } else {
+  def apply(environmentName: String): com.gu.acquisition.services.AcquisitionService =
+    if(environmentName == "PROD" || environmentName == "DEV" && Config.analyticsOnInDev) {
       prodService
+    } else {
+      MockAcquisitionService
     }
 }

--- a/app/views/fragments/javascriptFirstSteps.scala.html
+++ b/app/views/fragments/javascriptFirstSteps.scala.html
@@ -13,6 +13,7 @@
 <script id="gu">
     var guardian = JSON.parse('@Html(Json.stringify(Json.toJson(jsVars)))');
     guardian.analyticsEnabled = true;
+    guardian.analyticsEnabledInDev = @Config.analyticsOnInDev;
     guardian.buildNumber = '@app.BuildInfo.buildNumber';
     guardian.isDev = @(Config.stage == "DEV");
     guardian.supplierCode = '';

--- a/assets/javascripts/modules/analytics/analyticsEnabled.js
+++ b/assets/javascripts/modules/analytics/analyticsEnabled.js
@@ -7,7 +7,7 @@ define([
         window.guardian.analyticsEnabled &&
         !cookie.getCookie('ANALYTICS_OFF_KEY') &&
         !window.guardian.isDev
-    );
+    ) || window.guardian.analyticsEnabledInDev;
 
     return function (cb) {
         return function () {

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.4",
     "com.gu" %% "tip" % "0.1.1",
-    "com.gu" %% "acquisition-event-producer-play26" % "4.0.7",
+    "com.gu" %% "acquisition-event-producer-play26" % "4.0.8",
     "com.github.nscala-time" %% "nscala-time" % "2.16.0",
     "io.sentry" % "sentry-logback" % "1.7.5",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -30,7 +30,7 @@ qa {
 aws.queue.welcome-email = "subs-welcome-email-dev"
 aws.queue.holiday-suspension-email = "subs-holiday-suspension-email-dev"
 
-google.analytics.tracking.id="UA-33592456-4"
+google.analytics.tracking.id = "UA-51507017-5"
 
 stripe.checkout.flag = true
 

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -30,7 +30,7 @@ qa {
 aws.queue.welcome-email = "subs-welcome-email"
 aws.queue.holiday-suspension-email = "subs-holiday-suspension-email"
 
-google.analytics.tracking.id="UA-33592456-4"
+google.analytics.tracking.id = "UA-51507017-5"
 
 stripe.checkout.flag = true
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -65,5 +65,7 @@ play.filters.csrf {
     contentType.blackList = ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"]
 }
 
+analytics.onInDev = false
+
 include "getAddressIO.conf"
 include file("/etc/gu/subscriptions-frontend.private.conf")


### PR DESCRIPTION
This PR upgrades to the latest version of acquisition-event-producer which has a fix for the GA client/server data linking issue. 

It also adds a switch to make it easy to turn tracking on in DEV for test purposes, previously this involved changing a number of files and then remembering to revert the changes before committing.