### PR TITLE
Remove paper delivery UI

### DIFF
--- a/app/controllers/Shipping.scala
+++ b/app/controllers/Shipping.scala
@@ -50,11 +50,11 @@ class Shipping(touchpointBackend: TouchpointBackend, commonActions: CommonAction
   }
 
   def viewDeliveryPaperDigital() = NoCacheAction {
-    Redirect("/collection/paper-digital")
+    Redirect("/")
   }
 
   def viewDeliveryPaper() = NoCacheAction {
-    Redirect("/collection/paper")
+    Redirect("/")
   }
 
 }

--- a/app/controllers/Shipping.scala
+++ b/app/controllers/Shipping.scala
@@ -49,30 +49,12 @@ class Shipping(touchpointBackend: TouchpointBackend, commonActions: CommonAction
     }
   }
 
-  def viewDeliveryPaperDigital() = NoCacheAction.async {
-    val segment = "paper-digital"
-    catalog.map { catalog =>
-      index(DeliverySubscriptionProduct(
-        title = "Paper + digital home delivery subscription",
-        description =
-          """|If you live within the M25 you can have your papers delivered by 7am Monday - Saturday and 8.30am on Sunday.
-             |Plus you can start using the daily edition and premium live news app immediately.""".stripMargin,
-        altPackagePath = s"/collection/$segment",
-        options = catalog.delivery.list.toList.filter(_.charges.digipack.isDefined).map(planToOptions).sortBy(_.weeklyPrice).reverse
-      ), segment)
-    }
+  def viewDeliveryPaperDigital() = NoCacheAction {
+    Redirect("/collection/paper-digital")
   }
 
-  def viewDeliveryPaper() = NoCacheAction.async {
-    val segment = "paper"
-    catalog.map { catalog =>
-      index(DeliverySubscriptionProduct(
-        title = "Paper home delivery subscription",
-        description = "If you live within the M25 you can have your papers delivered by 7am Monday - Saturday and 8.30 on Sunday.",
-        altPackagePath = s"/collection/$segment",
-        options = catalog.delivery.list.toList.filter(_.charges.digipack.isEmpty).map(planToOptions).sortBy(_.weeklyPrice).reverse.filterNot(_.title.toLowerCase.trim == "saturday")
-      ), segment)
-    }
+  def viewDeliveryPaper() = NoCacheAction {
+    Redirect("/collection/paper")
   }
 
 }

--- a/app/views/fragments/shipping/shipping.scala.html
+++ b/app/views/fragments/shipping/shipping.scala.html
@@ -11,20 +11,6 @@
 
 <section class="section-slice">
 
-    @if(subscription.insideM25) {
-        <h3 class="u-display-only-mobile">Live outside the M25?</h3>
-        <a href="@subscription.altPackagePath" class="button button--large button--secondary button--m25" data-test-id="choose-package-outside-m25">
-            <span class="u-hide-until-tablet">Live outside the M25?</span>
-            Subscribe to <span class="u-hide-until-tablet">our</span> voucher scheme
-        </a>
-    } else {
-        <h3 class="u-display-only-mobile">Do you live inside the M25?</h3>
-        <a href="@subscription.altPackagePath" class="button button--large button--secondary button--m25" data-test-id="choose-package-inside-m25">
-            <span class="u-hide-until-tablet">Do you live inside the M25?</span>
-            Get the paper delivered <span class="u-hide-until-tablet">to your door</span>
-        </a>
-    }
-
     <h2 class="page-heading">Choose a package</h2>
 
     @for(option <- subscription.options) {


### PR DESCRIPTION
Removes the switch to paper delivery buttons and redirects the delivery URLs

<img width="958" alt="Screenshot 2019-03-22 at 09 04 50" src="https://user-images.githubusercontent.com/11539094/54811845-92450600-4c81-11e9-9baf-f12ee90459a2.png">

[Trello](https://trello.com/c/22A6TAOb/2314-print-home-delivery-old-checkout-switch-off)