### PR TITLE
Bump membership-common to v0.589

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -1,13 +1,12 @@
 package configuration
 
-
 import com.github.nscala_time.time.Imports._
 import com.gu.cas.PrefixedTokens
 import com.gu.config._
 import com.gu.memsub.auth.common.MemSub.Google._
 import com.gu.salesforce.SalesforceConfig
-import com.netaporter.uri.dsl._
 import com.typesafe.config.ConfigFactory
+import io.lemonlabs.uri.typesafe.dsl._
 import org.joda.time.Days
 import play.api.mvc.{Call, RequestHeader}
 
@@ -51,9 +50,12 @@ object Config {
 
     def idWebAppRegisterUrl(returnTo: Call)(implicit request: RequestHeader) = idWebAppUrl("register", returnTo)
 
-    def idWebAppUrl(idPath: String, returnTo : Call)(implicit request: RequestHeader): String =
-      (webAppUrl / idPath) ? ("returnUrl" -> returnTo.absoluteURL(secure = true)) ? ("skipConfirmation" -> "true")
-
+    def idWebAppUrl(idPath: String, returnTo: Call)(implicit request: RequestHeader): String =
+      (
+        (webAppUrl / idPath) ?
+          ("returnUrl" -> returnTo.absoluteURL(secure = true)) ?
+          ("skipConfirmation" -> "true")
+      ).toString
   }
 
   object Zuora {

--- a/app/controllers/PromoLandingPage.scala
+++ b/app/controllers/PromoLandingPage.scala
@@ -1,24 +1,26 @@
 package controllers
+
 import actions.{CommonActions, OAuthActions}
 import com.gu.i18n.CountryGroup.byCountryCode
 import com.gu.i18n.{Country, CountryGroup}
 import com.gu.memsub.Benefit.Digipack
-import com.gu.memsub.Subscription
 import com.gu.memsub.promo.Formatters.PromotionFormatters._
 import com.gu.memsub.promo.Promotion._
 import com.gu.memsub.promo._
-import com.gu.memsub.subsv2.{Catalog, WeeklyPlans}
-import com.netaporter.uri.dsl._
+import com.gu.memsub.subsv2.Catalog
 import configuration.Config
 import controllers.SessionKeys.PromotionTrackingCode
 import controllers.WeeklyLandingPage.{Hreflang, Hreflangs}
 import filters.HandleXFrameOptionsOverrideHeader
+import io.lemonlabs.uri.typesafe.dsl._
 import play.api.data.{Form, Forms}
 import play.api.libs.json.Json
 import play.api.mvc._
 import play.twirl.api.Html
-import services.TouchpointBackend
+import scalaz.OptionT
+import scalaz.std.scalaFuture._
 import services.FlashSale._
+import services.TouchpointBackend
 import utils.RequestCountry._
 import utils.Tracking.internalCampaignCode
 import views.html.promotion._
@@ -26,8 +28,6 @@ import views.html.weekly.landing_description
 import views.support.PegdownMarkdownRenderer
 
 import scala.concurrent.{ExecutionContext, Future}
-import scalaz.OptionT
-import scalaz.std.scalaFuture._
 
 class PromoLandingPage(
   tpBackend: TouchpointBackend,
@@ -156,7 +156,10 @@ class PromoLandingPage(
       }
     } yield landingPage
     maybeLandingPage.run.map(_.getOrElse {
-      Redirect(routes.Homepage.index().url ? (internalCampaignCode -> intcmp(promoCode.get).value), request.queryString)
+      Redirect(
+        url = (routes.Homepage.index().url ? (internalCampaignCode -> intcmp(promoCode.get).value)).toString,
+        request.queryString
+      )
     })
 
   }
@@ -201,7 +204,7 @@ class PromoLandingPage(
     } yield termsPage
 
     maybeTermsPage.run.map(_.getOrElse {
-      Redirect(routes.Homepage.index().url ? (internalCampaignCode -> s"FROM_PT_${promoCode.get}"))
+      Redirect((routes.Homepage.index().url ? (internalCampaignCode -> s"FROM_PT_${promoCode.get}")).toString)
     })
 
   }

--- a/app/model/SubscriptionAcquisitionComponents.scala
+++ b/app/model/SubscriptionAcquisitionComponents.scala
@@ -1,5 +1,6 @@
 package model
 
+import acquisitions.AcquisitionsHelper.referrerAcquisitionDataFromJSON
 import com.gu.acquisition.model.{GAData, OphanIds, ReferrerAcquisitionData}
 import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
 import com.gu.memsub.Benefit.PaperDay
@@ -7,12 +8,11 @@ import com.gu.memsub.BillingPeriod._
 import com.gu.memsub.promo.{PercentDiscount, Promotion}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
-import com.netaporter.uri.Uri
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
+import io.lemonlabs.uri.Uri
 import ophan.thrift.event.PaymentProvider.{Gocardless, Stripe}
 import ophan.thrift.event._
-import acquisitions.AcquisitionsHelper.referrerAcquisitionDataFromJSON
 
 import scala.collection.Set
 
@@ -50,7 +50,7 @@ object SubscriptionAcquisitionComponents {
     override def buildGAData(components: SubscriptionAcquisitionComponents): Either[String, GAData] = {
       import components.clientBrowserInfo._
 
-      val host = Uri.parse(Config.subscriptionsUrl).host.getOrElse("subscribe.theguardian.com")
+      val host = Uri.parse(Config.subscriptionsUrl).toUrl.hostOption.map(_.value).getOrElse("subscribe.theguardian.com")
       Right(GAData(host, gaClientId, Some(ipAddress), userAgent))
     }
 

--- a/app/model/WeeklyRegions.scala
+++ b/app/model/WeeklyRegions.scala
@@ -1,7 +1,7 @@
 package model
 
 import com.gu.memsub.subsv2.Catalog
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 
 trait WeeklyRegion {
   def title: String
@@ -18,13 +18,13 @@ object WeeklyRegion {
 case class UnitedKingdom(catalog: Catalog) extends WeeklyRegion {
   override val title = "United Kingdom"
   override val description = "Includes Isle of Man and Channel Islands"
-  override val url = Uri.parse(s"checkout/${catalog.weekly.zoneA.quarter.slug}").addParam("countryGroup", "uk")
+  override val url = Uri.parse(s"checkout/${catalog.weekly.zoneA.quarter.slug}").toUrl.addParam("countryGroup", "uk")
 }
 
 case class UnitedStates(catalog: Catalog) extends WeeklyRegion {
   override val title = "United States"
   override val description = "Includes Alaska and Hawaii"
-  override val url = Uri.parse(s"checkout/${catalog.weekly.zoneA.quarter.slug}").addParam("countryGroup", "us")
+  override val url = Uri.parse(s"checkout/${catalog.weekly.zoneA.quarter.slug}").toUrl.addParam("countryGroup", "us")
 }
 
 case class Row(catalog: Catalog) extends WeeklyRegion {

--- a/app/views/support/DigitalEdition.scala
+++ b/app/views/support/DigitalEdition.scala
@@ -1,10 +1,9 @@
 package views.support
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+
 import controllers.routes
-import model.DigitalEdition._
+import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.typesafe.dsl._
 import model.{DigitalEdition => DE}
-import utils.Tracking.internalCampaignCode
 
 object DigitalEdition {
 

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -8,7 +8,7 @@ import com.gu.memsub._
 import com.gu.memsub.images.{ResponsiveImage, ResponsiveImageGenerator, ResponsiveImageGroup}
 import com.gu.memsub.subsv2.CatalogPlan.ContentSubscription
 import com.gu.memsub.subsv2.{CatalogPlan, Plan}
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.typesafe.dsl._
 
 import scala.reflect.internal.util.StringOps
 object PlanOps {

--- a/app/views/support/WeeklyPromotion.scala
+++ b/app/views/support/WeeklyPromotion.scala
@@ -6,8 +6,8 @@ import com.gu.memsub.promo.CovariantIdObject.CovariantId
 import com.gu.memsub.promo.Promotion.PromoWithWeeklyLandingPage
 import com.gu.memsub.promo.{PromoCode, WeeklyLandingPage}
 import com.gu.memsub.subsv2.{CatalogPlan, WeeklyPlans}
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.typesafe.dsl._
 import model.GuardianWeeklyZones
 import model.PurchasableWeeklyProducts._
 import services.WeeklyPicker

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ libraryDependencies ++= Seq(
     filters,
     jodaForms,
     PlayImport.specs2 % "test",
-    "com.gu" %% "membership-common" % "0.553",
+    "com.gu" %% "membership-common" % "0.589",
     "com.gu.identity" %% "identity-auth-play" % "3.195",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "play-googleauth" % "0.7.6",
@@ -94,8 +94,8 @@ javaOptions in Test += "-Dconfig.file=test/acceptance/conf/acceptance-test.conf"
 
 resolvers ++= Seq(
     "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases",
-    "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-snapshots",
-    "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
+    "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-snapshots",
+    "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",
     Resolver.sonatypeRepo("releases"),
     Resolver.sonatypeRepo("snapshots"),
     Resolver.bintrayRepo("guardian", "ophan")
@@ -128,5 +128,3 @@ addCommandAlias("prodrun", "run 9200")
 addCommandAlias("fast-test", "testOnly -- -l AcceptanceTest")
 addCommandAlias("acceptance-test", "testOnly -- -n AcceptanceTest")
 addCommandAlias("play-artifact", "riffRaffNotifyTeamcity")
-
-

--- a/test/services/SalesforceServiceTest.scala
+++ b/test/services/SalesforceServiceTest.scala
@@ -1,15 +1,15 @@
 package services
+
 import com.gu.i18n.Title
 import com.gu.memsub.Product.Delivery
-import com.gu.memsub._
 import com.gu.memsub.Subscription.ProductRatePlanId
+import com.gu.memsub._
 import com.gu.memsub.subsv2.{CatalogPlan, PaperCharges}
-import model.{DeliveryRecipient, PaperData, PersonalData}
-import org.specs2.mutable.Specification
-import com.gu.salesforce.ContactDeserializer.Keys._
 import com.gu.salesforce.Contact
+import com.gu.salesforce.ContactDeserializer.Keys._
+import model.{DeliveryRecipient, PaperData, PersonalData}
 import org.joda.time.{DateTime, LocalDate}
-import scalaz.syntax.std.option._
+import org.specs2.mutable.Specification
 import play.api.libs.json.{JsString, Json}
 import scalaz.syntax.std.option._
 
@@ -58,8 +58,21 @@ class SalesforceServiceTest extends Specification {
 
     "Include your giftee address if you supply one" in {
       val buyerContact = Contact(
-        None, None, None, None, "Buyer's Lastname", DateTime.now,
-        "buyer_sfContactId", "buyer_sfAccountId", None, None, None, None, None, None
+        identityId = None,
+        regNumber = None,
+        title = None,
+        firstName = None,
+        lastName = "Buyer's Lastname",
+        joinDate = DateTime.now,
+        salesforceContactId = "buyer_sfContactId",
+        salesforceAccountId = "buyer_sfAccountId",
+        mailingStreet = None,
+        mailingCity = None,
+        mailingState = None,
+        mailingPostcode = None,
+        mailingCountry = None,
+        deliveryInstructions = None,
+        recordTypeId = None
       )
       val delivery = DeliveryRecipient(
         Some(Title.Mx), Some("firstname"), Some("lastname"), Some("email@email.com"),


### PR DESCRIPTION
This is to support the new Patron reader type: guardian/membership-common#633

There's been a namespace change in one of the transitive dependencies since v0.553.
`io.lemonlabs.uri.typesafe.dsl._` operators build `Uri` instances rather than Strings.  But the `toString` implementation seems to do the expected thing.
