### PR TITLE
Remove extra trailing slash on identity base

### DIFF
--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -4,7 +4,7 @@ include "touchpoint.UAT.conf"
 stage="PROD"
 
 identity {
-  baseUri = "https://idapi.theguardian.com/"
+  baseUri = "https://idapi.theguardian.com"
   production.keys=true
   webapp.url="https://profile.theguardian.com"
   sessionDomain=".theguardian.com"


### PR DESCRIPTION
Neither CODE nor DEV have a trailing slash, so this seems fairly safe - but anyway the motivation for this is that Identity appear to be rejecting requests with the extra slash with a 404, which is new.