### PR TITLE
Only include third party tracking if the user has opted in

### DIFF
--- a/assets/javascripts/modules/analytics/thirdPartyTracking.js
+++ b/assets/javascripts/modules/analytics/thirdPartyTracking.js
@@ -15,7 +15,7 @@ const getTrackingConsent = () => {
     return Unset;
 };
 
-const thirdPartyTrackingEnabled = () => getTrackingConsent() !== OptedOut;
+const thirdPartyTrackingEnabled = () => getTrackingConsent() === OptedIn;
 
 const writeTrackingConsentCookie = (trackingConsent) => {
     if (trackingConsent !== Unset) {


### PR DESCRIPTION
Previously we were including third party tracking scripts unless a user had explicitly opted out. This PR changes this so that we now only track users who have explicitly opted in.