### PR TITLE
Rename 'Subscriber ID' to 'Subscription ID'

### DIFF
--- a/app/controllers/AccountManagement.scala
+++ b/app/controllers/AccountManagement.scala
@@ -363,7 +363,7 @@ class AccountManagement(
 
   }
 
-  def manage(subscriberId: Option[String] = None, errorCode: Option[String] = None, promoCode: Option[PromoCode] = None): Action[AnyContent] = accountManagementAction.async { implicit request =>
+  def manage(subscriptionId: Option[String] = None, errorCode: Option[String] = None, promoCode: Option[PromoCode] = None): Action[AnyContent] = accountManagementAction.async { implicit request =>
     implicit val resolution: TouchpointBackends.Resolution = touchpointBackends.forRequest(PreSigninTestCookie, request.cookies)
     implicit val tpBackend = resolution.backend
     val eventualMaybeSubscription = SessionSubscription.subscriptionFromRequest
@@ -408,7 +408,7 @@ class AccountManagement(
 
     futureMaybeFutureManagePage.getOrElse {
       // not a valid AS number or some unnamed problem getting the details or no sub details in the session yet
-      Future.successful(Ok(views.html.account.details(subscriberId, promoCode)))
+      Future.successful(Ok(views.html.account.details(subscriptionId, promoCode)))
     }.flatMap(identity)
   }
 

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -4,7 +4,7 @@
 @import model.DigitalEdition.UK
 @import views.support.ContactCentreOps._
 @(
-    subscriberId: Option[String],
+    subscriptionId: Option[String],
     promoCode: Option[PromoCode],
     message: Option[String]= None
 )(implicit request: RequestHeader, flash: Flash, touchpointBackendResolution: services.TouchpointBackends.Resolution)
@@ -60,7 +60,7 @@
                                 <div class="form-field js-subscriber-id">
                                     <label class="label" for="first">Subscription ID</label>
                                     <input type="text" class="input-text js-input" name="subscriptionId" id="first"
-                                    value="@subscriberId" maxlength="30" required>
+                                    value="@subscriptionId" maxlength="30" required>
                                     @_root_.views.html.fragments.forms.errorMessage("This field is required")
                                 </div>
                                 <div class="form-field js-suspend-last">

--- a/app/views/account/details.scala.html
+++ b/app/views/account/details.scala.html
@@ -29,7 +29,7 @@
             <div>
                 <h3>Instructions</h3>
                 <p>
-                    Please log in below using your ​​Subscriber ID​, which you can find on any correspondence, and your last name.
+                    Please log in below using your ​​Subscription ID​, which you can find on any correspondence, and your last name.
                 </p>
             </div>
 
@@ -58,7 +58,7 @@
                             </div>
                             <div class="field-panel__fields">
                                 <div class="form-field js-subscriber-id">
-                                    <label class="label" for="first">Subscriber ID</label>
+                                    <label class="label" for="first">Subscription ID</label>
                                     <input type="text" class="input-text js-input" name="subscriptionId" id="first"
                                     value="@subscriberId" maxlength="30" required>
                                     @_root_.views.html.fragments.forms.errorMessage("This field is required")
@@ -91,7 +91,7 @@
 
             <div>
                 <p>
-                    If you do not have your Subscriber ID to hand, or need anything else,
+                    If you do not have your Subscription ID to hand, or need anything else,
                     please email <a class="u-link" href="@hrefMailto">@email</a> or contact Customer Services:
                 </p>
                 <h4>Australia and New Zealand</h4>

--- a/app/views/account/digitalpack.scala.html
+++ b/app/views/account/digitalpack.scala.html
@@ -26,7 +26,7 @@
                     Your details
                 </h3>
                 <dl class="mma-section__list">
-                    <dt class="mma-section__list--title">Subscriber ID</dt>
+                    <dt class="mma-section__list--title">Subscription ID</dt>
                     <dd class="mma-section__list--content">@subscription.name.get</dd>
                     @if(subscription.firstPaymentDate.isAfter(now)) {
                         <dt class="mma-section__list--title">Free trial</dt>

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -6,7 +6,7 @@
 @import scala.collection.immutable.List.empty
 @(chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[SoldToContact] = None, subscription: Subscription[SubscriptionPlan.ContentSubscription])(extra: Html = Html(""))
 <dl class="mma-section__list">
-    <dt class="mma-section__list--title">Subscriber ID</dt>
+    <dt class="mma-section__list--title">Subscription ID</dt>
     <dd class="mma-section__list--content">@{subscription.name.get}</dd>
     @account.fragments.planList(
         plans = subscription.currentPlans,

--- a/app/views/digitalpack/info.scala.html
+++ b/app/views/digitalpack/info.scala.html
@@ -98,7 +98,7 @@
                 <li class="grid__item">
                     <span class="numbered">
                         <span class="numbered__bullet">1.</span>
-                        <span class="numbered__body">Order now and we will send you a subscriber ID</span>
+                        <span class="numbered__body">Order now and we will send you a subscription ID</span>
                     </span>
                 </li>
                 <li class="grid__item">
@@ -110,7 +110,7 @@
                 <li class="grid__item">
                     <span class="numbered">
                         <span class="numbered__bullet">3.</span>
-                        <span class="numbered__body">Enter your subscriber ID into the app, and enjoy</span>
+                        <span class="numbered__body">Enter your subscription ID into the app, and enjoy</span>
                     </span>
                 </li>
             </ol>

--- a/app/views/fragments/checkout/reviewPanel.scala.html
+++ b/app/views/fragments/checkout/reviewPanel.scala.html
@@ -16,7 +16,7 @@
            data-number-of-months="@subscription.firstPlan.charges.billingPeriod.monthsInPeriod">
 
     <div class="review-panel__item">
-        <h4 class="review-panel__label">Subscriber ID:</h4>
+        <h4 class="review-panel__label">Subscription ID:</h4>
         <div class="review-panel__details">@subscription.name.get</div>
     </div>
 

--- a/app/views/fragments/confirmation/appSteps.scala.html
+++ b/app/views/fragments/confirmation/appSteps.scala.html
@@ -20,5 +20,5 @@
     </div>
 </div>
 
-<h4 class="steps__title">Once downloaded you'll be asked to enter your Subscriber ID. You can find this at the top of the grey box above, or in your confirmation email.</h4>
+<h4 class="steps__title">Once downloaded you'll be asked to enter your Subscription ID. You can find this at the top of the grey box above, or in your confirmation email.</h4>
 

--- a/app/views/fragments/promotion/subscriptionTermsAndConditions.scala.html
+++ b/app/views/fragments/promotion/subscriptionTermsAndConditions.scala.html
@@ -12,7 +12,7 @@
     <p>
         Subscriptions available to people aged 18 and over with a valid email address. Free trial open to new digital pack subscribers only. Free trial period lasts
         @promotion.asFreeTrial.fold(defaultDigitalPackFreeTrialPeriod.getDays.toString)(_.promotionType.duration.getDays.toString)
-        days from receipt of subscriber ID, up to and including the day before your first payment falls due. At the end of the free trial,
+        days from receipt of subscription ID, up to and including the day before your first payment falls due. At the end of the free trial,
         the subscription is charged at @promotion.asIncentive.map { p => standard price (currently @formatPrice(catalog.digipack.month, currency, promotion) a month) }
         @promotion.asDiscount.map { p => the special price of @formatPrice(catalog.digipack.month, currency), promotion) a month } unless cancelled.
         Requires Internet connection (additional charges may apply) and an Apple device.

--- a/conf/routes
+++ b/conf/routes
@@ -49,7 +49,7 @@ POST        /staff/cas/token                 controllers.CAS.generateToken
 GET         /oauth2callback                  controllers.OAuth.oauth2Callback
 
 # Manage my account
-GET         /manage                          controllers.AccountManagement.manage(subscriberId: Option[String], errorCode: Option[String], promoCode: Option[PromoCode])
+GET         /manage                          controllers.AccountManagement.manage(subscriptionId: Option[String], errorCode: Option[String], promoCode: Option[PromoCode])
 POST        /manage                          controllers.AccountManagement.processLogin
 GET         /manage/suspend                  controllers.AccountManagement.redirect
 POST        /manage/suspend                  controllers.AccountManagement.processSuspension


### PR DESCRIPTION
A user can have more than one subscription so 'Subscriber ID' is no longer appropriate. It has been changed to 'Subscription ID' to match changes in manage-frontend.

*_Logged in_*:
![image](https://user-images.githubusercontent.com/15648334/52223212-0f1c4c00-289d-11e9-9836-2520b738a0d0.png)

*_Logged out_*:
![image](https://user-images.githubusercontent.com/15648334/52223312-3e32bd80-289d-11e9-9b1e-b4b37efbd5bf.png)

*_Confirmation page_*:
![image](https://user-images.githubusercontent.com/15648334/52223339-50146080-289d-11e9-9ea4-6396468d6c3f.png)

