### PR TITLE
Annualised value tracking

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -306,7 +306,7 @@ class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions
           request.remoteAddress
         )
 
-        //This service is mocked unless it's running in PROD or analytics.onInDev=true in application.config
+        //This service is mocked in DEV unless analytics.onInDev=true in application.config
         AcquisitionService(tpBackend.environmentName)
           .submit(SubscriptionAcquisitionComponents(subscribeRequest, promotion, acquisitionData, clientBrowserInfo))
           .leftMap(

--- a/app/services/AcquisitionService.scala
+++ b/app/services/AcquisitionService.scala
@@ -9,9 +9,9 @@ object AcquisitionService {
   private val prodService = com.gu.acquisition.services.AcquisitionService.prod(RequestRunners.client)
 
   def apply(environmentName: String): com.gu.acquisition.services.AcquisitionService =
-    if(environmentName == "PROD" || environmentName == "DEV" && Config.analyticsOnInDev) {
-      prodService
-    } else {
+    if(environmentName == "DEV" && !Config.analyticsOnInDev) {
       MockAcquisitionService
+    } else {
+      prodService
     }
 }

--- a/app/views/fragments/javascriptFirstSteps.scala.html
+++ b/app/views/fragments/javascriptFirstSteps.scala.html
@@ -18,10 +18,11 @@
     guardian.optimizeEnabled = @Config.optimizeEnabled;
     guardian.buildNumber = '@app.BuildInfo.buildNumber';
     guardian.isDev = @(Config.stage == "DEV");
+    guardian.stage = '@Config.stage'
     guardian.supplierCode = '';
     guardian.googleAnalytics = {
         trackingId: '@Config.googleAnalyticsTrackingId',
-        cookieDomain: @if(Config.stage == "PROD") { 'auto' } else { 'none' }
+        cookieDomain: @if(Config.stage == "DEV") { 'none' } else { 'auto' }
     };
     guardian.isModernBrowser = (
         'querySelector' in document

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.4",
     "com.gu" %% "tip" % "0.1.1",
-    "com.gu" %% "acquisition-event-producer-play26" % "4.0.8",
+    "com.gu" %% "acquisition-event-producer-play26" % "4.0.11",
     "com.github.nscala-time" %% "nscala-time" % "2.16.0",
     "io.sentry" % "sentry-logback" % "1.7.5",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
@@ -93,6 +93,7 @@ resolvers ++= Seq(
     "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-snapshots",
     "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
     Resolver.sonatypeRepo("releases"),
+    Resolver.sonatypeRepo("snapshots"),
     Resolver.bintrayRepo("guardian", "ophan")
 )
 

--- a/cloud-formation/subscriptions-app.cf.yaml
+++ b/cloud-formation/subscriptions-app.cf.yaml
@@ -180,6 +180,12 @@ Resources:
           - Effect: Allow
             Action: sqs:*
             Resource: arn:aws:sqs:eu-west-1:865473395570:subs-holiday-suspension-email*
+      - PolicyName: InvokeAVLambda
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Resource: arn:aws:iam::021353022223:role/support-invoke-value-calculator
       ManagedPolicyArns:
       - !Sub arn:aws:iam::${AWS::AccountId}:policy/guardian-ec2-role-for-ssm
   SubscriptionsAppInstanceProfile:

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -1,14 +1,14 @@
-include "touchpoint.DEV.conf"
+include "touchpoint.CODE.conf"
 include "touchpoint.UAT.conf"
 
-stage = "DEV"
+stage = "CODE"
 
 identity {
   baseUri = "https://idapi.code.dev-theguardian.com"
   production.keys=false
   webapp.url="https://profile.code.dev-theguardian.com"
   test.users.secret="a-non-secure-key-for-our-dev-env-only"
-  sessionDomain="dev-theguardian.com"
+  sessionDomain=".dev-theguardian.com"
 }
 
 

--- a/conf/touchpoint.CODE.conf
+++ b/conf/touchpoint.CODE.conf
@@ -1,0 +1,34 @@
+# ***NO PRIVATE CREDENTIALS IN THIS FILE *** - use subscriptions-frontend in S3 for private data
+touchpoint.backend.environments {
+    CODE {
+        salesforce {
+            consumer {
+                key = ""
+                secret = ""
+            }
+            api {
+                url = "https://test.salesforce.com"
+                username = ""
+                password = ""
+                token = ""
+            }
+        }
+        zuora {
+            paymentDelayInDays = 14
+            paymentDelayGracePeriod = 2
+            api {
+                username = ""
+                password = ""
+            }
+        }
+        stripe {
+            api.key {
+                secret = ""
+                public = "pk_test_Qm3CGRdrV4WfGYCpm0sftR0f"
+            }
+        }
+        gocardless {
+            token = ""
+        }
+    }
+}


### PR DESCRIPTION
Upgrade the `acquisition-event-producer` library to start sending Annualised Value to GA in the Ecommerce revenue metric.

While testing this I noticed that the configuration for the CODE environment was a bit messed up so there are some fixes for that as well.