### PR TITLE
Update USA & Canada's phone line opening times

### DIFF
--- a/app/views/support/ContactCentreOps.scala
+++ b/app/views/support/ContactCentreOps.scala
@@ -12,7 +12,7 @@ object ContactCentreOps {
 
   def phone(contactUsCountry: Option[Country] = None): String = {
     if (contactUsCountry exists countriesHandledByUSCallCentre)
-      s"1-844-632-2010 (toll free); ${directLine(contactUsCountry)} (direct line). Lines are open 9:15am-6pm, Monday to Friday (EST/EDT)"
+      s"1-844-632-2010 (toll free); ${directLine(contactUsCountry)} (direct line). Lines are open 9am - 5pm on weekdays (EST)"
     else if (contactUsCountry exists countriesHandledByAUCallCentre)
       s"1800 773 766 (within Australia & toll free); ${directLine(contactUsCountry)} (direct line/outside Australia). Lines are open 9am-5pm, Monday to Friday (AEDT) excluding public holidays"
     else if (contactUsCountry.contains(UK))

--- a/app/views/support/ContactCentreOps.scala
+++ b/app/views/support/ContactCentreOps.scala
@@ -12,7 +12,7 @@ object ContactCentreOps {
 
   def phone(contactUsCountry: Option[Country] = None): String = {
     if (contactUsCountry exists countriesHandledByUSCallCentre)
-      s"1-844-632-2010 (toll free); ${directLine(contactUsCountry)} (direct line). Lines are open 9am - 5pm on weekdays (EST)"
+      s"1-844-632-2010 (toll free); ${directLine(contactUsCountry)} (direct line). Lines are open 9am - 5pm on weekdays (EST/EDT)"
     else if (contactUsCountry exists countriesHandledByAUCallCentre)
       s"1800 773 766 (within Australia & toll free); ${directLine(contactUsCountry)} (direct line/outside Australia). Lines are open 9am-5pm, Monday to Friday (AEDT) excluding public holidays"
     else if (contactUsCountry.contains(UK))


### PR DESCRIPTION
In this PR there is a small change to the copy relating the the USA & Canada's phone lines opening times.

![image](https://user-images.githubusercontent.com/5294853/68194263-a0dff380-ffac-11e9-9f30-1dad026383de.png)


This has been done to reflect that the contact centre closes at 5pm(EST) rather than the original 6:00(EST) 

Trello Ticket: https://trello.com/c/7IZ6kisi/631-update-opening-hours-on-all-mma-platforms