### PR TITLE
reveal Guardian Weekly Price Rise on /manage - only within 30days

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ By default, the setup script will hash file assets and generate a `conf/assets.m
 which in turn will cause Play to render assets with their hashed path. Use the `grunt compile --dev`
 task in order to have Play to render assets without hashing them.
 
-Finally, the grunt file provides a
-convenient `watch` task, which will dynamically recompile assets as they get edited.
+Alternatively, run `grunt watch --dev`, to dynamically recompile assets as they get edited.
 
 ## Test execution
 

--- a/app/views/account/fragments/billingSchedule.scala.html
+++ b/app/views/account/fragments/billingSchedule.scala.html
@@ -1,10 +1,11 @@
 @import com.gu.i18n.Currency
 @import com.gu.memsub.BillingSchedule
 @import views.support.BillingScheduleOps._
+@import com.gu.memsub.subsv2.SubscriptionPlan
 @import views.support.Dates._
 @import views.support.FloatOps._
 
-@(billingSchedule: BillingSchedule, currency: Currency)
+@(billingSchedule: BillingSchedule, currency: Currency, currentPlanOverride: Option[SubscriptionPlan.Paid] = None)
 
 <div class="mma-section__schedule">
     @billingSchedule.billsToDisplay.toList.map { bill =>
@@ -15,7 +16,14 @@
                 <span class="mma-section__calendar--sub">@bill.date.shortMonth</span>
             </div>
             <p class="mma-section__calendar--amount @bill.whenDiscounted("mma-section__calendar--amount--discounted")">
-              @currency.glyph@bill.amount.currency
+                @currency.glyph
+                @{
+                    currentPlanOverride
+                        .map(_.charges.price.prices.head.amount)
+                        .filter(_ < bill.amount)
+                        .map(_.currency)
+                        .getOrElse(bill.amount.currency)
+                }
             </p>
         </div>
     }

--- a/app/views/account/fragments/planList.scala.html
+++ b/app/views/account/fragments/planList.scala.html
@@ -4,7 +4,7 @@
 @import views.support.Dates._
 @import views.support.Pricing._
 
-@(plans: List[SubscriptionPlan.ContentSubscription], singularLabel: String, chosenPaperDays: List[PaperDay] = List.empty)
+@(plans: List[SubscriptionPlan.ContentSubscription], shouldShowPlanName: Boolean, singularLabel: String, chosenPaperDays: List[PaperDay] = List.empty)
 
 @if(plans.length > 1) {
     <dt class="mma-section__list--title">@{
@@ -17,15 +17,17 @@
 
 <dd class="mma-section__list--content">
 @for(plan <- plans) {
-    <div>
-    @if(plan.name == "Echo-Legacy" || plan.name == "Multi-day") {
-        Multi-day (@{
-        chosenPaperDays.map(_.id.replace("Print ", "")).mkString(", ")
-    })
-    } else {
-        @plan.name
+    @if(shouldShowPlanName) {
+        <div>
+        @if(plan.name == "Echo-Legacy" || plan.name == "Multi-day") {
+            Multi-day (@{
+            chosenPaperDays.map(_.id.replace("Print ", "")).mkString(", ")
+        })
+        } else {
+            @plan.name
+        }
+        </div>
     }
-    </div>
     <div>@plan.charges.prettyPricing(plan.charges.price.currencies.head)</div>
 
     <div>@if(plan.start.isAfter(now)) { Starts: } else { Started: } @prettyDate(plan.start)</div>

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -4,16 +4,18 @@
 @import model.SubscriptionOps._
 
 @import scala.collection.immutable.List.empty
-@(chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[SoldToContact] = None, subscription: Subscription[SubscriptionPlan.ContentSubscription])(extra: Html = Html(""))
+@(chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[SoldToContact] = None, subscription: Subscription[SubscriptionPlan.ContentSubscription], shouldShowPlanName: Boolean = true)(extra: Html = Html(""))
 <dl class="mma-section__list">
     <dt class="mma-section__list--title">Subscription ID</dt>
     <dd class="mma-section__list--content">@{subscription.name.get}</dd>
     @account.fragments.planList(
         plans = subscription.currentPlans,
+        shouldShowPlanName = shouldShowPlanName,
         singularLabel = "Current Plan",
         chosenPaperDays = chosenPaperDays)
     @account.fragments.planList(
         plans = subscription.futurePlans,
+        shouldShowPlanName = shouldShowPlanName,
         singularLabel = "Upcoming Plan",
         chosenPaperDays = chosenPaperDays)
 

--- a/app/views/account/fragments/yourDetails.scala.html
+++ b/app/views/account/fragments/yourDetails.scala.html
@@ -4,7 +4,7 @@
 @import model.SubscriptionOps._
 
 @import scala.collection.immutable.List.empty
-@(chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[SoldToContact] = None, subscription: Subscription[SubscriptionPlan.ContentSubscription], shouldShowPlanName: Boolean = true)(extra: Html = Html(""))
+@(chosenPaperDays: List[PaperDay] = empty, maybeContact: Option[SoldToContact] = None, subscription: Subscription[SubscriptionPlan.ContentSubscription], shouldShowPlanName: Boolean = true, shouldShowUpcomingPlan: Boolean = true)(extra: Html = Html(""))
 <dl class="mma-section__list">
     <dt class="mma-section__list--title">Subscription ID</dt>
     <dd class="mma-section__list--content">@{subscription.name.get}</dd>
@@ -13,11 +13,13 @@
         shouldShowPlanName = shouldShowPlanName,
         singularLabel = "Current Plan",
         chosenPaperDays = chosenPaperDays)
-    @account.fragments.planList(
-        plans = subscription.futurePlans,
-        shouldShowPlanName = shouldShowPlanName,
-        singularLabel = "Upcoming Plan",
-        chosenPaperDays = chosenPaperDays)
+    @if(shouldShowUpcomingPlan) {
+        @account.fragments.planList(
+            plans = subscription.futurePlans,
+            shouldShowPlanName = shouldShowPlanName,
+            singularLabel = "Upcoming Plan",
+            chosenPaperDays = chosenPaperDays)
+    }
 
     @maybeContact.map { contact =>
         <dt class="mma-section__list--title">Delivery details</dt>

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -25,7 +25,8 @@
                 </h3>
                 @views.html.account.fragments.yourDetails(
                     maybeContact = Some(contact),
-                    subscription = subscription
+                    subscription = subscription,
+                    shouldShowPlanName = false
                 )()
             </section>
             @billingSchedule.map { bs =>

--- a/app/views/account/weeklyDetails.scala.html
+++ b/app/views/account/weeklyDetails.scala.html
@@ -26,15 +26,20 @@
                 @views.html.account.fragments.yourDetails(
                     maybeContact = Some(contact),
                     subscription = subscription,
-                    shouldShowPlanName = false
+                    shouldShowPlanName = false,
+                    shouldShowUpcomingPlan = !subscription.shouldHideUpcomingPlan
                 )()
             </section>
-            @billingSchedule.map { bs =>
+            @billingSchedule.map { billingSchedule =>
                 <section class="mma-section">
                     <h3 class="mma-section__header">
                         Your billing schedule
                     </h3>
-                    @views.html.account.fragments.billingSchedule(bs, subscription.currency)
+                    @views.html.account.fragments.billingSchedule(
+                        billingSchedule = billingSchedule,
+                        currency = subscription.currency,
+                        currentPlanOverride = if(subscription.shouldHideUpcomingPlan) subscription.currentPlans.headOption else None
+                    )
                 </section>
             }
             <section class="mma-section">


### PR DESCRIPTION
To coordinate with the Guardian Weekly Price Rise letters, this PR ensures that the price rise is only visible online for 30 days in advance, and that the ugly internal name for the product rate plan is no longer exposed.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19289579/52945202-177a8980-3369-11e9-83e6-70ed5c62b408.png) | ![image](https://user-images.githubusercontent.com/19289579/52945175-09c50400-3369-11e9-8dee-24da611c644e.png) | 

If a price rise is inferred (product rate plans don't match on future plans) and the price rise is due more than 30 days ahead, in addition to hiding the 'Upcoming Plan', the current plan is passed into the `billingSchedule` and is then compared with each bill amount, if the bill amount is larger than the currentPlan amount then the current plan amount is used instead, which should support the temporary discounts without revealing the price rise before the 30 days