### PR TITLE
Display the new rate plans upon renewal, rather than the old Zone A/B/C ones

### DIFF
--- a/app/model/Renewal.scala
+++ b/app/model/Renewal.scala
@@ -9,7 +9,7 @@ import play.api.libs.json._
 case class Renewal(email: String, plan: Paper, paymentData: PaymentData, promoCode: Option[PromoCode], displayedPrice: String)
 
 class RenewalReads(catalog: Catalog) {
-  val weeklyPlans = catalog.weekly.zoneA.plans ++ catalog.weekly.zoneB.plans ++ catalog.weekly.zoneC.plans
+  val weeklyPlans = catalog.weekly.domestic.plans ++ catalog.weekly.restOfWorld.plans
   implicit val paperReads = new Reads[Paper] {
     override def reads(json: JsValue): JsResult[Paper] = json match {
       case JsString(ratePlanId) => weeklyPlans.find(_.id.get == ratePlanId).map(JsSuccess(_)).getOrElse(JsError("invalid plan"))


### PR DESCRIPTION
Display the new rate plans upon renewal, rather than the old. Requires [new version](https://github.com/guardian/membership-common/pull/587) of membership-common so that it can show the 1 year plans, rather than just quarterly and annual.

Note: I'll fix the too-light-grey, and the membership-common bump in another PR.

**Before:**

![picture 600](https://user-images.githubusercontent.com/1515970/50485710-4e2dc680-09ee-11e9-85aa-ed23996c090c.png)

**After:**

![picture 599](https://user-images.githubusercontent.com/1515970/50485948-5cc8ad80-09ef-11e9-9a47-78b8c70be0c0.png)


