### PR TITLE
Some code review improvements to Gifting PR

### DIFF
--- a/app/model/SubscriptionData.scala
+++ b/app/model/SubscriptionData.scala
@@ -99,7 +99,9 @@ case class SubscribeRequest(genericData: SubscriptionData, productData: Either[P
 }
 
 case class DeliveryRecipient(title: Option[Title], firstName: Option[String], lastName: Option[String], email: Option[String], address: Address) extends FullName {
-  val first = firstName.mkString
-  val last = lastName.mkString
-  val isGiftee = (Seq() ++ title.map(_.title) ++ firstName ++ lastName ++ email).exists(_.trim.nonEmpty)
+  val first: String = firstName.mkString
+  val last: String = lastName.mkString
+  val isGiftee: Boolean = (Seq() ++ title.map(_.title) ++ firstName ++ lastName ++ email).exists(_.trim.nonEmpty) // TODO make this a field of the case class
+  val gifteeAddress: Option[Address] = if (isGiftee) Some(address) else None
+  val buyersMailingAddress: Option[Address] = if (!isGiftee) Some(address) else None
 }

--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -18,18 +18,19 @@ trait SalesforceService extends LazyLogging {
 }
 
 class SalesforceServiceImp(val repo: SimpleContactRepository) extends SalesforceService {
+  val recordTypeId = repo.recordTypes.getIdForContactRecordType(DeliveryRecipientContact)
+
+  private def createRecipientContactIfGift(buyerContact: ContactId, paperData: Option[PaperData]): Option[Future[ContactId]] = {
+    // Only create a Delivery / Recipient (Related) Contact if the recipient has a giftee address
+    paperData.map(_.deliveryRecipient).filter(_.gifteeAddress.nonEmpty).map { recipient =>
+      repo.upsert(None, SalesforceService.getJSONForRecipientContact(buyerContact, recipient, recordTypeId))
+    }
+  }
+
   override def createOrUpdateBuyerAndRecipient(personalData: PersonalData, paperData: Option[PaperData], userId: Option[IdMinimalUser]): Future[PurchaserIdentifiers] = {
     for {
       buyerContact <- repo.upsert(userId.map(_.id), SalesforceService.getJSONForBuyerContact(personalData, paperData))
-      recipientContact <- { // Only create a Delivery / Recipient (Related) Contact if the recipient is a Giftee
-        val gifteeRecipient = paperData.map(_.deliveryRecipient).filter(_.isGiftee)
-        gifteeRecipient.map { recipient =>
-          val recordTypeId = repo.recordTypes.getIdForContactRecordType(DeliveryRecipientContact)
-          repo.upsert(None, SalesforceService.getJSONForRecipientContact(buyerContact, recipient, recordTypeId))
-        } getOrElse {
-          Future.successful(buyerContact)
-        }
-      }
+      recipientContact <- createRecipientContactIfGift(buyerContact, paperData) getOrElse Future.successful(buyerContact)
     } yield PurchaserIdentifiers(buyerContact, recipientContact, userId)
   }
 
@@ -49,7 +50,7 @@ object SalesforceService {
     Keys.ALLOW_GU_RELATED_MAIL -> personalData.receiveGnmMarketing
   ) ++ personalData.title.fold(Json.obj())(title => Json.obj(
     Keys.TITLE -> title.title
-  )) ++ paperData.map(_.deliveryRecipient).filterNot(_.isGiftee).map(_.address).fold(Json.obj())(addr => Json.obj(
+  )) ++ paperData.flatMap(_.deliveryRecipient.buyersMailingAddress).fold(Json.obj())(addr => Json.obj(
     Keys.MAILING_STREET -> addr.line,
     Keys.MAILING_CITY -> addr.town,
     Keys.MAILING_POSTCODE -> addr.postCode,
@@ -65,13 +66,14 @@ object SalesforceService {
     Keys.EMAIL -> deliveryRecipient.email,
     Keys.TITLE -> deliveryRecipient.title.map(_.title).mkString,
     Keys.FIRST_NAME -> deliveryRecipient.first,
-    Keys.LAST_NAME -> deliveryRecipient.last,
-    Keys.MAILING_STREET -> deliveryRecipient.address.line,
-    Keys.MAILING_CITY -> deliveryRecipient.address.town,
-    Keys.MAILING_POSTCODE -> deliveryRecipient.address.postCode,
-    Keys.MAILING_STATE -> deliveryRecipient.address.countyOrState,
-    Keys.MAILING_COUNTRY -> deliveryRecipient.address.country.fold(deliveryRecipient.address.countryName)(_.name)
-  )
+    Keys.LAST_NAME -> deliveryRecipient.last
+  ) ++ deliveryRecipient.gifteeAddress.fold(Json.obj())(addr => Json.obj(
+    Keys.MAILING_STREET -> addr.line,
+    Keys.MAILING_CITY -> addr.town,
+    Keys.MAILING_POSTCODE -> addr.postCode,
+    Keys.MAILING_STATE -> addr.countyOrState,
+    Keys.MAILING_COUNTRY -> addr.country.fold(addr.countryName)(_.name)
+  ))
 }
 
 case class SalesforceServiceError(s: String) extends Throwable {

--- a/app/views/fragments/checkout/giftRecipientDetails.scala.html
+++ b/app/views/fragments/checkout/giftRecipientDetails.scala.html
@@ -10,7 +10,7 @@
 
 <div class="js-gift-recipient-details is-hidden">
     @********************************************************************************************
-    * A decision was ade not to collect the Title for gift recipients, but in the event that    *
+    * A decision was made not to collect the Title for gift recipients, but in the event that   *
     * decision is reversed, you can just uncomment this section and this field should work fine *
     *********************************************************************************************
     <div class="form-field js-checkout-gift-title">


### PR DESCRIPTION
Some code review improvements to Gifting PR - https://github.com/guardian/subscriptions-frontend/pull/1222

1. Stopped proliferation of isGiftee throughout the users of DeliveryRecipient.
2. Ensured the telephoneNumber only formats based on the billing address country.
3. Reduced complexity of SalesforceServiceImp.createOrUpdateBuyerAndRecipient function
4. Better partitioning of setup code for var soldToContact...

I've still got to refactor the isGiftee field of DeliveryRecipient. My current plan is to use a hidden HTML input in the DOM to drive this. That'll come in a future PR.

Once this is approved, I'll merge this on Monday.

cc @jacobwinch  @pvighi 