### PR TITLE
Add check for checkbox existence

### DIFF
--- a/assets/javascripts/modules/checkout/submit.js
+++ b/assets/javascripts/modules/checkout/submit.js
@@ -92,9 +92,9 @@ define([
     }
 
     function deriveStripeKeyFromAddresses() {
-        var useDeliveryAddressForBillingCheckbox = document.querySelector('.js-checkout-delivery-same-as-billing')
+        var useDeliveryAddressForBillingCheckbox = document.querySelector('.js-checkout-delivery-same-as-billing');
 
-        var billingCountryOption = useDeliveryAddressForBillingCheckbox.checked ?
+        var billingCountryOption = useDeliveryAddressForBillingCheckbox && useDeliveryAddressForBillingCheckbox.checked ?
             document.querySelectorAll('#delivery-address-country option:checked')[0] :
             document.querySelectorAll('#personal-address-country option:checked')[0];
 


### PR DESCRIPTION
Adding a check for the existence of the checkbox, currently causing the Digipack checkout to fail as it doesn't have a delivery address only a billing address