### PR TITLE
honour state in AUS

### DIFF
--- a/assets/javascripts/modules/analytics/cmp.js
+++ b/assets/javascripts/modules/analytics/cmp.js
@@ -32,6 +32,12 @@ const checkCCPA = () => new Promise((resolve) => {
     })
 });
 
+const checkAus = () => new Promise((resolve) => {
+    onConsentChange(state => {
+        resolve(state.aus ? state.ccpa.personalisedAdvertising : null);
+    })
+});
+
 const registerCallbackOnConsentChange = (fn) => onConsentChange(fn);
 
-export { getConsentForVendors, checkAllTCFv2PurposesAreOptedIn, checkCCPA, registerCallbackOnConsentChange };
+export { getConsentForVendors, checkAllTCFv2PurposesAreOptedIn, checkCCPA, checkAus, registerCallbackOnConsentChange };

--- a/assets/javascripts/modules/analytics/setup.js
+++ b/assets/javascripts/modules/analytics/setup.js
@@ -12,12 +12,13 @@ define([
     function loadGA() {
         Promise.allSettled([
             cmp.checkCCPA(),
+            cmp.checkAus(),
             cmp.getConsentForVendors([ga.cmpVendorId]),
             cmp.checkAllTCFv2PurposesAreOptedIn()
         ]).then(results => {
-            const [ ccpaConsent, vendorConsents, allPurposesAgreed ] = results.map(promise => promise.value);
+            const [ ccpaConsent, ausConsent, vendorConsents, allPurposesAgreed ] = results.map(promise => promise.value);
 
-            if (ccpaConsent || vendorConsents[ga.cmpVendorId]) {
+            if (ccpaConsent || ausConsent || vendorConsents[ga.cmpVendorId]) {
                 ga.init();
                 loadGA.complete = true;
             } else if (allPurposesAgreed && typeof(vendorConsents[ga.cmpVendorId]) === 'undefined') {


### PR DESCRIPTION
## What does this change?

## Why are you doing this?

In https://github.com/guardian/subscriptions-frontend/pull/1312 we enabled the new Australian CMP. The state returned when in Australian mode by the `@guardian/consent-management-platform` library `onConsentChange` now looks like:

```js
{
  aus: {
    personalisedAdvertising: true
  }
}
```

We therefore need to update the consent checks to handle `state` if it looks like this.

