### PR TITLE
Tracking for Optimize redirect tests

### DIFF
--- a/app/acquisitions/AcquisitionsHelper.scala
+++ b/app/acquisitions/AcquisitionsHelper.scala
@@ -1,0 +1,73 @@
+package acquisitions
+
+import com.gu.acquisition.model.ReferrerAcquisitionData
+import com.typesafe.scalalogging.LazyLogging
+import ophan.thrift.event.AbTest
+import play.api.libs.json.{JsError, Json}
+import scalaz.\/
+
+import scala.collection.immutable.Set
+
+object AcquisitionsHelper extends LazyLogging {
+  def referrerAcquisitionDataFromJSON(json: String): Option[ReferrerAcquisitionData] = {
+    import \/._
+
+    fromTryCatchNonFatal(Json.parse(json))
+      .leftMap(err => s"""Unable to parse "$json" as JSON. $err""")
+      .flatMap { jsValue =>
+        Json.fromJson[ReferrerAcquisitionData](jsValue).fold(
+          errs => left(logger.warn(s"Unable to decode JSON $jsValue to an instance of ReferrerAcquisitionData. ${JsError.toJson(errs)}")),
+          referrerAcquisitionData => right(referrerAcquisitionData)
+        )
+      }
+      .toOption
+  }
+
+  def abTestFromQueryParam(param: String): AbTest = {
+    val Array(_, testName, testVariant) = param.split('.')
+    new AbTest {
+      override def name: String = s"optimize$$$$$testName"
+
+      override def variant: String = testVariant
+
+      override def complete: Option[Boolean] = None
+
+      override def campaignCodes: Option[collection.Set[String]] = None
+    }
+  }
+
+  def mergeAcquisitionDataJson(maybeAcquisitionDataJson: Option[String], optimizeData: Option[String]): Option[String] =
+    mergeAcquisitionData(maybeAcquisitionDataJson: Option[String], optimizeData: Option[String])
+      .map(
+        referrerAcquisitionData =>
+          Json.toJson(referrerAcquisitionData).toString()
+      )
+
+  def mergeAcquisitionData(maybeAcquisitionDataJson: Option[String], optimizeData: Option[String]): Option[ReferrerAcquisitionData] = {
+
+    val appendToExisting = for {
+      acquisitionDataJson <- maybeAcquisitionDataJson
+      acquisitionData <- referrerAcquisitionDataFromJSON(acquisitionDataJson)
+      optimizeExperimentParam <- optimizeData
+      newTests = acquisitionData.abTests.getOrElse(Set.empty[AbTest]) + abTestFromQueryParam(optimizeExperimentParam)
+    } yield acquisitionData.copy(abTests = Some(newTests))
+
+    appendToExisting.orElse(
+      optimizeData.map(
+        optimizeExperimentParam =>
+          new ReferrerAcquisitionData(
+            campaignCode = None,
+            referrerPageviewId = None,
+            referrerUrl = None,
+            componentId = None,
+            componentType = None,
+            source = None,
+            abTest = None,
+            abTests = Some(Set(abTestFromQueryParam(optimizeExperimentParam))),
+            queryParameters = None
+          )
+      )
+    )
+  }
+
+}

--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -1,21 +1,27 @@
 package actions
 
- import controllers.{Cached, NoCache}
- import play.api.mvc._
- import play.filters.csrf.CSRFCheck
+import acquisitions.AcquisitionsHelper
+import controllers.{Cached, NoCache}
+import play.api.mvc._
+import play.filters.csrf.CSRFCheck
 
- import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
+
 final class CommonActions(executionContext: ExecutionContext, cSRFCheck: CSRFCheck, parser: BodyParser[AnyContent]) {
 
   private implicit val executionContextImplicit = executionContext
 
   val StoreAcquisitionDataAction = new ActionBuilder[Request, AnyContent] {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request).map(result => {
-      request.getQueryString("acquisitionData").fold(result)(a => {
+      AcquisitionsHelper.mergeAcquisitionDataJson(
+        request.getQueryString("acquisitionData"),
+        request.getQueryString("utm_expid")
+      ).fold(result)(a => {
         val sessionWithAcquisitionData = result.session(request).data.toSeq ++ Seq("acquisitionData" -> a)
         result.withSession(sessionWithAcquisitionData: _*)
       })
     })
+
     override def parser = CommonActions.this.parser
 
     override protected def executionContext: ExecutionContext = CommonActions.this.executionContext

--- a/app/model/SubscriptionAcquisitionComponents.scala
+++ b/app/model/SubscriptionAcquisitionComponents.scala
@@ -12,10 +12,9 @@ import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import ophan.thrift.event.PaymentProvider.{Gocardless, Stripe}
 import ophan.thrift.event._
-import play.api.libs.json._
+import acquisitions.AcquisitionsHelper.referrerAcquisitionDataFromJSON
 
 import scala.collection.Set
-import scalaz.\/
 
 case class ClientBrowserInfo(
   gaClientId: String,
@@ -55,19 +54,6 @@ object SubscriptionAcquisitionComponents {
       Right(GAData(host, gaClientId, Some(ipAddress), userAgent))
     }
 
-    private def referrerAcquisitionDataFromJSON(json: String): Option[ReferrerAcquisitionData] = {
-      import \/._
-
-      fromTryCatchNonFatal(Json.parse(json))
-        .leftMap(err => s"""Unable to parse "$json" as JSON. $err""")
-        .flatMap { jsValue =>
-          Json.fromJson[ReferrerAcquisitionData](jsValue).fold(
-            errs => left(logger.warn(s"Unable to decode JSON $jsValue to an instance of ReferrerAcquisitionData. ${JsError.toJson(errs)}")),
-            referrerAcquisitionData => right(referrerAcquisitionData)
-          )
-        }
-        .toOption
-    }
 
     private def printOptionsFromPaperData(p: PaperData): Option[PrintOptions] = {
       // Explicit imports because Product and Benefit have name collisions

--- a/test/utils/AcquisitionsHelperTest.scala
+++ b/test/utils/AcquisitionsHelperTest.scala
@@ -1,0 +1,36 @@
+package utils
+
+import acquisitions.AcquisitionsHelper
+import acquisitions.AcquisitionsHelper._
+import org.scalatest.{FlatSpec, Matchers}
+
+class AcquisitionsHelperTest extends FlatSpec with Matchers {
+
+  val param = ".0ctCmYiGSGqiUFP0eMFobw.1"
+
+  "An Optimize QueryParam" should "parse correctly" in {
+
+    val test = abTestFromQueryParam(param)
+    test.name shouldBe "optimize$$0ctCmYiGSGqiUFP0eMFobw"
+    test.variant shouldBe "1"
+  }
+
+  "mergeAcquisitionData" should "merge existing acquisitionData with an Optimize param" in {
+    val json =
+      """
+        |{"abTests":[{"name":"ssr","variant":"notintest"}]}
+      """.stripMargin
+
+    val mergedData = AcquisitionsHelper.mergeAcquisitionData(Some(json), Some(param) )
+
+    mergedData.get.abTests.get.size shouldBe 2
+  }
+
+  it should "create the acquisitionData if none exists and an Optimize parameter is present" in {
+    AcquisitionsHelper.mergeAcquisitionData(None, Some(param)).get.abTests.get.size shouldBe 1
+  }
+
+  it should "return None when acquisitionData and Optimize parameter are null" in  {
+    AcquisitionsHelper.mergeAcquisitionData(None, None) shouldBe None
+  }
+}


### PR DESCRIPTION
Up until now we haven't been tracking Optimize redirect tests on subscribe. These are tests where a user shows up with a `utm_expid` query parameter with the test id and variant.

To track these we need to add the test information into the referrer acquisition data which is stored as json in the Play session. 

Where there is no existing referrer acquisition data (this should almost always be the case for redirect tests) we need to create it, if there is existing data we need to append to it - I've added some tests to ensure that the behaviour around this is correct.