### PR TITLE
user models from identity-model rather than identity-play-auth

### DIFF
--- a/app/model/IdUserOps.scala
+++ b/app/model/IdUserOps.scala
@@ -1,33 +1,31 @@
 package model
 
-import com.gu.identity.play.{IdUser, PrivateFields}
+import com.gu.identity.model.{User => IdUser, _}
 import com.gu.memsub.Address
 
 object IdUserOps {
   implicit class IdUserWithAddress(u: IdUser) {
 
     def billingAddress: Address = {
-      val pf = u.privateFields.getOrElse(PrivateFields())
-        Address(
-          lineOne = pf.billingAddress1.getOrElse(""),
-          lineTwo = pf.billingAddress2.getOrElse(""),
-          town = pf.billingAddress3.getOrElse(""),
-          countyOrState = pf.billingAddress4.getOrElse(""),
-          postCode = pf.billingPostcode.getOrElse(""),
-          countryName = pf.billingCountry.getOrElse("")
-        )
+      Address(
+        lineOne = u.privateFields.billingAddress1.getOrElse(""),
+        lineTwo = u.privateFields.billingAddress2.getOrElse(""),
+        town = u.privateFields.billingAddress3.getOrElse(""),
+        countyOrState = u.privateFields.billingAddress4.getOrElse(""),
+        postCode = u.privateFields.billingPostcode.getOrElse(""),
+        countryName = u.privateFields.billingCountry.getOrElse("")
+      )
     }
 
     def correspondenceAddress: Address = {
-      val pf = u.privateFields.getOrElse(PrivateFields())
-        Address(
-          lineOne = pf.address1.getOrElse(""),
-          lineTwo = pf.address2.getOrElse(""),
-          town = pf.address3.getOrElse(""),
-          countyOrState = pf.address4.getOrElse(""),
-          postCode = pf.postcode.getOrElse(""),
-          countryName = pf.country.getOrElse("")
-        )
+      Address(
+        lineOne = u.privateFields.address1.getOrElse(""),
+        lineTwo = u.privateFields.address2.getOrElse(""),
+        town = u.privateFields.address3.getOrElse(""),
+        countyOrState = u.privateFields.address4.getOrElse(""),
+        postCode = u.privateFields.postcode.getOrElse(""),
+        countryName = u.privateFields.country.getOrElse("")
+      )
     }
   }
 }

--- a/app/model/SubscriptionData.scala
+++ b/app/model/SubscriptionData.scala
@@ -86,7 +86,7 @@ object PersonalData {
       first = u.privateFields.firstName.mkString,
       last = u.privateFields.secondName.mkString,
       email = u.primaryEmailAddress,
-      receiveGnmMarketing = false,
+      receiveGnmMarketing = false, // Deprecated, unused and not a GDPR compliant consent
       address = u.billingAddress,
       telephoneNumber = phoneNumber
     )

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -1,7 +1,9 @@
 package services
 
 import com.amazonaws.regions.{Region, Regions}
-import com.gu.identity.play._
+import com.gu.identity.model.play.ReadsInstances
+import com.gu.identity.model.{User => IdUser}
+import com.gu.identity.play.{AccessCredentials, CookieBuilder, AuthenticatedIdUser, IdMinimalUser}
 import com.gu.memsub.{Address, NormalisedTelephoneNumber}
 import com.gu.monitoring._
 import com.gu.monitoring.SafeLogger._
@@ -20,7 +22,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.language.{higherKinds, implicitConversions}
 import scalaz.{Monad, NonEmptyList, \/}
 
-class IdentityService[M[_]](identityApiClient: => IdentityApiClient[M])(implicit monad: Monad[M]) extends LazyLogging {
+class IdentityService[M[_]](identityApiClient: => IdentityApiClient[M])(implicit monad: Monad[M]) extends LazyLogging with ReadsInstances {
 
   import IdentityService._
 

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ libraryDependencies ++= Seq(
     jodaForms,
     PlayImport.specs2 % "test",
     "com.gu" %% "membership-common" % "0.533",
-    "com.gu.identity" %% "identity-play-auth" % "2.5",
+    "com.gu.identity" %% "identity-play-auth" % "2.6",
     "com.gu.identity" %% "identity-model-play" % "3.184-M6",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.6",

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ libraryDependencies ++= Seq(
     PlayImport.specs2 % "test",
     "com.gu" %% "membership-common" % "0.533",
     "com.gu.identity" %% "identity-play-auth" % "2.5",
+    "com.gu.identity" %% "identity-model-play" % "3.184-M6",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.6",
     "com.gu" %% "identity-test-users" % "0.6",

--- a/test/model/IdUserOpsTest.scala
+++ b/test/model/IdUserOpsTest.scala
@@ -1,7 +1,7 @@
 package model
 
 import com.gu.memsub.Address
-import com.gu.identity.play.{PublicFields, PrivateFields, IdUser}
+import com.gu.identity.model.{PrivateFields, PublicFields, StatusFields, User => IdUser}
 import org.specs2.mutable.Specification
 import IdUserOps._
 
@@ -12,9 +12,10 @@ class IdUserOpsTest extends Specification {
       IdUser(
         id = "id",
         primaryEmailAddress = "email",
-        publicFields = PublicFields(None),
-        privateFields = Some(fields),
-        statusFields = None)
+        publicFields = PublicFields(),
+        privateFields = fields,
+        statusFields = StatusFields()
+      )
 
     val billingAddress = PrivateFields(
       billingAddress1 = Some("billingAddress1"),

--- a/test/services/IdentityServiceTest.scala
+++ b/test/services/IdentityServiceTest.scala
@@ -57,6 +57,7 @@ class IdentityServiceTest extends FreeSpec with Matchers {
     val invalidCookies = AccessCredentials.Cookies("invalid_cookie")
 
     val client = new TestIdentityApiClient {
+      import com.gu.identity.model.play.WritesInstances.userWrites
       override val userLookupByCookies = (cookies: AccessCredentials.Cookies) =>
         {
           val body =

--- a/test/utils/TestIdUser.scala
+++ b/test/utils/TestIdUser.scala
@@ -1,20 +1,20 @@
 package utils
 
-import com.gu.identity.play._
+import com.gu.identity.model.{PrivateFields, PublicFields, StatusFields, TelephoneNumber, User => IdUser}
 import play.api.libs.json._
 
 object TestIdUser {
-  implicit val writesStatusFields = Json.writes[StatusFields]
-  implicit val writesTelephoneNumber = Json.writes[TelephoneNumber]
-  implicit val writesPrivateFields = Json.writes[PrivateFields]
-  implicit val writesPublicFields = Json.writes[PublicFields]
-  implicit val writesIdUser = Json.writes[IdUser]
+//  implicit val writesStatusFields = Json.writes[StatusFields]
+//  implicit val writesTelephoneNumber = Json.writes[TelephoneNumber]
+//  implicit val writesPrivateFields = Json.writes[PrivateFields]
+//  implicit val writesPublicFields = Json.writes[PublicFields]
+//  implicit val writesIdUser = Json.writes[IdUser]
 
   val testUser = IdUser(
     id = "test-user",
     primaryEmailAddress = "test-user@example.com",
     publicFields = PublicFields(None),
-    privateFields = None,
-    statusFields = None
+    privateFields = PrivateFields(),
+    statusFields = StatusFields()
   )
 }

--- a/test/utils/TestIdUser.scala
+++ b/test/utils/TestIdUser.scala
@@ -1,14 +1,8 @@
 package utils
 
-import com.gu.identity.model.{PrivateFields, PublicFields, StatusFields, TelephoneNumber, User => IdUser}
-import play.api.libs.json._
+import com.gu.identity.model.{PrivateFields, PublicFields, StatusFields, User => IdUser}
 
 object TestIdUser {
-//  implicit val writesStatusFields = Json.writes[StatusFields]
-//  implicit val writesTelephoneNumber = Json.writes[TelephoneNumber]
-//  implicit val writesPrivateFields = Json.writes[PrivateFields]
-//  implicit val writesPublicFields = Json.writes[PublicFields]
-//  implicit val writesIdUser = Json.writes[IdUser]
 
   val testUser = IdUser(
     id = "test-user",


### PR DESCRIPTION
#1265 introduces the types for authentication using the identity API; in a subsequent PR [`identity-auth-play`](https://github.com/guardian/identity/tree/master/identity-auth-play/src) will be used to implement this authentication. 

Since this library will remove the user models currently being used, in favour for the user models in `identity-model`, I have split this out into a separate PR since there were [issues](https://github.com/guardian/support-frontend/pull/1984) when I previously tried to make analogous changes in support frontend in a single PR.