### PR TITLE
Update the SSL cert used for local development

### DIFF
--- a/nginx/subscribe.conf
+++ b/nginx/subscribe.conf
@@ -12,8 +12,8 @@ server {
     server_name sub.thegulocal.com;
 
     ssl on;
-    ssl_certificate wildcard-thegulocal-com-exp2019-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
-    ssl_certificate_key wildcard-thegulocal-com-exp2019-01-09.key; ## ditto
+    ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
+    ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key; ## ditto
 
     ssl_session_timeout 5m;
 


### PR DESCRIPTION
The SSL certificate we use for local development is about to expire, this PR updates it to a new one.