### PR TITLE
Connect Zuora SOAP client to healthcheck

### DIFF
--- a/app/controllers/Management.scala
+++ b/app/controllers/Management.scala
@@ -51,6 +51,7 @@ class Management(actorSystem: ActorSystem, fBackendFactory: TouchpointBackends, 
     boolTest(salesforce,"Salesforce") +++
     boolTest(CloudWatchHealth.hasPushedMetricSuccessfully, "CloudWatch") +++
     boolTest(zuoraService.lastPingTimeWithin(2.minutes), "ZuoraPing") +++
+    boolTest(soapClient.isReady, "ZuoraSoapClientAuth") +++
     boolTest(promoCollection.all.nonEmpty, "Promotions") +++
     catalogWorkedOkay
 


### PR DESCRIPTION
This is a safety net in preparation for refactoring out deprecated akka-agent from membership-common which is used for authentication purposes in Zuora SOAP client. akka-agent is blocking migration to Play 2.8.

Additional benefit is migration to Play 2.8 would help resolve snyk issues https://app.snyk.io/org/the-guardian-cuu/project/59debc86-04e6-44c0-8e62-597b5466a917/#issue-SNYK-JAVA-COMFASTERXMLJACKSONCORE-559106