### PR TITLE
remove Saturday pack from paper packs

### DIFF
--- a/app/controllers/Shipping.scala
+++ b/app/controllers/Shipping.scala
@@ -44,7 +44,7 @@ class Shipping(touchpointBackend: TouchpointBackend, commonActions: CommonAction
         title = "Paper voucher subscription",
         description = "Save money on your newspapers.",
         altPackagePath = s"/delivery/$segment",
-        options = catalog.voucher.list.toList.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse
+        options = catalog.voucher.list.toList.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse.filterNot(_.title.toLowerCase == "saturday")
       ), segment)
     }
   }
@@ -70,7 +70,7 @@ class Shipping(touchpointBackend: TouchpointBackend, commonActions: CommonAction
         title = "Paper home delivery subscription",
         description = "If you live within the M25 you can have your papers delivered by 7am Monday - Saturday and 8.30 on Sunday.",
         altPackagePath = s"/collection/$segment",
-        options = catalog.delivery.list.toList.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse
+        options = catalog.delivery.list.toList.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse.filterNot(_.title.toLowerCase == "saturday")
       ), segment)
     }
   }


### PR DESCRIPTION
Remove Saturday from paper delivery and collection packs to test its effect on other offerings.

This is in lieu of an upcoming AB test to assess the value of the Saturday offering and will be reverted in a week.