### PR TITLE
Use query param to pre-select annual digital pack option

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -28,8 +28,8 @@ GET         /checkout/findAddress            controllers.Checkout.findAddress(po
 
 # Checkout pages
 GET         /checkout/thank-you              controllers.Checkout.thankYou()
-GET         /checkout                        controllers.Checkout.renderCheckout(countryGroup: String ?= CountryGroup.UK.id, promoCode: Option[PromoCode], supplierCode: Option[SupplierCode], forThisPlan = "digitalpack-digitalpackmonthly")
-GET         /checkout/:forThisPlan           controllers.Checkout.renderCheckout(countryGroup: String ?= CountryGroup.UK.id, promoCode: Option[PromoCode], supplierCode: Option[SupplierCode], forThisPlan: String)
+GET         /checkout                        controllers.Checkout.renderCheckout(countryGroup: String ?= CountryGroup.UK.id, promoCode: Option[PromoCode], supplierCode: Option[SupplierCode], forThisPlan = "digitalpack-digitalpackmonthly", period: Option[String] ?= None)
+GET         /checkout/:forThisPlan           controllers.Checkout.renderCheckout(countryGroup: String ?= CountryGroup.UK.id, promoCode: Option[PromoCode], supplierCode: Option[SupplierCode], forThisPlan: String, period: Option[String] ?= None)
 
 # collection and delivery
 GET         /collection/paper-digital        controllers.Shipping.viewCollectionPaperDigital


### PR DESCRIPTION
In order to run an Optimize test for the new Digital Pack checkout, we need to select the billing period based on a query string instead of the path. 

This is a temporary change which allows us to do that.