### PR TITLE
Remove displayName usage from subscriptions frontend

### DIFF
--- a/app/services/AuthenticationService.scala
+++ b/app/services/AuthenticationService.scala
@@ -83,7 +83,7 @@ object AuthenticationService {
       case UserCredentials.SCGUUCookie(value) => AccessCredentials.Cookies(scGuU = value)
       case UserCredentials.CryptoAccessToken(value, _) => AccessCredentials.Token(tokenText = value)
     }
-    AuthenticatedIdUser(accessCredentials, IdMinimalUser(user.id, user.publicFields.username))
+    AuthenticatedIdUser(accessCredentials, IdMinimalUser(user.id, user.publicFields.username.orElse(user.privateFields.firstName)))
   }
 
   // Logs failure to authenticate a user.

--- a/app/services/AuthenticationService.scala
+++ b/app/services/AuthenticationService.scala
@@ -83,7 +83,7 @@ object AuthenticationService {
       case UserCredentials.SCGUUCookie(value) => AccessCredentials.Cookies(scGuU = value)
       case UserCredentials.CryptoAccessToken(value, _) => AccessCredentials.Token(tokenText = value)
     }
-    AuthenticatedIdUser(accessCredentials, IdMinimalUser(user.id, user.publicFields.displayName))
+    AuthenticatedIdUser(accessCredentials, IdMinimalUser(user.id, user.publicFields.username))
   }
 
   // Logs failure to authenticate a user.

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -171,9 +171,6 @@ object PersonalDataJsonSerialiser {
     val telephoneNumber = NormalisedTelephoneNumber.fromStringAndCountry(personalData.telephoneNumber, personalData.address.country)
     Json.obj(
       primaryEmailAddress -> personalData.email,
-      publicFields -> Json.obj(
-        "displayName" -> s"${personalData.first} ${personalData.last}"
-      ),
       "privateFields" -> Json.obj(
         "firstName" -> personalData.first,
         "secondName" -> personalData.last,

--- a/test/services/IdentityServiceTest.scala
+++ b/test/services/IdentityServiceTest.scala
@@ -86,9 +86,6 @@ class IdentityServiceTest extends FreeSpec with Matchers {
   "PersonalData serialization for the Identity service" in {
     val expectedJson = Json.obj(
       "primaryEmailAddress" -> "email@example.com",
-      "publicFields" -> Json.obj(
-        "displayName" -> "FirstName LastName"
-      ),
       "privateFields" -> Json.obj(
         "firstName" -> "FirstName",
         "secondName" -> "LastName",


### PR DESCRIPTION
We're planning on removing the displayName publicField from the Identity API in the future.

This PR needs to be released first, where displayName is no longer required:
https://github.com/guardian/identity/pull/1696
