### PR TITLE
Temporarily extend 6 for 6 plan to cover 7 weeks

### DIFF
--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -101,7 +101,7 @@ class CheckoutService(
           ),
           RatePlan(recurringPlan.id.get, None)
         )
-        val updatedContractAcceptance = sixWeeksPlanStartDate.plusWeeks(6)
+        val updatedContractAcceptance = sixWeeksPlanStartDate.plusWeeks(7) // FIXME: edit rate plan charge in Zuora and make this 6 again after 28th December
         originalCommand.copy(ratePlans = replacementPlans, contractAcceptance = updatedContractAcceptance)
       }
       updatedCommand.getOrElse(originalCommand)

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= Seq(
     filters,
     jodaForms,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.526",
+    "com.gu" %% "membership-common" % "0.1-SNAPSHOT",
     "com.gu.identity" %% "identity-play-auth" % "2.5",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.6",

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= Seq(
     filters,
     jodaForms,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.1-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.527",
     "com.gu.identity" %% "identity-play-auth" % "2.5",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.6",


### PR DESCRIPTION
We will not publish a Guardian Weekly magazine on 28th December, so as things stand we are actually selling 6 for 5. 

This change allows us to extend the 6 for 6 fulfilment period in order to correct this problem.

Note that I am planning to take the following steps to facilitate this change:

1. Update membership-common for all apps which use the catalog service, to pick up: https://github.com/guardian/membership-common/pull/585
1. Update catalog (all environments)
1. Merge this PR

If anybody signs up for 6 for 6 between steps 2 and 3 they will end up getting two magazines on the date of their 7th issue. As the likelihood of this happening is pretty small I think it's acceptable to introduce this bug briefly.

More context:
https://trello.com/c/2aCynmAW/2103-change-6-for-6-promo-to-give-7-issues-to-cover-missing-issue-over-christmas
https://trello.com/c/Img8mLoX/222-implement-workaround-for-guardian-weekly-6-for-6-fulfilment-issue-currently-due-to-affect-users-on-28th-december