### PR TITLE
More GA custom dimensions to remove

### DIFF
--- a/assets/javascripts/modules/analytics/ga.js
+++ b/assets/javascripts/modules/analytics/ga.js
@@ -58,7 +58,7 @@ define(['modules/analytics/analyticsEnabled',
         ga('membershipPropertyTracker.set', 'dimension5', 'subscriptions');               // platform
         // dimension6 (Identity ID) has been deprecated
         ga('membershipPropertyTracker.set', 'dimension7', identitySignedIn.toString());   // isLoggedOn
-        // dimension8 (stripeId) has been deprecated
+        // dimension8 (stripeId) was never sent by this site
         if (productData) {
             // dimension9 (productData.zuoraId) has been deprecated
             if (productData.productPurchased) {

--- a/assets/javascripts/modules/analytics/ga.js
+++ b/assets/javascripts/modules/analytics/ga.js
@@ -14,7 +14,6 @@ define(['modules/analytics/analyticsEnabled',
     function init() {
         var identitySignedIn = user.isLoggedIn();
         var identitySignedOut = !!cookie.getCookie('GU_SO') && !identitySignedIn;
-        var ophanBrowserId = cookie.getCookie('bwid');
         var productData = guardian.pageInfo ? guardian.pageInfo.productData : {};
         var intcmp = queryParam('INTCMP');
         var isCustomerAgent = !!guardian.supplierCode;
@@ -54,16 +53,14 @@ define(['modules/analytics/analyticsEnabled',
 
         ga('membershipPropertyTracker.set', 'dimension1', identitySignedIn.toString());   // deprecated - now uses dimension7 via util/user
         ga('membershipPropertyTracker.set', 'dimension2', identitySignedOut.toString());  // deprecated - is logically equivalent to: dimension6 != "" and dimension7 === "false"
-        (guardian.ophan) && ga('membershipPropertyTracker.set', 'dimension3', guardian.ophan.pageViewId); // ophanPageview Id
-        (ophanBrowserId) && ga('membershipPropertyTracker.set', 'dimension4', ophanBrowserId); // ophanBrowserId
+        // dimension3 (guardian.ophan.pageViewId) has been deprecated
+        // dimension4 (ophanBrowserId) has been deprecated
         ga('membershipPropertyTracker.set', 'dimension5', 'subscriptions');               // platform
         // dimension6 (Identity ID) has been deprecated
         ga('membershipPropertyTracker.set', 'dimension7', identitySignedIn.toString());   // isLoggedOn
-
+        // dimension8 (stripeId) has been deprecated
         if (productData) {
-            if (productData.zuoraId) {
-                ga('membershipPropertyTracker.set', 'dimension9', productData.zuoraId);   // zuoraId
-            }
+            // dimension9 (productData.zuoraId) has been deprecated
             if (productData.productPurchased) {
                 ga('membershipPropertyTracker.set', 'dimension11', productData.productType + ' - ' + productData.productPurchased);  // productPurchased
             }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Personal identifiers and dimensions with infinite cardinality (Ophan page view ID, Ophan Browser ID, Zuora ID etc) should not be being set as GA Custom Dimensions. This change removes them as they are not used in any GA reports and will soon be made inactive historical values will be deleted. See https://docs.google.com/spreadsheets/d/1MmWHNeeiQE_dzekImIP9Tv4beLx_8JzWx3rOtCp4PGg/edit#gid=1460779756

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
1) Browse the site, no Ophan identifiers should be being set anymore.
1) Browse the checkout in test user mode, accepting tracking in the CMP. Make a test subscription. On the thank-you page no more zuoraId will be sent.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
No more of these identifiers should be being sent to GA.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Risk of continuing to collect these custom dimensions is higher than impact on them no longer being in reports in GA. Risks are low as this site is mainly used by Customer Service representatives.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
N/A