### PR TITLE
Prevent users from selecting 28th December as their first delivery date

### DIFF
--- a/assets/javascripts/modules/checkout/planDateFilter.jsx
+++ b/assets/javascripts/modules/checkout/planDateFilter.jsx
@@ -23,7 +23,7 @@ define([
                 weekend: (date) => date.day() === 6 || date.day() === 0,
                 allDays: () => true
             },
-            weekly: (date) => date.day() === 5
+            weekly: (date) => date.day() === 5 && !date.isSame('2018-12-28')
         };
 
         let filters = validDays[deliveredProduct];


### PR DESCRIPTION
There's no magazine on 28th Dec, so we shouldn't allow users to select it as their first delivery date:

![image](https://user-images.githubusercontent.com/19384074/49434122-5efe6a00-f7ab-11e8-8471-f2375554c39e.png)
