### PR TITLE
Gifting for guardian weekly

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -63,10 +63,11 @@ object SessionSubscription extends StrictLogging {
       salesForceUser <- OptionT(tpBackend.salesforceService.repo.get(identityUser.user.id).map { d =>
         d.leftMap(e => logger.warn(s"Error looking up SF Contact for logged in user with Identity ID ${identityUser.user.id}: $e")).toOption.flatten
       })
-      zuoraSubscription <- OptionT(tpBackend.subscriptionService.current[ContentSubscription](salesForceUser).map{subs =>
+      /* TODO: If a user has more than one Billing Account, prioritise their non-gift subs, or create an interstitial page where they can choose which sub to manage */
+      zuoraSubscription <- OptionT(tpBackend.subscriptionService.current[ContentSubscription](salesForceUser).map { subs =>
         if (subs.length > 1) logger.warn(s"Logged in user with Identity ID ${identityUser.user.id}: with ${subs.length} subscriptions, only serving first.")
         subs.headOption
-        /*FIXME if they have more than one they can only manage the first*/})
+      })
     } yield zuoraSubscription).run
   }
 

--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -152,7 +152,7 @@ class Checkout(fBackendFactory: TouchpointBackends, commonActions: CommonActions
 
           val resolvedSupplierCode = supplierCode orElse request.session.get(SupplierTrackingCode).map(SupplierCode) // query param wins
           val supplierCodeSessionData = resolvedSupplierCode.map(code => Seq(SupplierTrackingCode -> code.get)).getOrElse(Seq.empty)
-          val productData = ProductPopulationData(user.map(_.address), planList)
+          val productData = ProductPopulationData(user.map(_.correspondenceAddress), planList)
           Ok(views.html.checkout.payment(
             personalData = personalData,
             productData = productData,

--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -161,9 +161,9 @@ object SubscriptionsForm {
 
   val deliveryRecipientMapping = mapping(
     "title"-> of(titleFormatter),
-    "first" -> text(0, nameMaxLength),
-    "last" -> text(0, nameMaxLength),
-    "email" -> email.verifying("This email is too long", _.length < emailMaxLength + 1),
+    "firstName" -> optional(text(0, nameMaxLength)),
+    "lastName" -> optional(text(0, nameMaxLength)),
+    "email" -> optional(email.verifying("This email is too long", _.length < emailMaxLength + 1)),
     "address" -> addressDataMapping
   )(DeliveryRecipient.apply)(DeliveryRecipient.unapply)
 
@@ -181,7 +181,7 @@ object SubscriptionsForm {
     "last" -> text(0, nameMaxLength),
     "emailValidation" -> emailMapping,
     "receiveGnmMarketing" -> booleanCheckbox,
-    "address" -> of[Address](addressWithFallback("delivery")),
+    "address" -> of[Address](addressWithFallback("delivery.address")),
     "telephoneNumber" -> optional(text),
     "title"-> of(titleFormatter)
   )(PersonalData.apply)(PersonalData.unapply)

--- a/app/forms/SubscriptionsForm.scala
+++ b/app/forms/SubscriptionsForm.scala
@@ -45,7 +45,7 @@ class SubscriptionsForm(catalog: Catalog) {
 
   val paperForm = Form(mapping(
     "startDate" -> jodaLocalDate("EEEE d MMMM y"),
-    "delivery" -> addressDataMapping,
+    "delivery" -> deliveryRecipientMapping,
     "deliveryInstructions" -> optional(text(0, 250)),
     "ratePlanId" -> of[CatalogPlan.Paper]
   )(PaperData.apply)(PaperData.unapply))
@@ -80,7 +80,7 @@ class SubscriptionsForm(catalog: Catalog) {
     } yield (countrySettings)
 
     val deliveryCountrySettings = for {
-      country <- paperData.deliveryAddress.country
+      country <- paperData.deliveryRecipient.address.country
       validDeliveryCountries <- localizationSettings.availableDeliveryCountriesWithCurrency
       countrySettings <- validDeliveryCountries.find(_.country == country)
     } yield (countrySettings)
@@ -157,6 +157,15 @@ object SubscriptionsForm {
     "country" -> countryName
   )(Address.apply)(Address.unapply)
     .verifying("address validation failed", AddressValidation.validateForCountry _)
+
+
+  val deliveryRecipientMapping = mapping(
+    "title"-> of(titleFormatter),
+    "first" -> text(0, nameMaxLength),
+    "last" -> text(0, nameMaxLength),
+    "email" -> email.verifying("This email is too long", _.length < emailMaxLength + 1),
+    "address" -> addressDataMapping
+  )(DeliveryRecipient.apply)(DeliveryRecipient.unapply)
 
   val emailMapping = tuple(
     "email" -> email.verifying("This email is too long", _.length < emailMaxLength + 1),

--- a/app/model/IdUserOps.scala
+++ b/app/model/IdUserOps.scala
@@ -18,7 +18,7 @@ object IdUserOps {
         )
     }
 
-    def address: Address = {
+    def correspondenceAddress: Address = {
       val pf = u.privateFields.getOrElse(PrivateFields())
         Address(
           lineOne = pf.address1.getOrElse(""),

--- a/app/model/PurchaserIdentifiers.scala
+++ b/app/model/PurchaserIdentifiers.scala
@@ -3,7 +3,15 @@ package model
 import com.gu.identity.play.IdMinimalUser
 import com.gu.salesforce.ContactId
 
-case class PurchaserIdentifiers(contactId: ContactId, identityId: Option[IdMinimalUser]) {
-  val description = (Seq(s"SalesforceContactID - ${contactId.salesforceContactId}") ++ identityId.map(id => s"IdentityID - $id")).mkString(" ")
+case class PurchaserIdentifiers(buyerContactId: ContactId, recipientContactId: ContactId, identityId: Option[IdMinimalUser]) {
+  val description = s"""
+      |Salesforce data: Account: ${buyerContactId.salesforceAccountId},
+      |Buyer Contact: ${buyerContactId.salesforceContactId},
+      |Recipient Contact: ${recipientContactId.salesforceContactId},
+      |Identity ID: ${identityId.map(_.id).mkString},
+      |Is gift? ${isGift}
+    """.stripMargin.trim
+  val isGift = buyerContactId.salesforceAccountId == recipientContactId.salesforceAccountId &&
+    buyerContactId.salesforceContactId != recipientContactId.salesforceContactId
   override def toString: String = description
 }

--- a/app/model/SubscriptionAcquisitionComponents.scala
+++ b/app/model/SubscriptionAcquisitionComponents.scala
@@ -115,7 +115,7 @@ object SubscriptionAcquisitionComponents {
       }
 
       val printOptions = for {
-        d <- p.deliveryAddress.country.map(_.alpha2)
+        d <- p.deliveryRecipient.address.country.map(_.alpha2)
         p <- printProduct
       } yield PrintOptions(p, d)
 

--- a/app/model/SubscriptionData.scala
+++ b/app/model/SubscriptionData.scala
@@ -43,6 +43,7 @@ case class PersonalData(first: String,
                         telephoneNumber: Option[String] = None,
                         title: Option[Title] = None
                         ) extends FullName {
+
   def fullName = s"$first $last"
 
   private lazy val countryGroup = CountryGroup.byCountryNameOrCode(address.country.fold(UK.alpha2)(c => c.alpha2))
@@ -81,8 +82,8 @@ object PersonalData {
 
     val personalData = PersonalData(
       title = u.privateFields.flatMap(_.title).flatMap(Title.fromString),
-      first = u.privateFields.flatMap(_.firstName).getOrElse(""),
-      last = u.privateFields.flatMap(_.secondName).getOrElse(""),
+      first = u.privateFields.flatMap(_.firstName).mkString,
+      last = u.privateFields.flatMap(_.secondName).mkString,
       email = u.primaryEmailAddress,
       receiveGnmMarketing = u.statusFields.flatMap(_.receiveGnmMarketing).getOrElse(false),
       address = u.billingAddress,
@@ -95,4 +96,10 @@ object PersonalData {
 
 case class SubscribeRequest(genericData: SubscriptionData, productData: Either[PaperData, DigipackData]) {
   def productRatePlanId = productData.fold(_.plan.id, _.plan.id)
+}
+
+case class DeliveryRecipient(title: Option[Title], firstName: Option[String], lastName: Option[String], email: Option[String], address: Address) extends FullName {
+  val first = firstName.mkString
+  val last = lastName.mkString
+  val isGiftee = (Seq() ++ title.map(_.title) ++ firstName ++ lastName ++ email).exists(_.trim.nonEmpty)
 }

--- a/app/model/SubscriptionData.scala
+++ b/app/model/SubscriptionData.scala
@@ -64,7 +64,7 @@ case class DigipackData(
 
 case class PaperData(
   startDate: LocalDate,
-  deliveryAddress: Address,
+  deliveryRecipient: DeliveryRecipient,
   deliveryInstructions: Option[String],
   plan: CatalogPlan.Paper
 ) {

--- a/app/model/exactTarget/DataExtensionRow.scala
+++ b/app/model/exactTarget/DataExtensionRow.scala
@@ -124,7 +124,7 @@ object PaperFieldsGenerator {
                ): Seq[(String, String)] = {
 
     fieldsFor(
-      deliveryAddress = paperData.deliveryAddress,
+      deliveryAddress = paperData.deliveryRecipient.address,
       maybeBillingAddress = Some(personalData.address),
       includesDigipack = paperData.plan.charges.benefits.list.toList.contains(Digipack),
       email = personalData.email,

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -194,7 +194,7 @@ class ExactTargetService(
 
     val enqueueResult = for {
       zuoraAccount <- EitherT(zuoraRestService.getAccount(subscription.accountId))
-      salesforceContact <- EitherT.right(SalesforceContactServiceUsingZuoraRest.getBuyerContactForZuoraRestAccount(zuoraAccount)(zuoraRestService, salesforceService.repo, executionContext))
+      salesforceContact <- EitherT.right(SalesforceContactServiceUsingZuoraRest.getBuyerContactForZuoraAccount(zuoraAccount)(salesforceService.repo, executionContext))
       row = createDataExtensionRow(salesforceContact, zuoraAccount)
       result <- EitherT(sendToQueue(salesforceContact, row))
     } yield result

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -8,7 +8,7 @@ import com.gu.aws.CredentialsProvider
 import com.gu.memsub.Subscription._
 import com.gu.memsub.promo.Promotion._
 import com.gu.memsub.promo._
-import com.gu.memsub.services.{GetSalesforceContactForSub, PaymentService => CommonPaymentService}
+import com.gu.memsub.services.{SalesforceContactServiceUsingZuoraRest, PaymentService => CommonPaymentService}
 import com.gu.memsub.subsv2.reads.ChargeListReads._
 import com.gu.memsub.subsv2.reads.SubPlanReads._
 import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan => Plan}
@@ -154,7 +154,7 @@ class ExactTargetService(
 
     for {
       row <- buildWelcomeEmailDataExtensionRow(subscribeResult, subscriptionData, gracePeriod, validPromotion, purchaserIds)
-      response <- SqsClient.sendDataExtensionToQueue(Config.welcomeEmailQueue, row, SFContactId(purchaserIds.contactId.salesforceContactId))
+      response <- SqsClient.sendDataExtensionToQueue(Config.welcomeEmailQueue, row, SFContactId(purchaserIds.buyerContactId.salesforceContactId))
     } yield {
       response match {
         case Success(sendMsgResult) => logger.info(s"Successfully enqueued ${subscribeResult.subscriptionName} welcome email for user ${purchaserIds.identityId}.")
@@ -193,8 +193,8 @@ class ExactTargetService(
     }
 
     val enqueueResult = for {
-      salesforceContact <- EitherT.right(GetSalesforceContactForSub(subscription)(zuoraService, salesforceService.repo, executionContext))
       zuoraAccount <- EitherT(zuoraRestService.getAccount(subscription.accountId))
+      salesforceContact <- EitherT.right(SalesforceContactServiceUsingZuoraRest.getBuyerContactForZuoraRestAccount(zuoraAccount)(zuoraRestService, salesforceService.repo, executionContext))
       row = createDataExtensionRow(salesforceContact, zuoraAccount)
       result <- EitherT(sendToQueue(salesforceContact, row))
     } yield result

--- a/app/services/PaymentService.scala
+++ b/app/services/PaymentService.scala
@@ -18,7 +18,7 @@ class PaymentService(val ukStripeService: StripeService, val auStripeService: St
 
   case class ZuoraAccountDirectDebit(paymentData: DirectDebitData, firstName: String, lastName: String, purchaserIds: PurchaserIdentifiers) extends AccountAndPayment {
 
-    override def makeAccount = Account(purchaserIds.contactId, identityIdForAccount(purchaserIds), GBP, autopay = true, GoCardless)
+    override def makeAccount = Account(purchaserIds.recipientContactId, identityIdForAccount(purchaserIds), GBP, autopay = true, GoCardless)
 
     override def makePaymentMethod =
       Future(BankTransfer(
@@ -36,7 +36,7 @@ class PaymentService(val ukStripeService: StripeService, val auStripeService: St
     private val stripeService = if (transactingCountry.contains(auStripeService.accountCountry)) auStripeService else ukStripeService
     private val overrideInvoiceTemplate = invoiceTemplatesByCountry.get(stripeService.accountCountry)
 
-    override def makeAccount = Account(purchaserIds.contactId, identityIdForAccount(purchaserIds), currency, autopay = true, stripeService.paymentGateway, overrideInvoiceTemplate)
+    override def makeAccount = Account(purchaserIds.recipientContactId, identityIdForAccount(purchaserIds), currency, autopay = true, stripeService.paymentGateway, overrideInvoiceTemplate)
 
     override def makePaymentMethod: Future[CreditCardReferenceTransaction] = {
       stripeService.Customer.create(card = paymentData.stripeToken)

--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -60,7 +60,7 @@ object SalesforceService {
   def getJSONForRecipientContact(buyerContact: ContactId, deliveryRecipient: DeliveryRecipient): JsObject = Json.obj(
     Keys.ACCOUNT_ID -> buyerContact.salesforceAccountId,
     Keys.EMAIL -> deliveryRecipient.email,
-    Keys.TITLE -> deliveryRecipient.title.mkString,
+    Keys.TITLE -> deliveryRecipient.title.map(_.title).mkString,
     Keys.FIRST_NAME -> deliveryRecipient.first,
     Keys.LAST_NAME -> deliveryRecipient.last,
     Keys.MAILING_STREET -> deliveryRecipient.address.line,

--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -54,7 +54,7 @@ object SalesforceService {
     Keys.MAILING_CITY -> addr.town,
     Keys.MAILING_POSTCODE -> addr.postCode,
     Keys.MAILING_STATE -> addr.countyOrState,
-  Keys.MAILING_COUNTRY -> addr.country.fold(addr.countryName)(_.name)
+    Keys.MAILING_COUNTRY -> addr.country.fold(addr.countryName)(_.name)
   ) ++ paperData.flatMap(_.sanitizedDeliveryInstructions).fold(Json.obj())(instrs => Json.obj(
     Keys.DELIVERY_INSTRUCTIONS -> instrs
   ))) ++ NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country).fold(Json.obj())(phone => Json.obj(Keys.TELEPHONE -> phone.format))

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -169,7 +169,7 @@
                             <a href="#yourDetails" class="text-button u-button-reset js-edit-your-details" title="Edit your personal details">Edit</a>
                         </div>
                         <div class="field-panel__fields">
-                            @fragments.checkout.fieldsPersonal(personalData)
+                            @fragments.checkout.fieldsPersonal(personalData, productData.isGuardianWeekly)
                             @defining(if(productData.isDigitalPack) "#billingAddress" else "#deliveryDetails") { goto =>
                                 @continueButton(goto, "js-checkout-your-details-submit")
                             }
@@ -184,7 +184,7 @@
                         <div id="deliveryDetails" class="field-panel is-collapsed js-fieldset-delivery-details">
                             <fieldset>
                                 <legend class="field-panel__legend">
-                                    Delivery address
+                                    <span class="js-delivery-details-legend">Delivery address</span>
                                 </legend>
                                 <div class="field-panel__fields">
                                     @if(productData.isVoucher) {

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -169,7 +169,7 @@
                             <a href="#yourDetails" class="text-button u-button-reset js-edit-your-details" title="Edit your personal details">Edit</a>
                         </div>
                         <div class="field-panel__fields">
-                            @fragments.checkout.fieldsPersonal(personalData, productData.isGuardianWeekly && !productData.isSixForSix)
+                            @fragments.checkout.fieldsPersonal(personalData, productSupportsGifting = productData.isGuardianWeekly && !productData.isSixForSix)
                             @defining(if(productData.isDigitalPack) "#billingAddress" else "#deliveryDetails") { goto =>
                                 @continueButton(goto, "js-checkout-your-details-submit")
                             }

--- a/app/views/checkout/payment.scala.html
+++ b/app/views/checkout/payment.scala.html
@@ -169,7 +169,7 @@
                             <a href="#yourDetails" class="text-button u-button-reset js-edit-your-details" title="Edit your personal details">Edit</a>
                         </div>
                         <div class="field-panel__fields">
-                            @fragments.checkout.fieldsPersonal(personalData, productData.isGuardianWeekly)
+                            @fragments.checkout.fieldsPersonal(personalData, productData.isGuardianWeekly && !productData.isSixForSix)
                             @defining(if(productData.isDigitalPack) "#billingAddress" else "#deliveryDetails") { goto =>
                                 @continueButton(goto, "js-checkout-your-details-submit")
                             }

--- a/app/views/fragments/checkout/address.scala.html
+++ b/app/views/fragments/checkout/address.scala.html
@@ -8,7 +8,6 @@
 @import views.support.{ContactCentreOps, CountryWithCurrency}
 @(address: Option[Address], namePrefix: String, countriesWithCurrency: List[CountryWithCurrency], plan: CatalogPlan.Paid, usePostcodeLookup: Boolean, determinesPriceBanding: Boolean, defaultCurrency: Currency)
 
-
 @attrs(field: String) = @{
     Html(s"id='${(namePrefix + "-" + field).replace('.', '-')}' name='$namePrefix.$field'")
 }
@@ -67,7 +66,7 @@
     </div>
     <div class="form-field js-checkout-country">
         <label class="label" @labelFor("country")>Country</label>
-        <select @attrs("country") class=" select select--wide js-country" required>
+        <select @attrs("country") class="select select--wide js-country js-input" required>
             @if(countriesWithCurrency.size > 1) {
                 <option data-currency-choice="@defaultCurrency"></option>
             }

--- a/app/views/fragments/checkout/fieldsBilling.scala.html
+++ b/app/views/fragments/checkout/fieldsBilling.scala.html
@@ -12,7 +12,7 @@
   <div class="js-checkout-use-delivery">
     <label class="option">
       <span class="option__input">
-        <input type="checkbox" class="js-input js-checkout-delivery-sames-as-billing" @billingAddress.forall(_.isEmpty).fold("checked", "")>
+        <input type="checkbox" class="js-input js-checkout-delivery-same-as-billing" @billingAddress.forall(_.isEmpty).fold("checked", "")>
       </span>
       <span class="option__label">
         Bill my delivery address

--- a/app/views/fragments/checkout/fieldsDelivery.scala.html
+++ b/app/views/fragments/checkout/fieldsDelivery.scala.html
@@ -32,9 +32,7 @@
 }
 
 @if(data.plans.default.isGuardianWeekly) {
-    if (!data.plans.default.name.toLowerCase.contains("six")) {
-        @_root_.views.html.fragments.checkout.giftRecipientDetails("delivery")
-    }
+    @_root_.views.html.fragments.checkout.giftRecipientDetails("delivery")
     @renderFields(usePostcodeLookup = false, showDeliveryInstructions = false, productName = "weekly", firstPaperLabel = "Start Issue")
 } else {
     @renderFields(usePostcodeLookup = true, showDeliveryInstructions = true, productName = "paper", firstPaperLabel = "Date of first paper")

--- a/app/views/fragments/checkout/fieldsDelivery.scala.html
+++ b/app/views/fragments/checkout/fieldsDelivery.scala.html
@@ -5,14 +5,14 @@
 @(data: ProductPopulationData, countriesWithCurrency: List[CountryWithCurrency], currency: Currency)
 
 @renderFields(usePostcodeLookup: Boolean, showDeliveryInstructions: Boolean, productName: String, firstPaperLabel: String) = {
-@_root_.views.html.fragments.checkout.address(
-    address = data.deliveryAddress,
-    namePrefix = "delivery",
-    countriesWithCurrency = countriesWithCurrency,
-    plan = data.plans.default,
-    usePostcodeLookup = usePostcodeLookup,
-    determinesPriceBanding = true,
-    defaultCurrency = currency)
+    @_root_.views.html.fragments.checkout.address(
+        address = data.deliveryAddress,
+        namePrefix = "delivery.address",
+        countriesWithCurrency = countriesWithCurrency,
+        plan = data.plans.default,
+        usePostcodeLookup = usePostcodeLookup,
+        determinesPriceBanding = true,
+        defaultCurrency = currency)
 
     <div class="js-checkout-delivery-data" id="deliveryFields">
         @if(showDeliveryInstructions) {
@@ -32,6 +32,7 @@
 }
 
 @if(data.plans.default.isGuardianWeekly) {
+    @_root_.views.html.fragments.checkout.giftRecipientDetails("delivery")
     @renderFields(usePostcodeLookup = false, showDeliveryInstructions = false, productName = "weekly", firstPaperLabel = "Start Issue")
 } else {
     @renderFields(usePostcodeLookup = true, showDeliveryInstructions = true, productName = "paper", firstPaperLabel = "Date of first paper")

--- a/app/views/fragments/checkout/fieldsDelivery.scala.html
+++ b/app/views/fragments/checkout/fieldsDelivery.scala.html
@@ -32,7 +32,9 @@
 }
 
 @if(data.plans.default.isGuardianWeekly) {
-    @_root_.views.html.fragments.checkout.giftRecipientDetails("delivery")
+    if (!data.plans.default.name.toLowerCase.contains("six")) {
+        @_root_.views.html.fragments.checkout.giftRecipientDetails("delivery")
+    }
     @renderFields(usePostcodeLookup = false, showDeliveryInstructions = false, productName = "weekly", firstPaperLabel = "Start Issue")
 } else {
     @renderFields(usePostcodeLookup = true, showDeliveryInstructions = true, productName = "paper", firstPaperLabel = "Date of first paper")

--- a/app/views/fragments/checkout/fieldsPersonal.scala.html
+++ b/app/views/fragments/checkout/fieldsPersonal.scala.html
@@ -1,33 +1,27 @@
 @import com.gu.i18n.Title
 @import model.PersonalData
 
-@(form: Option[PersonalData])
+@(form: Option[PersonalData], productSupportsGifting: Boolean)
 
 @signedInAttrs = @{ if (form.isDefined) "required readonly" else "" }
 
 @* ===== Name ===== *@
 <div class="form-field js-checkout-title">
-    <label class="label" for="title">Title</label>
-    <select class="select select--wide js-input" name="personal.title" id="title"
-    value="@form.map(_.title)" >
-            <option value=""></option>
-    @for(title <- Title.all){
-            <option value="@title.title" @if(form.map(_.title).mkString == title.title){selected} >@title.title</option>
-        }
-            <option value="">Other</option>
-    </select>
+    <div class="form-field">
+    @_root_.views.html.fragments.checkout.title(form.flatMap(_.title), "personal", false)
+    </div>
 </div>
 <div class="form-field js-checkout-first">
     <label class="label" for="first">First name</label>
     @* Zuora's PaymentMethod request is the limiting factor for maxlength here *@
     <input type="text" class="input-text js-input" name="personal.first" id="first"
-        value="@form.map(_.first)" maxlength="30" required>
+    value="@form.map(_.first)" maxlength="30" required>
     @fragments.forms.errorMessage("This field is required")
 </div>
 <div class="form-field js-checkout-last">
     <label class="label" for="last">Last name</label>
     <input type="text" class="input-text js-input" name="personal.last" id="last"
-        value="@form.map(_.last)" maxlength="50" required>
+    value="@form.map(_.last)" maxlength="50" required>
     @fragments.forms.errorMessage("This field is required")
 </div>
 
@@ -35,23 +29,34 @@
 <div class="form-field js-checkout-email">
     <label class="label" for="email">Email address</label>
     <input type="email" class="input-text js-input"  name="personal.emailValidation.email" id="email"
-        value="@form.map(_.email)" maxlength="80" @signedInAttrs data-validation-url="@{routes.Checkout.checkIdentity("").path.replaceFirst("\\?.*", "")}">
+    value="@form.map(_.email)" maxlength="80" @signedInAttrs data-validation-url="@{routes.Checkout.checkIdentity("").path.replaceFirst("\\?.*", "")}">
     @fragments.forms.errorMessage("")
 </div>
 <div class="form-field @if(form.isEmpty) {js-checkout-confirm-email}">
-    @if(form.isDefined) {
-        <input type="hidden" name="personal.emailValidation.confirm" id="confirm" value="@form.map(_.email)">
-    } else {
-        <label class="label" for="confirm">Confirm email address</label>
-        <input type="email" class="input-text js-input" name="personal.emailValidation.confirm" id="confirm" value="@form.map(_.email)" required>
+@if(form.isDefined) {
+    <input type="hidden" name="personal.emailValidation.confirm" id="confirm" value="@form.map(_.email)">
+} else {
+    <label class="label" for="confirm">Confirm email address</label>
+    <input type="email" class="input-text js-input" name="personal.emailValidation.confirm" id="confirm" value="@form.map(_.email)" required>
         @fragments.forms.errorMessage("The confirmation email must match your email address")
     }
 </div>
 
 @* ===== Phone ===== *@
-  <div class="form-field js-checkout-phone-number">
+<div class="form-field js-checkout-phone-number">
     <label class="label optional-marker" for="phone-number">Phone Number</label>
     <input type="tel" class="input-text js-input input-text"
     id="phone-number" name="personal.telephoneNumber"
     value="@form.map(_.telephoneNumber)" maxlength="20">
-  </div>
+</div>
+
+@if(productSupportsGifting) {
+    <div class="js-checkout-is-a-gift">
+        <label class="option">
+            <span class="option__input"><input class="js-input" type="checkbox" name="personal.isBuyingAGift" value="true"/></span>
+            <span>I'm buying Guardian Weekly as a gift</span>
+        </label>
+    </div>
+} else {
+    <input type="hidden" name="personal.isBuyingAGift" value="false"/>
+}

--- a/app/views/fragments/checkout/giftRecipientDetails.scala.html
+++ b/app/views/fragments/checkout/giftRecipientDetails.scala.html
@@ -1,0 +1,32 @@
+@(namePrefix: String)
+
+@attrs(field: String) = @{
+    Html(s"id='${(namePrefix + "-" + field).replace('.', '-')}' name='$namePrefix.$field'")
+}
+
+@labelFor(field: String) = @{
+    Html(s"for='${(namePrefix + "-" + field).replace('.', '-')}'")
+}
+
+<div class="js-gift-recipient-details is-hidden">
+    <div class="form-field js-checkout-gift-title">
+    @_root_.views.html.fragments.checkout.title(None, namePrefix, true)
+    </div>
+    <div class="form-field js-checkout-gift-first-name">
+        <label class="label" @labelFor("first")>Recipient's first name</label>
+        <input type="text" class="input-text js-input" @attrs("first")
+        value="" maxlength="50" disabled>
+        @fragments.forms.errorMessage("This field is required")
+    </div>
+    <div class="form-field js-checkout-gift-last-name">
+        <label class="label" @labelFor("last")>Recipient's last name</label>
+        <input type="text" class="input-text js-input" @attrs("last")
+        value="" maxlength="50" disabled>
+        @fragments.forms.errorMessage("This field is required")
+    </div>
+    <div class="form-field js-checkout-gift-email">
+        <label class="label optional-marker" @labelFor("email")>Recipient's email address</label>
+        <input type="text" class="input-text js-input" @attrs("email")
+        value="" maxlength="80" disabled>
+    </div>
+</div>

--- a/app/views/fragments/checkout/giftRecipientDetails.scala.html
+++ b/app/views/fragments/checkout/giftRecipientDetails.scala.html
@@ -9,19 +9,24 @@
 }
 
 <div class="js-gift-recipient-details is-hidden">
+    @********************************************************************************************
+    * A decision was ade not to collect the Title for gift recipients, but in the event that    *
+    * decision is reversed, you can just uncomment this section and this field should work fine *
+    *********************************************************************************************
     <div class="form-field js-checkout-gift-title">
     @_root_.views.html.fragments.checkout.title(None, namePrefix, true)
     </div>
+    *@
     <div class="form-field js-checkout-gift-first-name">
-        <label class="label" @labelFor("first")>Recipient's first name</label>
-        <input type="text" class="input-text js-input" @attrs("first")
-        value="" maxlength="50" disabled>
+        <label class="label" @labelFor("firstName")>Recipient's first name</label>
+        <input type="text" class="input-text js-input" @attrs("firstName")
+        value="" maxlength="50" disabled required>
         @fragments.forms.errorMessage("This field is required")
     </div>
     <div class="form-field js-checkout-gift-last-name">
-        <label class="label" @labelFor("last")>Recipient's last name</label>
-        <input type="text" class="input-text js-input" @attrs("last")
-        value="" maxlength="50" disabled>
+        <label class="label" @labelFor("lastName")>Recipient's last name</label>
+        <input type="text" class="input-text js-input" @attrs("lastName")
+        value="" maxlength="50" disabled required>
         @fragments.forms.errorMessage("This field is required")
     </div>
     <div class="form-field js-checkout-gift-email">

--- a/app/views/fragments/checkout/title.scala.html
+++ b/app/views/fragments/checkout/title.scala.html
@@ -1,0 +1,19 @@
+@import com.gu.i18n.Title
+
+@(form: Option[Title], namePrefix: String, renderDisabled: Boolean)
+
+@attrs(field: String) = @{
+    Html(s"id='${(namePrefix + "-" + field).replace('.', '-')}' name='$namePrefix.$field'")
+}
+@labelFor(field: String) = @{
+    Html(s"for='${(namePrefix + "-" + field).replace('.', '-')}'")
+}
+
+<label class="label" @labelFor("title")>Title</label>
+<select class="select select--wide js-input" @attrs("title") value="@form.map(_.title).mkString" @if(renderDisabled){ disabled="disabled" }>
+    <option value=""></option>
+    @for(title <- Title.all){
+        <option value="@title.title" @if(form.map(_.title).mkString == title.title){selected} >@title.title</option>
+    }
+    <option value="">Other</option>
+</select>

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -150,6 +150,7 @@ object PlanOps {
     def isPhysical: Boolean = products.hasPhysicalBenefits
     def isVoucher: Boolean = products.isVoucher
     def isDigitalPack: Boolean = products.isDigitalPack
+    def isSixForSix: Boolean = products.promotionalOnly
   }
 
 }

--- a/assets/javascripts/modules/checkout.js
+++ b/assets/javascripts/modules/checkout.js
@@ -13,6 +13,7 @@ define([
     'modules/checkout/deliveryAsBilling',
     'modules/checkout/ratePlanChoice',
     'modules/checkout/eventTracking',
+    'modules/checkout/gifting',
     'bean'
 ], function (
     optionMirror,
@@ -28,6 +29,7 @@ define([
     deliveryAsBilling,
     ratePlanChoice,
     eventTracking,
+    gifting,
     bean
 ) {
     'use strict';
@@ -62,6 +64,7 @@ define([
                     event.stopPropagation();
                 }
             });
+            gifting.init();
             curl('js!stripeCheckout');
         }
         eventTracking.init();

--- a/assets/javascripts/modules/checkout/deliveryAsBilling.js
+++ b/assets/javascripts/modules/checkout/deliveryAsBilling.js
@@ -1,7 +1,7 @@
 define(['modules/checkout/formElements','$', 'bean'], function (formEls, $, bean) {
     'use strict';
 
-    var BILLING_ADDRESS_AS_DELIVERY_ADDRESS_PICKER = $('.js-checkout-delivery-sames-as-billing')[0];
+    var BILLING_ADDRESS_AS_DELIVERY_ADDRESS_PICKER = $('.js-checkout-delivery-same-as-billing')[0];
     var $BILLING_ADDRESS = formEls.BILLING.$CONTAINER;
 
     var _ON_CHANGE_ACTIONS = [];

--- a/assets/javascripts/modules/checkout/deliveryDetails.js
+++ b/assets/javascripts/modules/checkout/deliveryDetails.js
@@ -71,7 +71,7 @@ define([
             return;
         }
 
-        var $postcodeField = $('[name="delivery.postcode"]', formEls.DELIVERY.$POSTCODE_CONTAINER);
+        var $postcodeField = $('[name="delivery.address.postcode"]', formEls.DELIVERY.$POSTCODE_CONTAINER);
         if ($postcodeField.val().length === 1) {
             toggleError($postcodeField.parent(), true);
             return;

--- a/assets/javascripts/modules/checkout/formElements.js
+++ b/assets/javascripts/modules/checkout/formElements.js
@@ -64,7 +64,7 @@ define(['$'], function ($) {
 
         $SIGN_IN_LINK: $('.js-sign-in-link'),
 
-        BILLING: addressFields('.js-fieldset-billing-address'),
+        BILLING: addressFields('.js-billing-address'),
         DELIVERY: addressFields('.js-fieldset-delivery-details'),
 
         $TITLE: $('.js-checkout-title .js-input'),

--- a/assets/javascripts/modules/checkout/formElements.js
+++ b/assets/javascripts/modules/checkout/formElements.js
@@ -9,6 +9,10 @@ define(['$'], function ($) {
     var addressFields = function(relativeTo) {
         var $CONTAINER = $(relativeTo);
         var container = $CONTAINER[0];
+        var $TITLE_CONTAINER = $('.js-checkout-gift-title', container);
+        var $FIRST_NAME_CONTAINER = $('.js-checkout-gift-first-name', container);
+        var $LAST_NAME_CONTAINER = $('.js-checkout-gift-last-name', container);
+        var $EMAIL_CONTAINER = $('.js-checkout-gift-email', container);
         var $ADDRESS1_CONTAINER = $('.js-checkout-house', container);
         var $ADDRESS2_CONTAINER = $('.js-checkout-street', container);
         var $TOWN_CONTAINER = $('.js-checkout-town', container);
@@ -20,6 +24,10 @@ define(['$'], function ($) {
 
         return {
             $CONTAINER: $CONTAINER,
+            $TITLE_CONTAINER: $TITLE_CONTAINER,
+            $FIRST_NAME_CONTAINER: $FIRST_NAME_CONTAINER,
+            $LAST_NAME_CONTAINER: $LAST_NAME_CONTAINER,
+            $EMAIL_CONTAINER: $EMAIL_CONTAINER,
             $ADDRESS1_CONTAINER: $ADDRESS1_CONTAINER,
             $ADDRESS2_CONTAINER: $ADDRESS2_CONTAINER,
             $TOWN_CONTAINER: $TOWN_CONTAINER,
@@ -29,6 +37,10 @@ define(['$'], function ($) {
             $ADDRESS_FINDER: $ADDRESS_FINDER,
             $ADDRESS_CHOOSER: $ADDRESS_CHOOSER,
 
+            $TITLE: $('.js-input', $TITLE_CONTAINER[0]),
+            $FIRST_NAME: $('.js-input', $FIRST_NAME_CONTAINER[0]),
+            $LAST_NAME: $('.js-input', $LAST_NAME_CONTAINER[0]),
+            $EMAIL: $('.js-input', $EMAIL_CONTAINER[0]),
             $ADDRESS1: $('.js-input', $ADDRESS1_CONTAINER[0]),
             $ADDRESS2: $('.js-input', $ADDRESS2_CONTAINER[0]),
             $TOWN: $('.js-input', $TOWN_CONTAINER[0]),
@@ -52,8 +64,8 @@ define(['$'], function ($) {
 
         $SIGN_IN_LINK: $('.js-sign-in-link'),
 
-        BILLING: addressFields('.js-billing-address'),
-        DELIVERY: addressFields('.js-checkout-delivery'),
+        BILLING: addressFields('.js-fieldset-billing-address'),
+        DELIVERY: addressFields('.js-fieldset-delivery-details'),
 
         $TITLE: $('.js-checkout-title .js-input'),
         $FIRST_NAME: $('.js-checkout-first .js-input'),

--- a/assets/javascripts/modules/checkout/gifting.js
+++ b/assets/javascripts/modules/checkout/gifting.js
@@ -36,8 +36,6 @@ define(['modules/checkout/formElements','$', 'bean'], function (formEls, $, bean
                         $CHECKOUT_DELIVERY_SAMES_AS_BILLING.attr('checked');
                         $DELIVERY_DETAILS_LEGEND.text('Delivery address');
                         $GIFT_RECIPIENT_DETAILS.addClass('is-hidden');
-                        //$BILL_MY_DELIVERY_ADDRESS_SECTION.removeClass('is-hidden');
-                        //$BILLING_ADDRESS_SECTION.addClass('is-hidden');
                     }
                     disableOrEnableAllFields($GIFT_RECIPIENT_DETAILS);
                     disableOrEnableAllFields($BILLING_ADDRESS_SECTION);

--- a/assets/javascripts/modules/checkout/gifting.js
+++ b/assets/javascripts/modules/checkout/gifting.js
@@ -1,0 +1,48 @@
+define(['modules/checkout/formElements','$', 'bean'], function (formEls, $, bean) {
+    'use strict';
+
+    const $GIFT_RECIPIENT_DETAILS = $('.js-gift-recipient-details');
+    const $IS_A_GIFT_CHECKBOX = $('.js-checkout-is-a-gift .js-input');
+    const $DELIVERY_DETAILS_LEGEND = $('.js-delivery-details-legend');
+    const $BILL_MY_DELIVERY_ADDRESS_SECTION = $('.js-checkout-use-delivery');
+    const $CHECKOUT_DELIVERY_SAMES_AS_BILLING = $('.js-checkout-delivery-same-as-billing');
+    const $BILLING_ADDRESS_SECTION = $('.js-billing-address');
+
+    function disableOrEnableAllFields($parentNode) {
+        if ($parentNode.length === 1) {
+            const $elems = $('.js-input', $parentNode[0]);
+            if ($parentNode.hasClass('is-hidden')) {
+                $elems.attr('disabled', 'disabled');
+                $elems.removeAttr('checked');
+                $elems.val('');
+            } else {
+                $elems.removeAttr('disabled');
+            }
+        }
+    }
+
+    return {
+        init: function() {
+            if ($IS_A_GIFT_CHECKBOX.length === 1) {
+                bean.on($IS_A_GIFT_CHECKBOX[0], 'change', function (event) {
+                    if (event.target.checked) {
+                        $CHECKOUT_DELIVERY_SAMES_AS_BILLING.removeAttr('checked');
+                        $CHECKOUT_DELIVERY_SAMES_AS_BILLING.attr('disabled', 'disabled');
+                        $DELIVERY_DETAILS_LEGEND.text('Gift recipient details');
+                        $GIFT_RECIPIENT_DETAILS.removeClass('is-hidden');
+                        $BILL_MY_DELIVERY_ADDRESS_SECTION.addClass('is-hidden');
+                        $BILLING_ADDRESS_SECTION.removeClass('is-hidden');
+                    } else {
+                        $CHECKOUT_DELIVERY_SAMES_AS_BILLING.attr('checked');
+                        $DELIVERY_DETAILS_LEGEND.text('Delivery address');
+                        $GIFT_RECIPIENT_DETAILS.addClass('is-hidden');
+                        //$BILL_MY_DELIVERY_ADDRESS_SECTION.removeClass('is-hidden');
+                        //$BILLING_ADDRESS_SECTION.addClass('is-hidden');
+                    }
+                    disableOrEnableAllFields($GIFT_RECIPIENT_DETAILS);
+                    disableOrEnableAllFields($BILLING_ADDRESS_SECTION);
+                });
+            }
+        }
+    };
+});

--- a/assets/javascripts/modules/checkout/reviewDetails.js
+++ b/assets/javascripts/modules/checkout/reviewDetails.js
@@ -30,14 +30,12 @@ define([
         return textUtils.mergeValues([
             formEls.DELIVERY.$TITLE.val(),
             formEls.DELIVERY.$FIRST_NAME.val(),
-            formEls.DELIVERY.$LAST_NAME.val(),
-            formEls.DELIVERY.$EMAIL.val()
+            formEls.DELIVERY.$LAST_NAME.val()
         ], ' ');
     }
 
     function populateDetails() {
         formEls.$REVIEW_NAME.text(textUtils.mergeValues([
-            formEls.$EMAIL.val(),
             formEls.$TITLE.val(),
             formEls.$FIRST_NAME.val(),
             formEls.$LAST_NAME.val()

--- a/assets/javascripts/modules/checkout/reviewDetails.js
+++ b/assets/javascripts/modules/checkout/reviewDetails.js
@@ -26,8 +26,18 @@ define([
         }
     }
 
+    function getGiftDetails() {
+        return textUtils.mergeValues([
+            formEls.DELIVERY.$TITLE.val(),
+            formEls.DELIVERY.$FIRST_NAME.val(),
+            formEls.DELIVERY.$LAST_NAME.val(),
+            formEls.DELIVERY.$EMAIL.val()
+        ], ' ');
+    }
+
     function populateDetails() {
         formEls.$REVIEW_NAME.text(textUtils.mergeValues([
+            formEls.$EMAIL.val(),
             formEls.$TITLE.val(),
             formEls.$FIRST_NAME.val(),
             formEls.$LAST_NAME.val()
@@ -50,6 +60,7 @@ define([
         var DELIVERY_COUNTRY_SELECT = formEls.DELIVERY.$COUNTRY_SELECT[0];
 
         formEls.$REVIEW_DELIVERY_ADDRESS.text(textUtils.mergeValues([
+            getGiftDetails(),
             formEls.DELIVERY.$ADDRESS1.val(),
             formEls.DELIVERY.$ADDRESS2.val(),
             formEls.DELIVERY.$TOWN.val(),
@@ -66,7 +77,6 @@ define([
         } else {
             formEls.$REVIEW_PHONE_FIELD.hide();
         }
-
 
         formEls.$REVIEW_ACCOUNT.text(formEls.$ACCOUNT.val());
         formEls.$REVIEW_SORTCODE.text(formEls.$SORTCODE.val());

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= Seq(
     filters,
     jodaForms,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.1-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.528",
     "com.gu.identity" %% "identity-play-auth" % "2.5",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.6",

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ libraryDependencies ++= Seq(
     filters,
     jodaForms,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.527",
+    "com.gu" %% "membership-common" % "0.1-SNAPSHOT",
     "com.gu.identity" %% "identity-play-auth" % "2.5",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.6",

--- a/test/model/IdUserOpsTest.scala
+++ b/test/model/IdUserOpsTest.scala
@@ -51,7 +51,7 @@ class IdUserOpsTest extends Specification {
     }
 
     "pull through delivery details if present and a blank address if not" in {
-      withoutBillingAddress.address.should_===(Address(
+      withoutBillingAddress.correspondenceAddress.should_===(Address(
         deliveryAddress.address1.get,
         deliveryAddress.address2.get,
         deliveryAddress.address3.get,
@@ -60,7 +60,7 @@ class IdUserOpsTest extends Specification {
         deliveryAddress.country.get
       ))
 
-      withBillingAddress.address.should_===(Address(
+      withBillingAddress.correspondenceAddress.should_===(Address(
         "", "", "", "", "", ""
       ))
     }

--- a/test/services/CheckoutServiceTest.scala
+++ b/test/services/CheckoutServiceTest.scala
@@ -1,12 +1,12 @@
 package services
-import com.gu.i18n.Country
+import com.gu.i18n.{Country, Title}
 import com.gu.memsub.Benefit._
 import com.gu.memsub.Product.{Delivery, ZDigipack}
 import com.gu.memsub.Subscription.{ProductRatePlanChargeId, ProductRatePlanId, SubscriptionRatePlanChargeId}
 import com.gu.memsub._
 import com.gu.memsub.subsv2._
 import com.gu.zuora.api.InvoiceTemplate
-import model.{DigipackData, PaperData}
+import model.{DeliveryRecipient, DigipackData, PaperData}
 import org.joda.time.{Days, LocalDate}
 import org.specs2.mutable.Specification
 import touchpoint.ZuoraProperties
@@ -14,7 +14,7 @@ import touchpoint.ZuoraProperties
 class CheckoutServiceTest extends Specification {
 
   implicit val today = new LocalDate("2016-07-22") // deterministic
-  val address = Address("123 Fake St", "", "Town", "Kent", "123", "Blah")
+  val address = DeliveryRecipient(Some(Title.Mx), Some("firstname"), Some("lastname"), Some("email@email.com"), Address("123 Fake St", "", "Town", "Kent", "123", "Blah"))
   val noPricing = PricingSummary(Map.empty)
 
   val paperPlan = new CatalogPlan[Delivery, PaperCharges, Current](

--- a/test/services/SalesforceServiceTest.scala
+++ b/test/services/SalesforceServiceTest.scala
@@ -4,13 +4,13 @@ import com.gu.memsub.Product.Delivery
 import com.gu.memsub._
 import com.gu.memsub.Subscription.ProductRatePlanId
 import com.gu.memsub.subsv2.{CatalogPlan, PaperCharges}
-import model.{PaperData, PersonalData}
+import model.{DeliveryRecipient, PaperData, PersonalData}
 import org.specs2.mutable.Specification
 import com.gu.salesforce.ContactDeserializer.Keys._
-import org.joda.time.LocalDate
+import com.gu.salesforce.Contact
+import org.joda.time.{DateTime, LocalDate}
 import scalaz.syntax.std.option._
 import play.api.libs.json.{JsString, Json}
-
 import scalaz.syntax.std.option._
 
 class SalesforceServiceTest extends Specification {
@@ -46,14 +46,38 @@ class SalesforceServiceTest extends Specification {
     }
 
     "Include your mailing address if you supply one" in {
-      val delivery = Address("Flat 456", "123 Delivery Grove", "Deliverytown", "Surrey", "DL1 ABC", "UK")
+      val delivery = DeliveryRecipient(None, None, None, None, Address("Flat 456", "123 Delivery Grove", "Deliverytown", "Surrey", "DL1 ABC", "UK"))
       val salesforceInfo = SalesforceService.getJSONForBuyerContact(data, PaperData(LocalDate.now(), delivery, "Papers please".some, plan).some)
-      (salesforceInfo \ MAILING_STREET).get mustEqual JsString(delivery.line)
-      (salesforceInfo \ MAILING_CITY).get mustEqual JsString(delivery.town)
-      (salesforceInfo \ MAILING_POSTCODE).get mustEqual JsString(delivery.postCode)
-      (salesforceInfo \ MAILING_COUNTRY).get mustEqual JsString(delivery.countryName)
-      (salesforceInfo \ MAILING_STATE).get mustEqual JsString(delivery.countyOrState)
+      (salesforceInfo \ MAILING_STREET).get mustEqual JsString(delivery.address.line)
+      (salesforceInfo \ MAILING_CITY).get mustEqual JsString(delivery.address.town)
+      (salesforceInfo \ MAILING_POSTCODE).get mustEqual JsString(delivery.address.postCode)
+      (salesforceInfo \ MAILING_COUNTRY).get mustEqual JsString(delivery.address.countryName)
+      (salesforceInfo \ MAILING_STATE).get mustEqual JsString(delivery.address.countyOrState)
       (salesforceInfo \ DELIVERY_INSTRUCTIONS).get mustEqual JsString("Papers please")
+    }
+
+    "Include your giftee address if you supply one" in {
+      val buyerContact = Contact(
+        None, None, None, None, "Buyer's Lastname", DateTime.now,
+        "buyer_sfContactId", "buyer_sfAccountId", None, None, None, None, None, None
+      )
+      val delivery = DeliveryRecipient(
+        Some(Title.Mx), Some("firstname"), Some("lastname"), Some("email@email.com"),
+        Address("Flat 456", "123 Delivery Grove", "Deliverytown", "Surrey", "DL1 ABC", "UK")
+      )
+      val salesforceInfo = SalesforceService.getJSONForRecipientContact(buyerContact, delivery, "recordTypeId_1")
+      (salesforceInfo \ ACCOUNT_ID).get mustEqual JsString(buyerContact.salesforceAccountId)
+      (salesforceInfo \ RECORD_TYPE_ID).get mustEqual JsString("recordTypeId_1")
+      (salesforceInfo \ EMAIL).get mustEqual JsString(delivery.email.mkString)
+      (salesforceInfo \ TITLE).get mustEqual JsString(delivery.title.map(_.title).mkString)
+      (salesforceInfo \ FIRST_NAME).get mustEqual JsString(delivery.first)
+      (salesforceInfo \ LAST_NAME).get mustEqual JsString(delivery.last)
+      (salesforceInfo \ MAILING_STREET).get mustEqual JsString(delivery.address.line)
+      (salesforceInfo \ MAILING_CITY).get mustEqual JsString(delivery.address.town)
+      (salesforceInfo \ MAILING_POSTCODE).get mustEqual JsString(delivery.address.postCode)
+      (salesforceInfo \ MAILING_COUNTRY).get mustEqual JsString(delivery.address.countryName)
+      (salesforceInfo \ MAILING_STATE).get mustEqual JsString(delivery.address.countyOrState)
+      // (salesforceInfo \ DELIVERY_INSTRUCTIONS).get mustEqual JsString("Papers please") -- not applicable for GW gifting
     }
   }
 }

--- a/test/services/SalesforceServiceTest.scala
+++ b/test/services/SalesforceServiceTest.scala
@@ -31,7 +31,7 @@ class SalesforceServiceTest extends Specification {
     val data = PersonalData("Joe", "Bloggs", "joebloggs@example,com", receiveGnmMarketing = true, bloggsResidence, Some("1234"), Title.Prof.some)
 
     "Serialise your good old fashioned basic fields" in {
-      SalesforceService.createSalesforceUserData(personalData = data, None) mustEqual Json.obj(
+      SalesforceService.getJSONForBuyerContact(personalData = data, None) mustEqual Json.obj(
         EMAIL -> data.email,
         TITLE -> data.title.map(_.title),
         FIRST_NAME -> data.first,
@@ -47,7 +47,7 @@ class SalesforceServiceTest extends Specification {
 
     "Include your mailing address if you supply one" in {
       val delivery = Address("Flat 456", "123 Delivery Grove", "Deliverytown", "Surrey", "DL1 ABC", "UK")
-      val salesforceInfo = SalesforceService.createSalesforceUserData(data, PaperData(LocalDate.now(), delivery, "Papers please".some, plan).some)
+      val salesforceInfo = SalesforceService.getJSONForBuyerContact(data, PaperData(LocalDate.now(), delivery, "Papers please".some, plan).some)
       (salesforceInfo \ MAILING_STREET).get mustEqual JsString(delivery.line)
       (salesforceInfo \ MAILING_CITY).get mustEqual JsString(delivery.town)
       (salesforceInfo \ MAILING_POSTCODE).get mustEqual JsString(delivery.postCode)


### PR DESCRIPTION
This change enables customers to buy Guardian Weekly subscriptions as a gift. It excludes Six-for-six subscriptions.

It depends on https://github.com/guardian/membership-common/pull/586

The main UI change is a checkbox on the checkout page that switches the Delivery Address section to become a Gift Recipient section, and takes 3 new fields: Giftee's name, last name and email address.

Behind the scenes, the Salesforce orchestration creates a Delivery / Recipient Contact (Representing the gift recipient) alongside or in addition to an existing Standard Contact (Representing the buyer). A logged in customer can buy as many gifts as they like, and it will create that many new Delivery / Recipient Contacts without interfering with the Standard Contact's delivery address.

Changes in how subs are read back out of Zuora (in /manage for example), have also been made to ensure either only the buyer contact is retrieved. This uses the new Membership Common SalesforceContactServiceUsingZuoraRest object.

**Screenshots:**
![2](https://user-images.githubusercontent.com/1515970/49946477-fb7ce680-fee6-11e8-80a4-dece4f750984.png)
![3](https://user-images.githubusercontent.com/1515970/49946493-02a3f480-fee7-11e8-877c-3114f05dcf0b.png)
![5](https://user-images.githubusercontent.com/1515970/49946510-0b94c600-fee7-11e8-915a-5faef0fc029d.png)

cc @jacobwinch @pvighi 