### PR TITLE
Fix aus checkout for gweekly

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ By default, the setup script will hash file assets and generate a `conf/assets.m
 which in turn will cause Play to render assets with their hashed path. Use the `grunt compile --dev`
 task in order to have Play to render assets without hashing them.
 
-Alternatively, run `grunt watch --dev`, to dynamically recompile assets as they get edited.
+Then run `grunt watch --dev`, to dynamically recompile assets as they get edited.
 
 ## Test execution
 

--- a/assets/javascripts/modules/checkout/submit.js
+++ b/assets/javascripts/modules/checkout/submit.js
@@ -63,7 +63,7 @@ define([
             submitEl.removeAttribute('disabled');
         }
 
-        var stripeKey = deriveStripeKeyFromDeliveryCountry()
+        var stripeKey = deriveStripeKeyFromAddresses()
 
         handler = StripeCheckout.configure(Object.assign({}, guardian.stripeCheckout, {'key' : stripeKey}));
         bean.on(window, 'popstate', handler.close);
@@ -91,9 +91,15 @@ define([
         });
     }
 
-    function deriveStripeKeyFromDeliveryCountry() {
-        var deliveryAddressOption = document.querySelectorAll('#delivery-address-country option:checked')[0];
-        var stripeServiceName = (deliveryAddressOption && deliveryAddressOption.dataset.stripeServiceName) || 'ukPublicKey';
+    function deriveStripeKeyFromAddresses() {
+        var useDeliveryAddressForBillingCheckbox = document.querySelector('.js-checkout-delivery-same-as-billing')
+
+        var billingCountryOption = useDeliveryAddressForBillingCheckbox.checked ?
+            document.querySelectorAll('#delivery-address-country option:checked')[0] :
+            document.querySelectorAll('#personal-address-country option:checked')[0];
+
+        var stripeServiceName = (billingCountryOption && billingCountryOption.dataset.stripeServiceName) || 'ukPublicKey';
+
         return guardian.stripe[stripeServiceName]
     }
 

--- a/assets/javascripts/modules/checkout/submit.js
+++ b/assets/javascripts/modules/checkout/submit.js
@@ -63,23 +63,20 @@ define([
             submitEl.removeAttribute('disabled');
         }
 
-        var deliveryCountryElement = document.querySelector('#delivery-address-country')
-        var deliveryCountry = deliveryCountryElement.options[deliveryCountryElement.selectedIndex].value
+        var stripeKey = deriveStripeKeyFromDeliveryCountry()
 
-        handler = StripeCheckout.configure(stripeConfigWithCorrectKey(guardian.stripeCheckout, guardian.stripe, deliveryCountry));
+        handler = StripeCheckout.configure(Object.assign({}, guardian.stripeCheckout, {'key' : stripeKey}));
         bean.on(window, 'popstate', handler.close);
 
         var successfulCharge = false;
         var ratePlan = document.querySelector('.js-rate-plans input:checked').dataset;
-        var checkedOption = document.querySelectorAll('#personal-address-country option:checked')[0];
-        var stripeServiceName = (checkedOption && checkedOption.dataset.stripeServiceName) || 'ukPublicKey';
 
         handler.open({
             currency: ratePlan.currency,
             description: ratePlan.optionMirrorPackage,
             panelLabel: 'Subscribe',
             email: formElements.$EMAIL.val(),
-            key: guardian.stripe[stripeServiceName],
+            key: stripeKey,
             token: function (token) {
                 successfulCharge = token;
                 stripeCheckout.setPaymentToken(token.id);
@@ -94,10 +91,10 @@ define([
         });
     }
 
-    function stripeConfigWithCorrectKey(stripeCheckout, stripeKeys, country) {
-        var stripeKey = (country === 'AU' ? stripeKeys.auPublicKey : stripeKeys.ukPublicKey)
-
-        return Object.assign({}, stripeCheckout, {'key' : stripeKey})
+    function deriveStripeKeyFromDeliveryCountry() {
+        var deliveryAddressOption = document.querySelectorAll('#delivery-address-country option:checked')[0];
+        var stripeServiceName = (deliveryAddressOption && deliveryAddressOption.dataset.stripeServiceName) || 'ukPublicKey';
+        return guardian.stripe[stripeServiceName]
     }
 
     function send(pageViewId) {

--- a/assets/javascripts/modules/checkout/submit.js
+++ b/assets/javascripts/modules/checkout/submit.js
@@ -63,7 +63,10 @@ define([
             submitEl.removeAttribute('disabled');
         }
 
-        handler = StripeCheckout.configure(guardian.stripeCheckout);
+        var deliveryCountryElement = document.querySelector('#delivery-address-country')
+        var deliveryCountry = deliveryCountryElement.options[deliveryCountryElement.selectedIndex].value
+
+        handler = StripeCheckout.configure(stripeConfigWithCorrectKey(guardian.stripeCheckout, guardian.stripe, deliveryCountry));
         bean.on(window, 'popstate', handler.close);
 
         var successfulCharge = false;
@@ -89,6 +92,12 @@ define([
                 }
             }
         });
+    }
+
+    function stripeConfigWithCorrectKey(stripeCheckout, stripeKeys, country) {
+        var stripeKey = (country === 'AU' ? stripeKeys.auPublicKey : stripeKeys.ukPublicKey)
+
+        return Object.assign({}, stripeCheckout, {'key' : stripeKey})
     }
 
     function send(pageViewId) {


### PR DESCRIPTION
This PR contains a fix for an issue where CSRs would not be able to create subscriptions for users in Australia.

The issue was due to the UK stripe key being used for those transactions.

This change ensures the stripe key corresponding to the billing address is used when creating the stripe component.