### PR TITLE
Bump jackson-databind to 2.9.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ scalaVersion := "2.12.6"
 scalacOptions ++= Seq("-feature")
 
 val scalatestVersion = "3.0.4"
+val jacksonVersion = "2.9.8"
 
 libraryDependencies ++= Seq(
     cache,
@@ -72,8 +73,8 @@ libraryDependencies ++= Seq(
     "net.logstash.logback" % "logstash-logback-encoder" % "4.11",
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.9.2",
     "com.google.guava" % "guava" % "25.0-jre", //-- added explicitly - snyk report avoid logback vulnerability
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7", //added explicitly to avoid snyk vulnerability
-    "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7", //added explicitly to avoid snyk vulnerability
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion, //added explicitly to avoid snyk vulnerability
+    "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion, //added explicitly to avoid snyk vulnerability
     "ch.qos.logback" % "logback-classic" % "1.2.3", //-- added explicitly - snyk report avoid logback vulnerability
     "org.scala-lang" % "scala-compiler" % "2.11.12",
     "org.bouncycastle" % "bcprov-jdk15on" % "1.60" // https://snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-32412


### PR DESCRIPTION
## Why are you doing this?
<!--
Please do not forget to log the amount of hours you spent in this PR here:
https://docs.google.com/spreadsheets/d/1DO24_EkHI3emwTSXpnkwWGhKf7n_9VDcGu0g4kdfUD0/edit#gid=0
-->
Updating the version of jackson-databind and jackson-annotations because of these issues reported by Snyk:
https://app.snyk.io/org/the-guardian-cuu/project/17832d7d-f280-403b-9d17-4065dc14d89a/

<!--
Remember, PRs are documentation for future contributors

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Trello card:
N/A - raised by Snyk.

## Changes
* Jackson-databind version bumps

