### PR TITLE
Revert 6 for 7 hack

### DIFF
--- a/app/services/CheckoutService.scala
+++ b/app/services/CheckoutService.scala
@@ -102,7 +102,7 @@ class CheckoutService(
           ),
           RatePlan(recurringPlan.id.get, None)
         )
-        val updatedContractAcceptance = sixWeeksPlanStartDate.plusWeeks(7) // FIXME: edit rate plan charge in Zuora and make this 6 again after 28th December
+        val updatedContractAcceptance = sixWeeksPlanStartDate.plusWeeks(6)
         originalCommand.copy(ratePlans = replacementPlans, contractAcceptance = updatedContractAcceptance)
       }
       updatedCommand.getOrElse(originalCommand)


### PR DESCRIPTION
It's no longer possible to purchase a subscription which includes 28th December 2018 as a delivery date, so [this hack](https://github.com/guardian/subscriptions-frontend/pull/1217/files) can be reverted. We're currently (unnecessarily) giving all new 6 for 6 subscribers a free 7th issue.

I'll change the catalog (in all environments) shortly before merging this PR.