### PR TITLE
Update delivery time from 7am to 8am

### DIFF
--- a/app/model/Subscriptions.scala
+++ b/app/model/Subscriptions.scala
@@ -45,7 +45,7 @@ object Subscriptions {
     val steps = Seq(
       "Pick the perfect package for you",
       "Confirm your address is within the M25",
-      "Get your papers delivered to your door by 7am Monday - Saturday and 8:30am on Sundays"
+      "Get your papers delivered to your door by 8am Monday - Saturday and 8:30am on Sundays"
     )
   }
 


### PR DESCRIPTION
The aim is to give delivery partners more time to get the papers into the letterboxes due to 'unprecedented demand' (hashtag coronavirus).

There's a [trello card](https://trello.com/c/EIfl3jde/2948-update-delivery-times-on-hd-checkout) for this work.

Please note that I'm not convinced this code actually appears anywhere, just wanted to make the change in case I somehow managed to miss where it is published.