### PR TITLE
Bump membership-common to support GW 3 month plan

### DIFF
--- a/app/model/Email.scala
+++ b/app/model/Email.scala
@@ -72,7 +72,7 @@ object DigipackWelcome1Email extends LazyLogging {
     val paymentDelay = daysBetween(subscription.startDate, subscription.firstPaymentDate).minus(gracePeriod)
 
     val paymentFields = paymentMethod match {
-      case GoCardless(mandateId, accName, accNumber, sortCode) => Seq(
+      case GoCardless(mandateId, accName, accNumber, sortCode, _, _) => Seq(
         "Account number" -> formatAccountNumber(accNumber),
         "Sort Code" -> formatSortCode(sortCode),
         "Account Name" -> accName,
@@ -157,7 +157,7 @@ object PaperFieldsGenerator {
                  promotionDescription: Option[String]
                ): Seq[(String, String)] = {
     val paymentFields = paymentMethod match {
-      case GoCardless(mandateId, accName, accNumber, sortCode) => Seq(
+      case GoCardless(mandateId, accName, accNumber, sortCode, _, _) => Seq(
         "bank_account_no" -> formatAccountNumber(accNumber),
         "bank_sort_code" -> formatSortCode(sortCode),
         "account_holder" -> accName,

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ libraryDependencies ++= Seq(
     filters,
     jodaForms,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.533",
+    "com.gu" %% "membership-common" % "0.553",
     "com.gu.identity" %% "identity-auth-play" % "3.184-M7",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.6",


### PR DESCRIPTION
Similar to https://github.com/guardian/members-data-api/pull/413 we want to support the **new GW 3 month plan** on this legacy platform since some customers will have received links in welcome emails and/or already be familiar with `/manage` for viewing these subs.