### PR TITLE
Fixing GA to load when all consents have been agreed to

### DIFF
--- a/assets/javascripts/modules/analytics/cmp.js
+++ b/assets/javascripts/modules/analytics/cmp.js
@@ -11,7 +11,7 @@ const getConsentForVendors = (cmpVendorIds) => new Promise((resolve) => {
          * vendor specific consent from state.
          */
         resolve(cmpVendorIds.reduce((accumulator, vendorId) => {
-            const consented = state.tcfv2 && state.tcfv2.vendorConsents ? state.tcfv2.vendorConsents[vendorId] : undefined;
+            const consented = state.tcfv2 && state.tcfv2.vendorConsents ? state.tcfv2.vendorConsents[vendorId] : null;
             return {
                 ...accumulator,
                 [vendorId]: consented,

--- a/assets/javascripts/modules/analytics/cmp.js
+++ b/assets/javascripts/modules/analytics/cmp.js
@@ -11,7 +11,7 @@ const getConsentForVendors = (cmpVendorIds) => new Promise((resolve) => {
          * vendor specific consent from state.
          */
         resolve(cmpVendorIds.reduce((accumulator, vendorId) => {
-            const consented = state.tcfv2 && state.tcfv2.vendorConsents && state.tcfv2.vendorConsents[vendorId] || false;
+            const consented = state.tcfv2 && state.tcfv2.vendorConsents ? state.tcfv2.vendorConsents[vendorId] : undefined;
             return {
                 ...accumulator,
                 [vendorId]: consented,

--- a/assets/javascripts/modules/analytics/setup.js
+++ b/assets/javascripts/modules/analytics/setup.js
@@ -22,7 +22,7 @@ define([
                 loadGA.complete = true;
             } else if (allPurposesAgreed && typeof(vendorConsents[ga.cmpVendorId]) === 'undefined') {
                 console.log('Google Analytics has not been configured as a vendor yet, but all purposes have been ' +
-                    'agreed so we\'re loading it.');
+                    'agreed so we\'re loading it.', vendorConsents[ga.cmpVendorId]);
                 ga.init();
                 loadGA.complete = true;
             } else {

--- a/assets/javascripts/modules/analytics/setup.js
+++ b/assets/javascripts/modules/analytics/setup.js
@@ -20,7 +20,7 @@ define([
             if (ccpaConsent || vendorConsents[ga.cmpVendorId]) {
                 ga.init();
                 loadGA.complete = true;
-            } else if (allPurposesAgreed && vendorConsents[ga.cmpVendorId] === null) {
+            } else if (allPurposesAgreed && typeof(vendorConsents[ga.cmpVendorId]) === 'undefined') {
                 console.log('Google Analytics has not been configured as a vendor yet, but all purposes have been ' +
                     'agreed so we\'re loading it.');
                 ga.init();

--- a/assets/javascripts/modules/analytics/setup.js
+++ b/assets/javascripts/modules/analytics/setup.js
@@ -20,6 +20,10 @@ define([
             if (ccpaConsent || vendorConsents[ga.cmpVendorId]) {
                 ga.init();
                 loadGA.complete = true;
+            } else if (allPurposesAgreed && vendorConsents[ga.cmpVendorId] === null) {
+                console.log(`Google Analytics has not been configured as a vendor yet, but all purposes have been agreed so we're loading it.`);
+                ga.init();
+                loadGA.complete = true;
             } else {
                 if (ccpaConsent === null) {
                     console.log('Either there\'s insufficient consent for Google Analytics, or the user has ' +

--- a/assets/javascripts/modules/analytics/setup.js
+++ b/assets/javascripts/modules/analytics/setup.js
@@ -21,7 +21,8 @@ define([
                 ga.init();
                 loadGA.complete = true;
             } else if (allPurposesAgreed && vendorConsents[ga.cmpVendorId] === null) {
-                console.log(`Google Analytics has not been configured as a vendor yet, but all purposes have been agreed so we're loading it.`);
+                console.log('Google Analytics has not been configured as a vendor yet, but all purposes have been ' +
+                    'agreed so we\'re loading it.');
                 ga.init();
                 loadGA.complete = true;
             } else {

--- a/assets/javascripts/modules/analytics/setup.js
+++ b/assets/javascripts/modules/analytics/setup.js
@@ -22,7 +22,7 @@ define([
                 loadGA.complete = true;
             } else if (allPurposesAgreed && typeof(vendorConsents[ga.cmpVendorId]) === 'undefined') {
                 console.log('Google Analytics has not been configured as a vendor yet, but all purposes have been ' +
-                    'agreed so we\'re loading it.', vendorConsents[ga.cmpVendorId]);
+                    'agreed so we\'re loading it.');
                 ga.init();
                 loadGA.complete = true;
             } else {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Fixing GA to load when all consents have been agreed to. This is whilst we wait for GA to be properly set up as a vendor.

