### PR TITLE
Handle promocodes on the /weekly endpoint

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -31,9 +31,12 @@ import org.joda.time.LocalDate
 import play.api.data.Form
 import play.api.libs.json._
 import play.api.mvc._
+import scalaz.std.scalaFuture._
+import scalaz.{NonEmptyList, OptionT}
 import services.AuthenticationService.authenticatedUserFor
 import services._
 import utils.RequestCountry._
+import utils.TestUsers
 import utils.TestUsers.{NameEnteredInForm, PreSigninTestCookie}
 import views.html.{checkout => view}
 import views.support.{PlanList, BillingPeriod => _, _}
@@ -41,9 +44,6 @@ import views.support.{PlanList, BillingPeriod => _, _}
 import scala.Function.const
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
-import scalaz.std.scalaFuture._
-import scalaz.{NonEmptyList, OptionT}
-import utils.TestUsers
 
 class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions, implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
 
@@ -179,7 +179,6 @@ class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions
 
   def handleCheckout = NoCacheAction.async { implicit request =>
 
-    //there's an annoying circular dependency going on here
     val tempData = SubscriptionsForm.subsForm.bindFromRequest().value
     implicit val resolution: TouchpointBackends.Resolution = fBackendFactory.forRequest(NameEnteredInForm, tempData)
     implicit val tpBackend = resolution.backend

--- a/conf/routes
+++ b/conf/routes
@@ -36,7 +36,7 @@ GET         /collection/paper-digital        controllers.Shipping.viewCollection
 GET         /collection/paper                controllers.Shipping.viewCollectionPaper
 GET         /delivery/paper-digital          controllers.Shipping.viewDeliveryPaperDigital
 GET         /delivery/paper                  controllers.Shipping.viewDeliveryPaper
-GET         /weekly                          controllers.WeeklyLandingPage.index(country: Option[Country])
+GET         /weekly                          controllers.WeeklyLandingPage.index(country: Option[Country], promoCode: Option[PromoCode])
 GET         /weekly/:country                 controllers.WeeklyLandingPage.withCountry(country: String)
 
 # Staff signin (note, done by OAuth, in addition to regular signin)


### PR DESCRIPTION
To be able to run a [redirect test](https://support.google.com/optimize/answer/6361119?hl=en) on the Guardian Weekly page we need one canonical url that we can redirect to, however the current GW page is a promo page with multiple different urls depending on the source of the traffic. This PR will allow us to send users to `/weekly?promoCode=[some promocode]` and have them still end up at the correct promo code page.