### PR TITLE
Ensuring Identity ID is not passed to GA

### DIFF
--- a/assets/javascripts/modules/analytics/ga.js
+++ b/assets/javascripts/modules/analytics/ga.js
@@ -57,7 +57,7 @@ define(['modules/analytics/analyticsEnabled',
         (guardian.ophan) && ga('membershipPropertyTracker.set', 'dimension3', guardian.ophan.pageViewId); // ophanPageview Id
         (ophanBrowserId) && ga('membershipPropertyTracker.set', 'dimension4', ophanBrowserId); // ophanBrowserId
         ga('membershipPropertyTracker.set', 'dimension5', 'subscriptions');               // platform
-        (identitySignedIn) && ga('membershipPropertyTracker.set', 'dimension6', user.getUserFromCookie().id); // identityId
+        // dimension6 (Identity ID) has been deprecated
         ga('membershipPropertyTracker.set', 'dimension7', identitySignedIn.toString());   // isLoggedOn
 
         if (productData) {


### PR DESCRIPTION
## What does this change?
The Identity ID is no longer needed in GA and the Support site stopped sending Identity IDs to GA ages ago.

As part of our data minimisation work, poor @NathanielBennett has been sending off repeated deletion requests to Google whilst this site has been adding new ones back in! Hopefully that will end now.