### PR TITLE
update versions for dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import play.sbt.PlayImport
+import scala.sys.process._
 
 name := "frontend"
 
@@ -73,7 +74,7 @@ libraryDependencies ++= Seq(
     "net.logstash.logback" % "logstash-logback-encoder" % "4.11",
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.9.2",
     "com.google.guava" % "guava" % "25.0-jre", //-- added explicitly - snyk report avoid logback vulnerability
-    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion, //added explicitly to avoid snyk vulnerability
+    "com.fasterxml.jackson.core" % "jackson-databind" % (jacksonVersion+".1"), //added explicitly to avoid snyk vulnerability
     "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion, //added explicitly to avoid snyk vulnerability
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion, //added explicitly to avoid snyk vulnerability
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion, //added explicitly to avoid snyk vulnerability

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 
 resolvers += Resolver.typesafeRepo("releases") // Play seems to require quite a few things from here
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 


### PR DESCRIPTION
Updated jackson core for a snyk vulnerability.
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450917

I have also updated sbt and play as they were both way behind.
Seems to work the tests pass (apart from the ones that seem to hit address services etc.)
and I got most of the way through a digital pack checkout, however the UAT and DEV salesforce credentials are not up to date so I couldn't actually create the subscription.