### PR TITLE
Adding Editions team to access for test-users

### DIFF
--- a/app/actions/OAuthActions.scala
+++ b/app/actions/OAuthActions.scala
@@ -42,7 +42,8 @@ final class OAuthActions(
     "touchpoint@guardian.co.uk",
     "crm@guardian.co.uk",
     "dig.qa@guardian.co.uk",
-    "membership.testusers@guardian.co.uk"
+    "membership.testusers@guardian.co.uk",
+    "editions.product@guardian.co.uk"
   ))
 
   val StaffAuthorisedForCASAction = GoogleAuthenticatedStaffAction andThen requireGroup[GoogleAuthRequest](Set(


### PR DESCRIPTION
Members of the Editions team would like access to test-users for the purpose of testing acquisition/onboarding journeys for Editions.

This version of test users provides some nice functionality still, which we haven't replaced on support.theguardian.com AFAICT.