### PR TITLE
Remove ExactTarget naming

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -102,7 +102,7 @@ class ManageDelivery(implicit val executionContext: ExecutionContext) extends Co
       suspendableDays = Config.suspendableWeeks * sub.plan.charges.chargedDays.size
       suspendedDays = SuspensionService.holidayToSuspendedDays(pendingHolidays, sub.plan.charges.chargedDays.toList)
     } yield {
-      tpBackend.exactTargetService.enqueueETHolidaySuspensionEmail(sub, sub.plan.name, newBS, pendingHolidays.size, suspendableDays, suspendedDays).onFailure { case e: Throwable =>
+      tpBackend.emailService.enqueueHolidaySuspensionEmail(sub, sub.plan.name, newBS, pendingHolidays.size, suspendableDays, suspendedDays).onFailure { case e: Throwable =>
         error(s"Failed to generate data needed to enqueue ${sub.name.get}'s holiday suspension email. Reason: ${e.getMessage}")(sub)
       }
       Ok(views.html.account.suspensionSuccess(

--- a/app/model/Email.scala
+++ b/app/model/Email.scala
@@ -1,4 +1,4 @@
-package model.email
+package model
 
 import java.lang.Math.min
 import java.util.UUID
@@ -11,8 +11,7 @@ import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan => Plan}
 import com.gu.memsub.{Subscription => _, _}
 import com.gu.salesforce.Contact
 import com.typesafe.scalalogging.LazyLogging
-import model.email.EmailHelpers._
-import model.{PaperData, PersonalData}
+import model.EmailHelpers._
 import org.joda.time.Days.daysBetween
 import org.joda.time.{Days, LocalDate}
 import views.support.Dates.prettyDate

--- a/app/model/email/Email.scala
+++ b/app/model/email/Email.scala
@@ -1,4 +1,4 @@
-package model.exactTarget
+package model.email
 
 import java.lang.Math.min
 import java.util.UUID
@@ -11,7 +11,7 @@ import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan => Plan}
 import com.gu.memsub.{Subscription => _, _}
 import com.gu.salesforce.Contact
 import com.typesafe.scalalogging.LazyLogging
-import model.exactTarget.DataExtensionRowHelpers._
+import model.email.EmailHelpers._
 import model.{PaperData, PersonalData}
 import org.joda.time.Days.daysBetween
 import org.joda.time.{Days, LocalDate}
@@ -22,13 +22,13 @@ import scalaz.NonEmptyList
 import scalaz.syntax.nel._
 import scalaz.syntax.std.list._
 
-trait DataExtensionRow {
+trait Email {
   def email: String
   def fields: Seq[(String, String)]
   def forExtension: DataExtension
 }
 
-object DataExtensionRowHelpers {
+object EmailHelpers {
   val dd = "Direct Debit"
   val card = "Credit/Debit Card"
   val paypal = "PayPal"
@@ -58,7 +58,7 @@ object DataExtensionRowHelpers {
   def trimPromotionDescription(p: String): String = p.substring(0, min(p.length, 255))
 }
 
-object DigipackWelcome1DataExtensionRow extends LazyLogging {
+object DigipackWelcome1Email extends LazyLogging {
 
   def apply(
              personalData: PersonalData,
@@ -68,7 +68,7 @@ object DigipackWelcome1DataExtensionRow extends LazyLogging {
              subscriptionDetails: String,
              promotionDescription: Option[String] = None,
              currency:Currency
-           ): DigipackWelcome1DataExtensionRow = {
+           ): DigipackWelcome1Email = {
 
     val paymentDelay = daysBetween(subscription.startDate, subscription.firstPaymentDate).minus(gracePeriod)
 
@@ -86,7 +86,7 @@ object DigipackWelcome1DataExtensionRow extends LazyLogging {
 
     val promotionFields = promotionDescription.map(d => "Promotion description" -> trimPromotionDescription(d))
 
-    DigipackWelcome1DataExtensionRow(
+    DigipackWelcome1Email(
       personalData.email,
       Seq(
         "ZuoraSubscriberId" -> subscription.name.get,
@@ -207,7 +207,7 @@ object PaperFieldsGenerator {
   }
 }
 
-object PaperHomeDeliveryWelcome1DataExtensionRow {
+object PaperHomeDeliveryWelcome1Email {
   def apply(
              paperData: PaperData,
              personalData: PersonalData,
@@ -215,17 +215,17 @@ object PaperHomeDeliveryWelcome1DataExtensionRow {
              paymentMethod: PaymentMethod,
              subscriptionDetails: String,
              promotionDescription: Option[String] = None
-           ): PaperHomeDeliveryWelcome1DataExtensionRow = {
+           ): PaperHomeDeliveryWelcome1Email = {
 
     val commonFields = PaperFieldsGenerator.fieldsFor(paperData, personalData, subscription, paymentMethod, subscriptionDetails, promotionDescription)
     val additionalFields = Seq("delivery_instructions" -> paperData.deliveryInstructions.getOrElse(""))
 
-    PaperHomeDeliveryWelcome1DataExtensionRow(personalData.email, commonFields ++ additionalFields)
+    PaperHomeDeliveryWelcome1Email(personalData.email, commonFields ++ additionalFields)
 
   }
 }
 
-object PaperVoucherWelcome1DataExtensionRow {
+object PaperVoucherWelcome1Email {
   def apply(
              paperData: PaperData,
              personalData: PersonalData,
@@ -233,14 +233,14 @@ object PaperVoucherWelcome1DataExtensionRow {
              paymentMethod: PaymentMethod,
              subscriptionDetails: String,
              promotionDescription: Option[String] = None
-           ): PaperVoucherWelcome1DataExtensionRow = {
+           ): PaperVoucherWelcome1Email = {
 
     val fields = PaperFieldsGenerator.fieldsFor(paperData, personalData, subscription, paymentMethod, subscriptionDetails, promotionDescription)
-    PaperVoucherWelcome1DataExtensionRow(personalData.email, fields)
+    PaperVoucherWelcome1Email(personalData.email, fields)
   }
 }
 
-object GuardianWeeklyWelcome1DataExtensionRow {
+object GuardianWeeklyWelcome1Email {
 
   import model.SubscriptionOps._
 
@@ -251,7 +251,7 @@ object GuardianWeeklyWelcome1DataExtensionRow {
              paymentMethod: PaymentMethod,
              subscriptionDetails: String,
              promotionDescription: Option[String] = None
-           ): GuardianWeeklyWelcome1DataExtensionRow = {
+           ): GuardianWeeklyWelcome1Email = {
 
     val commonFields = PaperFieldsGenerator.fieldsFor(paperData, personalData, subscription, paymentMethod, subscriptionDetails, promotionDescription)
 
@@ -259,11 +259,11 @@ object GuardianWeeklyWelcome1DataExtensionRow {
       Seq("date_of_second_payment" -> formatDate(weeklySub.secondPaymentDate))
     } getOrElse Nil
 
-    GuardianWeeklyWelcome1DataExtensionRow(personalData.email, commonFields ++ additionalFields)
+    GuardianWeeklyWelcome1Email(personalData.email, commonFields ++ additionalFields)
   }
 }
 
-object HolidaySuspensionBillingScheduleDataExtensionRow {
+object HolidaySuspensionBillingScheduleEmail {
 
   def apply(
            email: Option[String],
@@ -275,7 +275,7 @@ object HolidaySuspensionBillingScheduleDataExtensionRow {
            numberOfSuspensionsLinedUp: Int,
            daysUsed: Int,
            daysAllowed: Int
-         ): HolidaySuspensionBillingScheduleDataExtensionRow = {
+         ): HolidaySuspensionBillingScheduleEmail = {
 
     val (thereafterBill, trimmedSchedule) = BillingSchedule.rolledUp(billingSchedule)
     val schedule = trimmedSchedule.toList.toNel.getOrElse(thereafterBill.wrapNel)
@@ -287,7 +287,7 @@ object HolidaySuspensionBillingScheduleDataExtensionRow {
 
     val emailAddress = email.getOrElse("holiday-suspension-bounce@guardian.co.uk")
 
-    HolidaySuspensionBillingScheduleDataExtensionRow(
+    HolidaySuspensionBillingScheduleEmail(
       emailAddress,
       subscriptionName,
       Seq(
@@ -313,7 +313,7 @@ object HolidaySuspensionBillingScheduleDataExtensionRow {
 
 
 
-object GuardianWeeklyRenewalDataExtensionRow {
+object GuardianWeeklyRenewalEmail {
 
   private def extractAddress(contact: Contact) = Address(
     lineOne = contact.mailingStreet.getOrElse(""),
@@ -331,7 +331,7 @@ object GuardianWeeklyRenewalDataExtensionRow {
             paymentMethod: PaymentMethod,
             email: String,
             newTermStartDate: LocalDate
-           ): GuardianWeeklyRenewalDataExtensionRow = {
+           ): GuardianWeeklyRenewalEmail = {
 
 
     val commonFields = PaperFieldsGenerator.fieldsFor(
@@ -351,31 +351,31 @@ object GuardianWeeklyRenewalDataExtensionRow {
       promotionDescription = None
     )
 
-    GuardianWeeklyRenewalDataExtensionRow(email, commonFields)
+    GuardianWeeklyRenewalEmail(email, commonFields)
   }
 
   def constructSalutation(titleOpt: Option[String], firstNameOpt: Option[String], lastNameOpt: Option[String]): String =
     titleOpt.flatMap(title => lastNameOpt.map(lastName => s"$title $lastName")).getOrElse(firstNameOpt.getOrElse("Subscriber"))
 }
 
-case class DigipackWelcome1DataExtensionRow(email: String, fields: Seq[(String, String)]) extends DataExtensionRow {
+case class DigipackWelcome1Email(email: String, fields: Seq[(String, String)]) extends Email {
   override def forExtension = DigipackDataExtension
 }
 
-case class PaperHomeDeliveryWelcome1DataExtensionRow(email: String, fields: Seq[(String, String)]) extends DataExtensionRow {
+case class PaperHomeDeliveryWelcome1Email(email: String, fields: Seq[(String, String)]) extends Email {
   override def forExtension = PaperDeliveryDataExtension
 }
 
-case class PaperVoucherWelcome1DataExtensionRow(email: String, fields: Seq[(String, String)]) extends DataExtensionRow {
+case class PaperVoucherWelcome1Email(email: String, fields: Seq[(String, String)]) extends Email {
   override def forExtension = PaperVoucherDataExtension
 }
-case class GuardianWeeklyWelcome1DataExtensionRow(email: String, fields: Seq[(String, String)]) extends DataExtensionRow {
+case class GuardianWeeklyWelcome1Email(email: String, fields: Seq[(String, String)]) extends Email {
   override def forExtension = GuardianWeeklyWelcome1DataExtension
 }
 
-case class HolidaySuspensionBillingScheduleDataExtensionRow(email: String, subscriptionName: String, fields: Seq[(String, String)]) extends DataExtensionRow {
+case class HolidaySuspensionBillingScheduleEmail(email: String, subscriptionName: String, fields: Seq[(String, String)]) extends Email {
   override def forExtension = HolidaySuspensionBillingScheduleExtension
 }
-case class GuardianWeeklyRenewalDataExtensionRow(email: String, fields: Seq[(String, String)]) extends DataExtensionRow {
+case class GuardianWeeklyRenewalEmail(email: String, fields: Seq[(String, String)]) extends Email {
   override def forExtension = GuardianWeeklyRenewalDataExtension
 }

--- a/app/model/error/CheckoutService.scala
+++ b/app/model/error/CheckoutService.scala
@@ -71,7 +71,7 @@ object CheckoutService {
     override val response = errorResponse
   }
 
-  case class CheckoutExactTargetFailure(
+  case class CheckoutEmailFailure(
       purchaserIds: PurchaserIdentifiers,
       msg: String,
       requestData: Option[String] = None,

--- a/app/model/error/ExactTragetService.scala
+++ b/app/model/error/ExactTragetService.scala
@@ -1,5 +1,0 @@
-package model.error
-
-object ExactTragetService {
-  class ExactTargetAuthenticationError(msg: String) extends Exception(msg)
-}

--- a/app/model/exactTarget/package.scala
+++ b/app/model/exactTarget/package.scala
@@ -1,5 +1,0 @@
-package model
-
-package object exactTarget {
-  case class ExactTargetException(message: String) extends Throwable(message)
-}

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -23,8 +23,8 @@ import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import logging.{Context, ContextLogging}
 import model.SubscriptionOps._
-import model.email.HolidaySuspensionBillingScheduleEmail.constructSalutation
-import model.email._
+import model.HolidaySuspensionBillingScheduleEmail.constructSalutation
+import model._
 import model.{PurchaserIdentifiers, Renewal, SubscribeRequest}
 import org.joda.time.{Days, LocalDate}
 import play.api.libs.json._

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -23,8 +23,8 @@ import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import logging.{Context, ContextLogging}
 import model.SubscriptionOps._
-import model.exactTarget.HolidaySuspensionBillingScheduleDataExtensionRow.constructSalutation
-import model.exactTarget._
+import model.email.HolidaySuspensionBillingScheduleEmail.constructSalutation
+import model.email._
 import model.{PurchaserIdentifiers, Renewal, SubscribeRequest}
 import org.joda.time.{Days, LocalDate}
 import play.api.libs.json._
@@ -35,25 +35,24 @@ import views.support.Pricing._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
+
 /**
-  * Sends welcome email message to Amazon SQS queue which is consumed by membership-workflow.
-  *
-  * Exact Target expects the message to be in the following format:
-  * https://code.exacttarget.com/apis-sdks/rest-api/v1/messaging/messageDefinitionSends.html
+  * Publishes messages to membership-workflow SQS queues
+  * https://github.com/guardian/membership-workflow
   */
-class ExactTargetService(
+class EmailService(
   subscriptionService: subsv2.services.SubscriptionService[Future],
   paymentService: Future[CommonPaymentService],
   zuoraService: ZuoraService,
   salesforceService: SalesforceService
 )(implicit val executionContext: ExecutionContext) extends ContextLogging {
 
-  private def buildWelcomeEmailDataExtensionRow(
+  private def buildEmailSqsMessage(
       subscribeResult: SubscribeResult,
       subscriptionData: SubscribeRequest,
       gracePeriod: Days,
       validPromotion: Option[ValidPromotion[NewUsers]],
-      purchaserIds: PurchaserIdentifiers): Future[DataExtensionRow] = {
+      purchaserIds: PurchaserIdentifiers): Future[Email] = {
 
     val zuoraPaidSubscription: Future[Subscription[Plan.Paid]] =
       subscriptionData.productData.fold(
@@ -97,7 +96,7 @@ class ExactTargetService(
 
       subscriptionData.productData.fold(
         paperData => if (paperData.plan.isHomeDelivery) {
-          PaperHomeDeliveryWelcome1DataExtensionRow(
+          PaperHomeDeliveryWelcome1Email(
             paperData = paperData,
             personalData = personalData,
             subscription = sub,
@@ -106,7 +105,7 @@ class ExactTargetService(
             promotionDescription = promotionDescription
           )
         } else if (paperData.plan.isGuardianWeekly) {
-          GuardianWeeklyWelcome1DataExtensionRow(
+          GuardianWeeklyWelcome1Email(
             paperData = paperData,
             personalData = personalData,
             subscription = sub,
@@ -116,7 +115,7 @@ class ExactTargetService(
           )
         }
         else {
-          PaperVoucherWelcome1DataExtensionRow(
+          PaperVoucherWelcome1Email(
             paperData = paperData,
             personalData = personalData,
             subscription = sub,
@@ -125,7 +124,7 @@ class ExactTargetService(
             promotionDescription = promotionDescription
           )
         },
-        _ => DigipackWelcome1DataExtensionRow(
+        _ => DigipackWelcome1Email(
           personalData = personalData,
           subscription = sub,
           paymentMethod = pm,
@@ -145,7 +144,7 @@ class ExactTargetService(
     }
   }
 
-  def enqueueETWelcomeEmail(
+  def enqueueWelcomeEmail(
       subscribeResult: SubscribeResult,
       subscriptionData: SubscribeRequest,
       gracePeriod: Days,
@@ -153,8 +152,8 @@ class ExactTargetService(
       purchaserIds: PurchaserIdentifiers): Future[Unit] =
 
     for {
-      row <- buildWelcomeEmailDataExtensionRow(subscribeResult, subscriptionData, gracePeriod, validPromotion, purchaserIds)
-      response <- SqsClient.sendDataExtensionToQueue(Config.welcomeEmailQueue, row, SFContactId(purchaserIds.buyerContactId.salesforceContactId))
+      message <- buildEmailSqsMessage(subscribeResult, subscriptionData, gracePeriod, validPromotion, purchaserIds)
+      response <- MembershipWorkflowSqsClient.sendMessage(Config.welcomeEmailQueue, message, SFContactId(purchaserIds.buyerContactId.salesforceContactId))
     } yield {
       response match {
         case Success(sendMsgResult) => logger.info(s"Successfully enqueued ${subscribeResult.subscriptionName} welcome email for user ${purchaserIds.identityId}.")
@@ -162,7 +161,7 @@ class ExactTargetService(
       }
     }
 
-  def enqueueETHolidaySuspensionEmail(
+  def enqueueHolidaySuspensionEmail(
       subscription: Subscription[Plan.Delivery],
       packageName: String,
       billingSchedule: BillingSchedule,
@@ -171,8 +170,8 @@ class ExactTargetService(
       daysAllowed: Int
   )(implicit zuoraRestService: ZuoraRestService[Future]): Future[Unit] = {
 
-    def createDataExtensionRow(salesforceContact: Contact, zuoraAccount: ZuoraRestService.AccountSummary) = {
-      HolidaySuspensionBillingScheduleDataExtensionRow(
+    def buildHolidaySuspensionEmailSqsMessage(salesforceContact: Contact, zuoraAccount: ZuoraRestService.AccountSummary) = {
+      HolidaySuspensionBillingScheduleEmail(
         email = zuoraAccount.billToContact.email,
         saluation = constructSalutation(salesforceContact.title, salesforceContact.firstName, Some(salesforceContact.lastName)),
         subscriptionName = subscription.name.get,
@@ -185,18 +184,18 @@ class ExactTargetService(
       )
     }
 
-    def sendToQueue(salesforceContact: Contact, row: HolidaySuspensionBillingScheduleDataExtensionRow) = {
-      SqsClient.sendDataExtensionToQueue(Config.holidaySuspensionEmailQueue, row, SFContactId(salesforceContact.salesforceContactId)).map {
+    def sendToQueue(salesforceContact: Contact, email: HolidaySuspensionBillingScheduleEmail) = {
+      MembershipWorkflowSqsClient.sendMessage(Config.holidaySuspensionEmailQueue, email, SFContactId(salesforceContact.salesforceContactId)).map {
         case Success(_) => \/.right(())
-        case Failure(e) => \/.left(s"Details were: ${row.subscriptionName}, ${e.toString}")
+        case Failure(e) => \/.left(s"Details were: ${email.subscriptionName}, ${e.toString}")
       }
     }
 
     val enqueueResult = for {
       zuoraAccount <- EitherT(zuoraRestService.getAccount(subscription.accountId))
       salesforceContact <- EitherT.right(SalesforceContactServiceUsingZuoraRest.getBuyerContactForZuoraAccount(zuoraAccount)(salesforceService.repo, executionContext))
-      row = createDataExtensionRow(salesforceContact, zuoraAccount)
-      result <- EitherT(sendToQueue(salesforceContact, row))
+      message = buildHolidaySuspensionEmailSqsMessage(salesforceContact, zuoraAccount)
+      result <- EitherT(sendToQueue(salesforceContact, message))
     } yield result
 
     enqueueResult.run.map {
@@ -229,24 +228,24 @@ class ExactTargetService(
         maybePaymentMethod.toRightDisjunction(SimpleError(s"Failed to enqueue guardian weekly renewal email. No payment method found in account"))
       })
 
-    def sendToQueue(row: GuardianWeeklyRenewalDataExtensionRow): Future[\/[Error, SendMessageResult]] = {
+    def sendToQueue(email: GuardianWeeklyRenewalEmail): Future[\/[Error, SendMessageResult]] = {
 
-      SqsClient.sendDataExtensionToQueue(Config.holidaySuspensionEmailQueue, row, SFContactId(contact.salesforceContactId)).map {
+      MembershipWorkflowSqsClient.sendMessage(Config.holidaySuspensionEmailQueue, email, SFContactId(contact.salesforceContactId)).map {
         case Success(sendMsgResult) => \/-(sendMsgResult)
-        case Failure(e) => -\/(ExceptionThrown(s"Failed to enqueue ${oldSub.name.get}'s guardian weekly renewal email. Details were: " + row.toString, e))
+        case Failure(e) => -\/(ExceptionThrown(s"Failed to enqueue ${oldSub.name.get}'s guardian weekly renewal email. Details were: " + email.toString, e))
       }
     }
 
     val sentMessage = (for {
       paymentMethod <- EitherT(getPaymentMethod(oldSub.accountId))
-      row = GuardianWeeklyRenewalDataExtensionRow(subscriptionName = oldSub.name,
+      email = GuardianWeeklyRenewalEmail(subscriptionName = oldSub.name,
         subscriptionDetails = subscriptionDetails,
         planName = renewal.plan.name,
         contact = contact,
         paymentMethod = paymentMethod,
         email = renewal.email,
         newTermStartDate = newTermStartDate)
-      sendMessage <- EitherT(sendToQueue(row))
+      sendMessage <- EitherT(sendToQueue(email))
     } yield sendMessage).run
 
     sentMessage.map {
@@ -257,23 +256,23 @@ class ExactTargetService(
   }
 }
 
-object SqsClient extends LazyLogging {
+object MembershipWorkflowSqsClient extends LazyLogging {
   private val sqsClient = AmazonSQSClient.builder
     .withCredentials(CredentialsProvider)
     .withRegion(EU_WEST_1)
     .build()
 
-  def sendDataExtensionToQueue(queueName: String, row: DataExtensionRow, sfContactId: SFContactId)(implicit executionContext: ExecutionContext): Future[Try[SendMessageResult]] = {
+  def sendMessage(queueName: String, emailMessage: Email, sfContactId: SFContactId)(implicit executionContext: ExecutionContext): Future[Try[SendMessageResult]] = {
     Future {
       val payload = Json.obj(
         "To" -> Json.obj(
-          "Address" -> row.email,
-          "SubscriberKey" -> row.email,
+          "Address" -> emailMessage.email,
+          "SubscriberKey" -> emailMessage.email,
           "ContactAttributes" -> Json.obj(
-            "SubscriberAttributes" ->  Json.toJsFieldJsValueWrapper(row.fields.toMap)
+            "SubscriberAttributes" ->  Json.toJsFieldJsValueWrapper(emailMessage.fields.toMap)
           )
         ),
-        "DataExtensionName" -> row.forExtension.name,
+        "DataExtensionName" -> emailMessage.forExtension.name,
         "SfContactId" -> sfContactId.get
       ).toString
 

--- a/app/services/TouchpointBackends.scala
+++ b/app/services/TouchpointBackends.scala
@@ -49,7 +49,7 @@ trait TouchpointBackend {
   def discountRatePlanIds: DiscountRatePlanIds
   def suspensionService: SuspensionService[Future]
   def subsForm: Future[SubscriptionsForm]
-  def exactTargetService: ExactTargetService
+  def emailService: EmailService
   def checkoutService: CheckoutService
   def goCardlessService: GoCardlessService
   implicit def simpleRestClient: SimpleClient[Future]
@@ -94,8 +94,8 @@ class TouchpointBackends(actorSystem: ActorSystem, wsClient: WSClient, execution
       lazy val discountRatePlanIds: DiscountRatePlanIds = Config.discountRatePlanIds(config.environmentName)
       lazy val suspensionService = new SuspensionService[Future](Config.holidayRatePlanIds(config.environmentName), simpleRestClient)
       lazy val subsForm = slightlyUnsafeCatalog.map(catalog => new forms.SubscriptionsForm(catalog))
-      lazy val exactTargetService: ExactTargetService = new ExactTargetService(this.subscriptionService, this.commonPaymentService, this.zuoraService, this.salesforceService)
-      lazy val checkoutService: CheckoutService = new CheckoutService(identityService, this.salesforceService, this.paymentService, slightlyUnsafeCatalog, this.zuoraService, new ZuoraRestService[Future], this.exactTargetService, this.zuoraProperties, this.promoService, this.discountRatePlanIds)
+      lazy val emailService: EmailService = new EmailService(this.subscriptionService, this.commonPaymentService, this.zuoraService, this.salesforceService)
+      lazy val checkoutService: CheckoutService = new CheckoutService(identityService, this.salesforceService, this.paymentService, slightlyUnsafeCatalog, this.zuoraService, new ZuoraRestService[Future], this.emailService, this.zuoraProperties, this.promoService, this.discountRatePlanIds)
       lazy val goCardlessService: GoCardlessService = new GoCardlessService(config.goCardlessToken)
     }
   }


### PR DESCRIPTION
ExactTarget is no longer used.

Related PR: https://github.com/guardian/membership-workflow/pull/171