### PR TITLE
Authentication via identity API

### DIFF
--- a/app/MyApplicationLoader.scala
+++ b/app/MyApplicationLoader.scala
@@ -17,7 +17,8 @@ import play.components.HttpConfigurationComponents
 import play.filters.csrf.CSRFComponents
 import play.filters.headers.{SecurityHeadersConfig, SecurityHeadersFilter}
 import router.Routes
-import services.TouchpointBackends
+import services.{AsyncAuthenticationService, TouchpointBackends}
+import utils.TestUsersService
 
 class MyApplicationLoader extends ApplicationLoader {
   def load(context: Context) = {
@@ -44,7 +45,11 @@ class MyComponents(context: Context)
     with AssetsComponents
 {
 
-  val touchpointBackends = new TouchpointBackends(actorSystem, wsClient, executionContext)
+  val authenticationService = new AsyncAuthenticationService
+  val sessionsSubscription = new SessionSubscription(authenticationService)
+  val testUsersService = new TestUsersService(authenticationService)
+
+  val touchpointBackends = new TouchpointBackends(testUsersService, actorSystem, wsClient, executionContext)
 
   override lazy val httpErrorHandler: ErrorHandler =
     new ErrorHandler(environment, configuration, sourceMapper, Some(router))
@@ -62,14 +67,14 @@ class MyComponents(context: Context)
     new Homepage(commonActions, controllerComponents),
     new Management(actorSystem = actorSystem, touchpointBackends, oAuthActions, executionContext, controllerComponents),
     new DigitalPack(touchpointBackends.Normal, commonActions, controllerComponents),
-    new CheckoutHandler(touchpointBackends, commonActions, executionContext, controllerComponents),
-    new Checkout(touchpointBackends, commonActions, executionContext, controllerComponents),
+    new CheckoutHandler(touchpointBackends, commonActions, authenticationService, testUsersService, executionContext, controllerComponents),
+    new Checkout(touchpointBackends, commonActions, authenticationService, executionContext, controllerComponents),
     new Promotion(touchpointBackends, commonActions, executionContext, controllerComponents),
     new Shipping(touchpointBackends.Normal, commonActions, controllerComponents),
     new WeeklyLandingPage(touchpointBackends.Normal, commonActions, controllerComponents),
     new OAuth(wsClient = wsClient, commonActions, oAuthActions, executionContext, controllerComponents),
     new CAS(oAuthActions, executionContext, controllerComponents),
-    new AccountManagement(touchpointBackends, commonActions, httpClient, controllerComponents),
+    new AccountManagement(touchpointBackends, commonActions, httpClient, sessionsSubscription, authenticationService, controllerComponents),
     new PatternLibrary(commonActions, controllerComponents),
     new Testing(touchpointBackends.Test, commonActions, oAuthActions, controllerComponents),
     new PromoLandingPage(touchpointBackends.Normal, commonActions, oAuthActions, executionContext, controllerComponents),
@@ -81,7 +86,7 @@ class MyComponents(context: Context)
     new CheckCacheHeadersFilter(),
     new SecurityHeadersFilter(SecurityHeadersConfig.fromConfiguration(context.initialConfiguration)),
     csrfFilter,
-    new AddGuIdentityHeaders(),
+    new AddGuIdentityHeaders(authenticationService),
     new AddEC2InstanceHeader(wsClient)
   )
 

--- a/app/controllers/CheckoutHandler.scala
+++ b/app/controllers/CheckoutHandler.scala
@@ -21,16 +21,23 @@ import play.api.libs.json._
 import play.api.mvc._
 
 import scalaz.NonEmptyList
-import services.AuthenticationService.authenticatedUserFor
 import services._
 import utils.RequestCountry._
-import utils.{PaymentGatewayError, TestUsers}
-import utils.TestUsers.{NameEnteredInForm, PreSigninTestCookie}
+import utils.{PaymentGatewayError, TestUsersService}
+import utils.TestUsersService.{NameEnteredInForm, PreSigninTestCookie}
 import views.support.{BillingPeriod => _}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class CheckoutHandler(fBackendFactory: TouchpointBackends, commonActions: CommonActions, implicit val executionContext: ExecutionContext, override protected val controllerComponents: ControllerComponents) extends BaseController with LazyLogging {
+class CheckoutHandler(
+    fBackendFactory: TouchpointBackends,
+    commonActions: CommonActions,
+    authenticationService: AsyncAuthenticationService,
+    testUsersService: TestUsersService,
+    implicit val executionContext: ExecutionContext,
+    override protected val controllerComponents: ControllerComponents
+) extends BaseController with LazyLogging {
+
   import SessionKeys.{Currency => _, UserId => _, _}
   import commonActions._
 
@@ -38,128 +45,102 @@ class CheckoutHandler(fBackendFactory: TouchpointBackends, commonActions: Common
     res.backend.checkoutService
 
   def handleCheckout: Action[AnyContent] = NoCacheAction.async { implicit request =>
-
     val tempData = SubscriptionsForm.subsForm.bindFromRequest().value
-    implicit val resolution: TouchpointBackends.Resolution = fBackendFactory.forRequest(NameEnteredInForm, tempData)
-    implicit val tpBackend: TouchpointBackend = resolution.backend
-    val idUserOpt = authenticatedUserFor(request)
 
     val sessionTrackingCode = request.session.get(PromotionTrackingCode)
     val sessionSupplierCode = request.session.get(SupplierTrackingCode)
 
-    tpBackend.subsForm.flatMap { subsForm =>
+    def failure(subscribeRequest: SubscribeRequest, seqErr: NonEmptyList[SubsError]) = {
+      Future.successful(
+        seqErr.head match {
+          case e: CheckoutIdentityFailure =>
+            logger.error(SubsError.header(e))
+            logger.warn(SubsError.toStringPretty(e))
 
-      val preliminarySubscribeRequest = {
-        subsForm.bindFromRequest.valueOr {
-          e =>
-            throw new Exception(scrub"Backend validation failed: identityId=${idUserOpt.map(_.user.id).mkString};" +
-              s" JavaScriptEnabled=${request.headers.toMap.contains("X-Requested-With")};" +
-              s" ${e.map(err => s"${err.key} ${err.message}").mkString(", ")}")
+            Forbidden(Json.obj("type" -> "CheckoutIdentityFailure",
+              "message" -> "User could not subscribe because Identity Service could not register the user"))
+
+          case e: CheckoutStripeError =>
+            logger.warn(SubsError.toStringPretty(e))
+
+            Forbidden(Json.obj(
+              "type" -> "CheckoutStripeError",
+              "message" -> e.paymentError.getMessage))
+
+          case e: CheckoutZuoraPaymentGatewayError =>
+            logger.warn(SubsError.toStringPretty(e))
+            PaymentGatewayError.process(e.paymentError, e.purchaserIds, subscribeRequest.genericData.personalData.address.countryName)
+
+          case e: CheckoutPaymentTypeFailure =>
+            logger.error(SubsError.header(e))
+            logger.warn(SubsError.toStringPretty(e))
+
+            Forbidden(Json.obj("type" -> "CheckoutPaymentTypeFailure",
+              "message" -> e.msg))
+
+          case e: CheckoutSalesforceFailure =>
+            logger.error(SubsError.header(e))
+            logger.warn(SubsError.toStringPretty(e))
+
+            Forbidden(Json.obj("type" -> "CheckoutSalesforceFailure",
+              "message" -> e.msg))
+
+          case e: CheckoutGenericFailure =>
+            logger.error(SubsError.header(e))
+            logger.warn(SubsError.toStringPretty(e))
+
+            Forbidden(Json.obj("type" -> "CheckoutGenericFailure",
+              "message" -> "User could not subscribe"))
         }
+      )
+    }
+
+    def success(subscribeRequest: SubscribeRequest, r: CheckoutSuccess, tpBackend: TouchpointBackend) = {
+
+      r.nonFatalErrors.map(e => SubsError.header(e) -> SubsError.toStringPretty(e)).foreach {
+        case (h, m) =>
+          logger.warn(h)
+          logger.error(m)
       }
-      val subscribeRequest = preliminarySubscribeRequest.copy(
-        genericData = preliminarySubscribeRequest.genericData.copy(
-          promoCode = preliminarySubscribeRequest.genericData.promoCode orElse sessionTrackingCode.map(PromoCode)
-        )
+      val productData = Seq(
+        SubsName -> r.subscribeResult.subscriptionName,
+        RatePlanId -> subscribeRequest.productRatePlanId.get,
+        SessionKeys.Currency -> subscribeRequest.genericData.currency.toString,
+        BillingCountryName -> subscribeRequest.genericData.personalData.address.countryName
       )
 
-      val requestData = SubscriptionRequestData(
-        ipCountry = request.getFastlyCountry,
-        supplierCode = sessionSupplierCode.map(SupplierCode)
-      )
-
-      val checkoutResult = checkoutService.processSubscription(subscribeRequest, idUserOpt, requestData)
-
-      def failure(seqErr: NonEmptyList[SubsError]) = {
-        Future.successful(
-          seqErr.head match {
-            case e: CheckoutIdentityFailure =>
-              logger.error(SubsError.header(e))
-              logger.warn(SubsError.toStringPretty(e))
-
-              Forbidden(Json.obj("type" -> "CheckoutIdentityFailure",
-                "message" -> "User could not subscribe because Identity Service could not register the user"))
-
-            case e: CheckoutStripeError =>
-              logger.warn(SubsError.toStringPretty(e))
-
-              Forbidden(Json.obj(
-                "type" -> "CheckoutStripeError",
-                "message" -> e.paymentError.getMessage))
-
-            case e: CheckoutZuoraPaymentGatewayError =>
-              logger.warn(SubsError.toStringPretty(e))
-              PaymentGatewayError.process(e.paymentError, e.purchaserIds, subscribeRequest.genericData.personalData.address.countryName)
-
-            case e: CheckoutPaymentTypeFailure =>
-              logger.error(SubsError.header(e))
-              logger.warn(SubsError.toStringPretty(e))
-
-              Forbidden(Json.obj("type" -> "CheckoutPaymentTypeFailure",
-                "message" -> e.msg))
-
-            case e: CheckoutSalesforceFailure =>
-              logger.error(SubsError.header(e))
-              logger.warn(SubsError.toStringPretty(e))
-
-              Forbidden(Json.obj("type" -> "CheckoutSalesforceFailure",
-                "message" -> e.msg))
-
-            case e: CheckoutGenericFailure =>
-              logger.error(SubsError.header(e))
-              logger.warn(SubsError.toStringPretty(e))
-
-              Forbidden(Json.obj("type" -> "CheckoutGenericFailure",
-                "message" -> "User could not subscribe"))
-          }
-        )
+      val userSessionFields = r.userIdData match {
+        case Some(GuestUser(UserId(userId), IdentityToken(token))) =>
+          Seq(SessionKeys.UserId -> userId, IdentityGuestPasswordSettingToken -> token)
+        case _ => Seq()
       }
 
-      def success(r: CheckoutSuccess) = {
-
-        r.nonFatalErrors.map(e => SubsError.header(e) -> SubsError.toStringPretty(e)).foreach {
-          case (h, m) =>
-            logger.warn(h)
-            logger.error(m)
-        }
-        val productData = Seq(
-          SubsName -> r.subscribeResult.subscriptionName,
-          RatePlanId -> subscribeRequest.productRatePlanId.get,
-          SessionKeys.Currency -> subscribeRequest.genericData.currency.toString,
-          BillingCountryName -> subscribeRequest.genericData.personalData.address.countryName
-        )
-
-        val userSessionFields = r.userIdData match {
-          case Some(GuestUser(UserId(userId), IdentityToken(token))) =>
-            Seq(SessionKeys.UserId -> userId, IdentityGuestPasswordSettingToken -> token)
-          case _ => Seq()
-        }
-
-        val appliedCode = r.validPromotion.flatMap(vp => vp.promotion.asTracking.fold[Option[PromoCode]](Some(vp.code))(_ => None))
-        val appliedCodeSession = appliedCode.map(promoCode => Seq(AppliedPromoCode -> promoCode.get)).getOrElse(Seq.empty)
-        val subscriptionDetails = Some(StartDate -> subscribeRequest.productData.fold(_.startDate, _ => LocalDate.now).toString("d MMMM YYYY"))
-        val marketingOptIn = Seq(MarketingOptIn -> subscribeRequest.genericData.personalData.receiveGnmMarketing.toString)
-        // Don't remove the SupplierTrackingCode from the session
-        val session = (productData ++ userSessionFields ++ marketingOptIn ++ appliedCodeSession ++ subscriptionDetails).foldLeft(request.session - AppliedPromoCode - PromotionTrackingCode) {
-          _ + _
-        }
-
-        def logAndReturnSuccess = {
-          logger.info(s"User successfully became subscriber:\n\tUser: SF=${r.salesforceMember.salesforceContactId}\n\tPlan: ${subscribeRequest.productData.fold(_.plan, _.plan).name}\n\tSubscription: ${r.subscribeResult.subscriptionName}")
-          Ok(Json.obj("redirect" -> routes.Checkout.thankYou().url)).withSession(session)
-        }
-
-        submitAcquisitionEvent(request, subscribeRequest).value.map { _ =>
-          logAndReturnSuccess
-        }.recoverWith {
-          case exception =>
-            logger.error(s"Failed to submit acquisition event correctly due to $exception")
-            Future.successful(logAndReturnSuccess)
-        }
+      val appliedCode = r.validPromotion.flatMap(vp => vp.promotion.asTracking.fold[Option[PromoCode]](Some(vp.code))(_ => None))
+      val appliedCodeSession = appliedCode.map(promoCode => Seq(AppliedPromoCode -> promoCode.get)).getOrElse(Seq.empty)
+      val subscriptionDetails = Some(StartDate -> subscribeRequest.productData.fold(_.startDate, _ => LocalDate.now).toString("d MMMM YYYY"))
+      val marketingOptIn = Seq(MarketingOptIn -> subscribeRequest.genericData.personalData.receiveGnmMarketing.toString)
+      // Don't remove the SupplierTrackingCode from the session
+      val session = (productData ++ userSessionFields ++ marketingOptIn ++ appliedCodeSession ++ subscriptionDetails).foldLeft(request.session - AppliedPromoCode - PromotionTrackingCode) {
+        _ + _
       }
 
-      def submitAcquisitionEvent(request: Request[AnyContent], subscribeRequest: SubscribeRequest): EitherT[Future, Unit, AcquisitionSubmission] = {
-        val testUser = TestUsers.isTestUser(PreSigninTestCookie, request.cookies)(request)
+      def logAndReturnSuccess = {
+        logger.info(s"User successfully became subscriber:\n\tUser: SF=${r.salesforceMember.salesforceContactId}\n\tPlan: ${subscribeRequest.productData.fold(_.plan, _.plan).name}\n\tSubscription: ${r.subscribeResult.subscriptionName}")
+        Ok(Json.obj("redirect" -> routes.Checkout.thankYou().url)).withSession(session)
+      }
+
+      submitAcquisitionEvent(request, subscribeRequest, tpBackend).value.map { _ =>
+        logAndReturnSuccess
+      }.recoverWith {
+        case exception =>
+          logger.error(s"Failed to submit acquisition event correctly due to $exception")
+          Future.successful(logAndReturnSuccess)
+      }
+    }
+
+    def submitAcquisitionEvent(request: Request[AnyContent], subscribeRequest: SubscribeRequest, tpBackend: TouchpointBackend): EitherT[Future, Unit, AcquisitionSubmission] = {
+      val testUserResult = EitherT.right[Unit](testUsersService.isTestUser(PreSigninTestCookie, request.cookies)(request))
+      testUserResult.flatMap { testUser =>
         if(testUser.isEmpty) {
           val acquisitionData = request.session.get("acquisitionData")
           if (acquisitionData.isEmpty) {
@@ -184,10 +165,38 @@ class CheckoutHandler(fBackendFactory: TouchpointBackends, commonActions: Common
           EitherT(either) // Don't submit acquisitions for test users
         }
       }
-
-      checkoutResult.flatMap(_.fold(failure, success))
-
     }
 
+    for {
+      resolution <- fBackendFactory.forRequest(NameEnteredInForm, tempData)
+      idUserOpt <- authenticationService.tryAuthenticatedUserFor(request)
+      subsForm <- resolution.backend.subsForm
+      subscribeRequest = {
+        val preliminarySubscribeRequest = {
+          subsForm.bindFromRequest.valueOr {
+            e =>
+              throw new Exception(scrub"Backend validation failed: identityId=${idUserOpt.map(_.user.id).mkString};" +
+                s" JavaScriptEnabled=${request.headers.toMap.contains("X-Requested-With")};" +
+                s" ${e.map(err => s"${err.key} ${err.message}").mkString(", ")}")
+          }
+        }
+        preliminarySubscribeRequest.copy(
+          genericData = preliminarySubscribeRequest.genericData.copy(
+            promoCode = preliminarySubscribeRequest.genericData.promoCode orElse sessionTrackingCode.map(PromoCode)
+          )
+        )
+      }
+      requestData = SubscriptionRequestData(
+        ipCountry = request.getFastlyCountry,
+        supplierCode = sessionSupplierCode.map(SupplierCode)
+      )
+      checkoutResult <- checkoutService(resolution).processSubscription(subscribeRequest, idUserOpt, requestData)
+      result <- checkoutResult.fold(
+        errs => failure(subscribeRequest, errs),
+        checkoutSuccess => success(subscribeRequest, checkoutSuccess, resolution.backend)
+      )
+    } yield {
+      result
+    }
   }
 }

--- a/app/controllers/Testing.scala
+++ b/app/controllers/Testing.scala
@@ -5,7 +5,7 @@ import com.gu.memsub.subsv2.CatalogPlan.Paid
 import com.typesafe.scalalogging.LazyLogging
 import play.api.mvc.{BaseController, ControllerComponents, Cookie}
 import services.TouchpointBackend
-import utils.TestUsers.testUsers
+import utils.TestUsersService.testUsers
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future

--- a/app/filters/AddGuIdentityHeaders.scala
+++ b/app/filters/AddGuIdentityHeaders.scala
@@ -3,21 +3,27 @@ package filters
 import akka.stream.Materializer
 import play.api.http.HeaderNames
 import play.api.mvc._
-import services.AuthenticationService
-import utils.TestUsers._
+import services.AsyncAuthenticationService
+import utils.TestUsersService._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AddGuIdentityHeaders (implicit val mat: Materializer, val executionContext: ExecutionContext) extends Filter with HeaderNames {
+class AddGuIdentityHeaders(authenticationService: AsyncAuthenticationService)(implicit val mat: Materializer, val executionContext: ExecutionContext) extends Filter with HeaderNames {
 
-  def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = for {
-    result <- nextFilter(requestHeader)
-  } yield (for {
-    cacheHeader <- result.header.headers.get(CACHE_CONTROL) if cacheHeader.contains("no-cache")
-    user <- AuthenticationService.authenticatedUserFor(requestHeader)
-  } yield result.withHeaders(
-    "X-Gu-Identity-Id" -> user.id,
-    "X-Gu-Membership-Test-User" -> SignedInUsername.passes(user).isDefined.toString
-  )).getOrElse(result)
+  def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] =
+    for {
+      result <- nextFilter(requestHeader)
+      userOpt <- authenticationService.tryAuthenticatedUserFor(requestHeader)
+    } yield {
+      (for {
+        user <- userOpt
+        cacheHeader <- result.header.headers.get(CACHE_CONTROL) if cacheHeader.contains("no-cache")
+      } yield {
+        result.withHeaders(
+          "X-Gu-Identity-Id" -> user.id,
+          "X-Gu-Membership-Test-User" -> SignedInUsername.passes(user).isDefined.toString
+        )
+      }).getOrElse(result)
+    }
 
 }

--- a/app/services/AuthenticationService.scala
+++ b/app/services/AuthenticationService.scala
@@ -1,8 +1,26 @@
 package services
 
 import com.gu.identity.cookie.IdentityKeys
+import com.gu.identity.play.AuthenticatedIdUser
 import configuration.Config
+import play.api.mvc.RequestHeader
+
+import scala.concurrent.{ExecutionContext, Future}
 
 object AuthenticationService extends com.gu.identity.play.AuthenticationService {
   override val identityKeys: IdentityKeys = Config.Identity.keys
+}
+
+class AsyncAuthenticationService(implicit ec: ExecutionContext) {
+
+  def authenticatedUserFor(requestHeader: RequestHeader): Future[AuthenticatedIdUser] =
+    AuthenticationService.authenticatedUserFor(requestHeader) match {
+      case Some(user) => Future.successful(user)
+      case None => Future.failed(new RuntimeException("unable to authenticate user"))
+    }
+
+  def tryAuthenticatedUserFor(requestHeader: RequestHeader): Future[Option[AuthenticatedIdUser]] =
+    authenticatedUserFor(requestHeader)
+      .map(user => Option(user))
+      .recover { case _ => None }
 }

--- a/app/utils/OptionTSyntax.scala
+++ b/app/utils/OptionTSyntax.scala
@@ -1,0 +1,16 @@
+package utils
+
+import scalaz.OptionT
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait OptionTSyntax {
+
+  // Provides pure() method on OptionT companion object similar to one provided by cats:
+  // https://typelevel.org/cats/api/cats/data/OptionT$.html#pure[F[_]]:cats.data.OptionT.PurePartiallyApplied[F]
+  // No need to make it generic in F, since F will always be a Future in our case.
+  implicit class OptionTOps(obj: OptionT.type) {
+    def pure[A](data: Future[A])(implicit ec: ExecutionContext): OptionT[Future, A] =
+      OptionT[Future, A](data.map(Some.apply))
+  }
+}

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -3,7 +3,7 @@
 @import controllers.WeeklyLandingPage.Hreflangs
 @import model.DigitalEdition
 @import controllers.CachedAssets.hashedPathFor
-@import utils.TestUsers.{NameEnteredInForm, PreSigninTestCookie, SignedInUsername}
+@import utils.TestUsersService.{NameEnteredInForm, PreSigninTestCookie, SignedInUsername}
 @import utils.Tracking
 @(
     title: String,


### PR DESCRIPTION
Identity are wanting to centralise user authentication i.e. an application should authenticate a user by making a call to the authentication endpoint in identity API (please talk to us in person for more context).

This changes the type signature of user authentication from:
```scala
RequestHeader => Option[U]
```
to:
```scala
RequestHeader => Future[Option[U]]
```
To lay the ground-work for this change, define and use the class `AsyncAuthenticatedBuilder` to support this change in type signature.  

__Notes:__
- this PR does not change the authentication mechanism used; authenticating via the identity API will be done in a subsequent PR
- apologies for the savage diffs in this PR; refactoring was quite awkward in some places since the ubiquitous:
    ```scala
    implicit val resolution: TouchpointBackend.Resolution = touchpointBackends.forRequest(...)
    implicit val tpBackend: TouchpointBackend = resolution.backend
    ```
    is now asynchronous (`forRequest()` relies on authenticating a user); I will annotate some of the diffs to hopefully make them easier to digest.