### PR TITLE
Revert "Don't set custom metric 10 on conversions"

### DIFF
--- a/assets/javascripts/modules/analytics/ga.js
+++ b/assets/javascripts/modules/analytics/ga.js
@@ -99,6 +99,7 @@ define(['modules/analytics/analyticsEnabled',
 
         _EVENT_QUEUE.forEach(function (obj) {
             var upgrading = (obj.eventLabel === 'Rate Plan Change' && guardian.pageInfo.productData.initialProduct !== guardian.pageInfo.productData.productPurchasing) ? 1 : 0;
+            var converted = (obj.eventLabel === 'Converted') ? 1 : 0;
             var productName = guardian.pageInfo.productData.productPurchasing || guardian.pageInfo.productData.productPurchased;
             var event = {
                 eventCategory: 'Subscriptions Checkout',
@@ -107,7 +108,8 @@ define(['modules/analytics/analyticsEnabled',
                 dimension11: guardian.pageInfo.productData.productType + ' - ' + productName,
                 dimension13: !!guardian.supplierCode,
                 metric1: upgrading,
-                metric2: obj.elapsedTime
+                metric2: obj.elapsedTime,
+                metric10: converted
             };
             if (guardian.pageInfo.productData.promoCode) {
                 event.dimension19 = guardian.pageInfo.productData.promoCode;


### PR DESCRIPTION
Reverts guardian/subscriptions-frontend#1251

Post deploy tests are failing consistently so I'm reverting this while I investigate