### PR TITLE
Pushing users to manage plaform for management of holiday stops

### DIFF
--- a/app/utils/ManageUrlBuilder.scala
+++ b/app/utils/ManageUrlBuilder.scala
@@ -1,0 +1,23 @@
+package utils
+
+import com.gu.memsub.Product
+
+object ManageUrlBuilder {
+  def paymentUrl(baseUrl: String, product: Product) = {
+    productSpecificUrl(baseUrl, "payment", product)
+  }
+
+  def suspendUrl(baseUrl: String, product: Product) = {
+      productSpecificUrl(baseUrl, "suspend", product)
+  }
+
+  private def productSpecificUrl(baseUrl: String, path: String, product: Product )= {
+    product match {
+      case Product.Voucher => s"$baseUrl/$path/voucher"
+      case Product.Delivery => s"$baseUrl/$path/delivery"
+      case _: Product.ZDigipack => s"$baseUrl/$path/digitalpack"
+      case _: Product.Weekly => s"$baseUrl/$path/guardianweekly"
+      case _ => ""
+    }
+  }
+}

--- a/app/utils/ManageUrlBuilder.scala
+++ b/app/utils/ManageUrlBuilder.scala
@@ -14,7 +14,7 @@ object ManageUrlBuilder {
   private def productSpecificUrl(baseUrl: String, path: String, product: Product )= {
     product match {
       case Product.Voucher => s"$baseUrl/$path/voucher"
-      case Product.Delivery => s"$baseUrl/$path/delivery"
+      case Product.Delivery => s"$baseUrl/$path/homedelivery"
       case _: Product.ZDigipack => s"$baseUrl/$path/digitalpack"
       case _: Product.Weekly => s"$baseUrl/$path/guardianweekly"
       case _ => ""

--- a/app/views/account/delivery.scala.html
+++ b/app/views/account/delivery.scala.html
@@ -62,44 +62,14 @@
                 }
             </section>
 
-            @if((suspendableDays - suspendedDays) > 0) {
-                <section class="mma-section">
-                    <form class="form js-suspend-form" action="@routes.AccountManagement.processSuspension().url" method="POST" novalidate>
-                        <fieldset>
-                            <legend class="mma-section__header">
-                                Book a delivery holiday
-                            </legend>
-                            @helper.CSRF.formField
-
-                            <div class="form-field js-suspend-start-date mma-dates__fields">
-                                <ul class="mma-error-list">
-                                @errorCodes.map { code => <li class="form-field__error-message mma-error-list__item">@getMessageFromCode(code)</li> }
-                                </ul>
-                                <div id="dateRangePicker"
-                                firstPaymentDate="@prettyDate(subscription.firstPaymentDate)"
-                                remainingDays="@{
-                                    suspendableDays - suspendedDays
-                                }"
-                                excludeExistingDays="@{
-                                    holidayRefunds.flatMap(x => holidayToDays(x._2.start, x._2.finish)).map(prettyDate).mkString(",")
-                                }"
-                                ratePlanName="@subscription.plan.name"></div>
-                            </div>
-                            <button type="submit" class="js-suspend-submit button button--primary button--large u-margin-bottom mma-dates__button">
-                                Create
-                            </button>
-                        </fieldset>
-                    </form>
-                    <span class="mma-dates__request">
-                        Please give us at least 3 days notice to process the delivery holiday. You can line up to @suspendableWeeks weeks of holidays.
-                        <strong>All dates are inclusive</strong>.
-                    </span>
-                </section>
-            }
+            <section class="mma-section">
+                <h3 class="mma-section__header">Book a delivery holiday</h3>
+                @views.html.account.fragments.manageSuspension(subscription, maybeEmail, subscription.plans.head.product, Some(Country.UK))
+            </section>
 
             <section class="mma-section">
                 <h3 class="mma-section__header">Upcoming delivery holidays</h3>
-                @account.fragments.suspensions(holidayRefunds, suspendableDays, suspendedDays)
+                @account.fragments.suspensions(holidayRefunds, suspendableDays, suspendedDays, maybeEmail, subscription.plans.head.product)
             </section>
             @billingSchedule.map { bs =>
                 <section class="mma-section">
@@ -137,12 +107,12 @@
                     </form>
                 </section>
             }
-            
+
             <section class="mma-section">
                 <h3 class="mma-section__header">Update your payment method</h3>
                 @views.html.account.fragments.paymentUpdate(subscription, maybeEmail, subscription.plans.head.product, Some(Country.UK))
             </section>
-            
+
         </section>
     </main>
 }

--- a/app/views/account/delivery.scala.html
+++ b/app/views/account/delivery.scala.html
@@ -69,7 +69,7 @@
 
             <section class="mma-section">
                 <h3 class="mma-section__header">Upcoming delivery holidays</h3>
-                @account.fragments.suspensions(holidayRefunds, suspendableDays, suspendedDays, maybeEmail, subscription.plans.head.product)
+                @account.fragments.suspensions(holidayRefunds, suspendableDays, suspendedDays, maybeEmail.isDefined, subscription.plans.head.product)
             </section>
             @billingSchedule.map { bs =>
                 <section class="mma-section">

--- a/app/views/account/fragments/manageSuspension.scala.html
+++ b/app/views/account/fragments/manageSuspension.scala.html
@@ -7,12 +7,14 @@
 
 @(subscription:Subscription[SubscriptionPlan.ContentSubscription], maybeEmail: Option[String], product: Product, contactUsCountry: Option[Country])
 
-<div class="js-suspend-update" data-sub-id="@{subscription.name.get}" @for(email <- maybeEmail) {data-email="@email"} data-phone="@product.phone(contactUsCountry)" data-product="@product.name">
-    @if(maybeEmail.isDefined) {
-        <a href="@suspendUrl(Config.manageUrl, product)">
-            <button class="button button--primary button--large">Manage your delivery holidays</button>
-        </a>
-    } else {
-        <p>To manage your delivery holidays, please contact the call centre. @product.phone(contactUsCountry)</p>
-    }
-</div>
+@defining(maybeEmail.isDefined) { userIsLoggedIn =>
+    <div class="js-suspend-update" data-sub-id="@{subscription.name.get}" @for(email <- maybeEmail) {data-email="@email"} data-phone="@product.phone(contactUsCountry)" data-product="@product.name">
+        @if(userIsLoggedIn) {
+            <a href="@suspendUrl(Config.manageUrl, product)">
+                <button class="button button--primary button--large">Manage your delivery holidays</button>
+            </a>
+        } else {
+            <p>To manage your delivery holidays, please contact the call centre. @product.phone(contactUsCountry)</p>
+        }
+    </div>
+}

--- a/app/views/account/fragments/manageSuspension.scala.html
+++ b/app/views/account/fragments/manageSuspension.scala.html
@@ -1,0 +1,18 @@
+@import com.gu.i18n.Country
+@import com.gu.memsub.Product
+@import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
+@import views.support.PlanOps._
+@import configuration.Config
+@import utils.ManageUrlBuilder._
+
+@(subscription:Subscription[SubscriptionPlan.ContentSubscription], maybeEmail: Option[String], product: Product, contactUsCountry: Option[Country])
+
+<div class="js-suspend-update" data-sub-id="@{subscription.name.get}" @for(email <- maybeEmail) {data-email="@email"} data-phone="@product.phone(contactUsCountry)" data-product="@product.name">
+    @if(maybeEmail.isDefined) {
+        <a href="@suspendUrl(Config.manageUrl, product)">
+            <button class="button button--primary button--large">Manage your delivery holidays</button>
+        </a>
+    } else {
+        <p>To manage your delivery holidays, please contact the call centre. @product.phone(contactUsCountry)</p>
+    }
+</div>

--- a/app/views/account/fragments/paymentUpdate.scala.html
+++ b/app/views/account/fragments/paymentUpdate.scala.html
@@ -3,22 +3,13 @@
 @import com.gu.memsub.subsv2.{Subscription, SubscriptionPlan}
 @import views.support.PlanOps._
 @import configuration.Config
+@import utils.ManageUrlBuilder._
 
 @(subscription:Subscription[SubscriptionPlan.ContentSubscription], maybeEmail: Option[String], product: Product, contactUsCountry: Option[Country])
 
-@managePaymentPath = {@product match {
-    case _: Product.ZDigipack => {payment/digitalpack}
-    case _: Product.Weekly => {payment/guardianweekly}
-    case _: Product.Paper => {payment/paper}
-    case _ => {}
-}}
-
-@manageBaseUrl = {@Config.manageUrl}
-
-
 <div class="js-payment-update" data-sub-id="@{subscription.name.get}" @for(email <- maybeEmail) {data-email="@email"} data-phone="@product.phone(contactUsCountry)" data-product="@product.name">
     @if(maybeEmail.isDefined) {
-        <a href="@manageBaseUrl/@managePaymentPath">
+        <a href="@paymentUrl(Config.manageUrl, product)">
             <button class="button button--primary button--large">View or update your payment details</button>
         </a>
     } else {

--- a/app/views/account/fragments/suspensions.scala.html
+++ b/app/views/account/fragments/suspensions.scala.html
@@ -4,11 +4,15 @@
 @import com.gu.subscriptions.suspendresume.SuspensionService.HolidayRefund
 @import views.support.ContactCentreOps
 @import views.support.Dates.formattedDateRange
+@import com.gu.memsub.Product
+@import utils.ManageUrlBuilder._
+@import configuration.Config
 
-@(holidayRefunds: Seq[HolidayRefund] = Seq.empty, suspendableDays: Int, suspendedDays: Int)
 
+@(holidayRefunds: Seq[HolidayRefund] = Seq.empty, suspendableDays: Int, suspendedDays: Int, maybeEmail: Option[String], product: Product)
+
+<div class="prose">
 @if(holidayRefunds.nonEmpty) {
-    <div class="prose">
         You have @suspendedDays @if(suspendedDays == 1) { day } else { days } already lined up:
         <dl class="mma-section__list">
             @for((refund, holiday) <- holidayRefunds) {
@@ -22,7 +26,18 @@
             <p class="scheduled-suspensions__help">
                 Please contact Customer Services on: <a href="@ContactCentreOps.hrefTelNumber(UK)">@ContactCentreOps.directLine(UK)</a> or email <a href="@ContactCentreOps.hrefMailto">@ContactCentreOps.email</a> if you wish to cancel or amend any of these.
             </p>
-    </div>
 } else {
-    You have no suspensions currently lined up.
+    <p>You have no suspensions currently lined up.</p>
+}
+@if(maybeEmail.isDefined) {
+    <p>
+        Cant see your delivery holidays? The management of delivery holidays is being moved to a new part of the site, so you may have
+        delivery holidays that are not displayed here. Click on the button below to see them.
+    </p>
+</div>
+<a href="@suspendUrl(Config.manageUrl, product)">
+    <button class="button button--primary button--large">Manage your delivery holidays</button>
+</a>
+} else {
+</div>
 }

--- a/app/views/account/fragments/suspensions.scala.html
+++ b/app/views/account/fragments/suspensions.scala.html
@@ -31,7 +31,7 @@
 }
 @if(maybeEmail.isDefined) {
     <p>
-        Cant see your delivery holidays? The management of delivery holidays is being moved to a new part of the site, so you may have
+        Can't see your delivery holidays? The management of delivery holidays is being moved to a new part of the site, so you may have
         delivery holidays that are not displayed here. Click on the button below to see them.
     </p>
 </div>

--- a/app/views/account/fragments/suspensions.scala.html
+++ b/app/views/account/fragments/suspensions.scala.html
@@ -8,8 +8,7 @@
 @import utils.ManageUrlBuilder._
 @import configuration.Config
 
-
-@(holidayRefunds: Seq[HolidayRefund] = Seq.empty, suspendableDays: Int, suspendedDays: Int, maybeEmail: Option[String], product: Product)
+@(holidayRefunds: Seq[HolidayRefund] = Seq.empty, suspendableDays: Int, suspendedDays: Int, userIsSignedIn: Boolean, product: Product)
 
 <div class="prose">
 @if(holidayRefunds.nonEmpty) {
@@ -29,7 +28,7 @@
 } else {
     <p>You have no suspensions currently lined up.</p>
 }
-@if(maybeEmail.isDefined) {
+@if(userIsSignedIn) {
     <p>
         Can't see your delivery holidays? The management of delivery holidays is being moved to a new part of the site, so you may have
         delivery holidays that are not displayed here. Click on the button below to see them.

--- a/app/views/account/suspensionSuccess.scala.html
+++ b/app/views/account/suspensionSuccess.scala.html
@@ -31,11 +31,6 @@
         </section>
 
         <section class="mma-section">
-            <h3 class="mma-section__header">Your suspensions</h3>
-            <div>@account.fragments.suspensions(holidayRefunds, suspendableDays, suspendedDays)</div>
-        </section>
-
-        <section class="mma-section">
             <h3 class="mma-section__header">Your new billing schedule</h3>
             @account.fragments.billingSchedule(billingSchedule, currency)
         </section>


### PR DESCRIPTION
Updating the delivery management page for the release of home delivery holiday stops on the new platform.

- Removed the legacy holiday stops for and replaced with a button linking to the manage-frontend holiday stops management page
- Added some explanatory text to the display of legacy holiday stops aimed at reducing confusion over the migration. 
- Consolidated manage-frontend url building to avoid boiler plate in the templates.

Once the migration/backfill of legacy holiday stops is complete this can be cleaned further to remove any details of the legacy holiday stops