### PR TITLE
update sbt-dependency-graph to allow snyk monitor to work

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.2")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")
 


### PR DESCRIPTION
After updating sbt to 1.3.2, snyk monitor didn't work any more.  This causes snyk monitor not to realise the dependencies have changed.
I have bumped it to the latest, but actually there are still outstanding bugs.  At least this means this step will pass. See the issue on the plugin: https://github.com/jrudolph/sbt-dependency-graph/issues/178
@alexflav23 @twrichards 