### PR TITLE
Fixed the voucher checkout JS error.

### DIFF
--- a/app/views/fragments/checkout/fieldsVoucher.scala.html
+++ b/app/views/fragments/checkout/fieldsVoucher.scala.html
@@ -5,7 +5,7 @@
 
 @_root_.views.html.fragments.checkout.address(
     address = data.deliveryAddress,
-    namePrefix = "delivery",
+    namePrefix = "delivery.address",
     countriesWithCurrency = countriesWithCurrency,
     plan = data.plans.default,
     usePostcodeLookup = true,


### PR DESCRIPTION
Fixes JS error on voucher checkout: 
```
raven.js:351 Uncaught TypeError: Cannot read property 'length' of null
    at HTMLAnchorElement.handleBillingVisibility (deliveryDetails.js:75)
    at call (bean.js:254)
    at HTMLAnchorElement.handler (bean.js:269)
    at HTMLAnchorElement.rootListener (bean.js:434)
    at HTMLAnchorElement.wrapped (raven.js:347)
09:24:03.696
```
cc @jacobwinch 