### PR TITLE
trim DOW

### DIFF
--- a/app/controllers/Shipping.scala
+++ b/app/controllers/Shipping.scala
@@ -44,7 +44,7 @@ class Shipping(touchpointBackend: TouchpointBackend, commonActions: CommonAction
         title = "Paper voucher subscription",
         description = "Save money on your newspapers.",
         altPackagePath = s"/delivery/$segment",
-        options = catalog.voucher.list.toList.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse.filterNot(_.title.toLowerCase == "saturday")
+        options = catalog.voucher.list.toList.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse.filterNot(_.title.toLowerCase.trim == "saturday")
       ), segment)
     }
   }
@@ -70,7 +70,7 @@ class Shipping(touchpointBackend: TouchpointBackend, commonActions: CommonAction
         title = "Paper home delivery subscription",
         description = "If you live within the M25 you can have your papers delivered by 7am Monday - Saturday and 8.30 on Sunday.",
         altPackagePath = s"/collection/$segment",
-        options = catalog.delivery.list.toList.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse.filterNot(_.title.toLowerCase == "saturday")
+        options = catalog.delivery.list.toList.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse.filterNot(_.title.toLowerCase.trim == "saturday")
       ), segment)
     }
   }


### PR DESCRIPTION
Currently, we have `Saturday ` as the `title` for Saturday paper delivery. Not sure how/why yet, this will get us working whilst investigating.

Relates to https://github.com/guardian/subscriptions-frontend/pull/1203, which was all working fine in CODE too!