### PR TITLE
update AMI and instance to ARM/bionic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -111,6 +111,8 @@ packageDescription := """Subscription Frontend"""
 
 riffRaffPackageType := (packageBin in Debian).value
 
+riffRaffArtifactResources += (file("cloud-formation/subscriptions-app.cf.yaml"), "cfn/cfn.yaml")
+
 routesGenerator := InjectedRoutesGenerator
 
 javaOptions in Universal ++= Seq(

--- a/cloud-formation/subscriptions-app.cf.yaml
+++ b/cloud-formation/subscriptions-app.cf.yaml
@@ -26,13 +26,6 @@ Parameters:
       Internal Guardian, or '0.0.0.0/0' - the whole internet!)
     Type: String
     Default: 0.0.0.0/0
-  InstanceType:
-    Type: String
-    Description: EC2 instance type
-    AllowedValues:
-    - t2.small
-    - t3.small
-    ConstraintDescription: must be a valid EC2 instance type.
   ImageId:
     Description: AMI ID
     Type: String
@@ -91,7 +84,7 @@ Resources:
       ImageId: !Ref 'ImageId'
       SecurityGroups:
       - !Ref 'InstanceSecurityGroup'
-      InstanceType: !Ref 'InstanceType'
+      InstanceType: t4g.small
       KeyName: !Ref 'KeyName'
       IamInstanceProfile: !Ref 'SubscriptionsAppInstanceProfile'
       AssociatePublicIpAddress: true

--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -1,17 +1,18 @@
 stacks: [subscriptions]
 regions: [eu-west-1]
 deployments:
-  ami:
-    type: ami-cloudformation-parameter
+  cfn:
+    type: cloud-formation
     app: frontend
     parameters:
+      templatePath: cfn.yaml
       amiTags:
-        Recipe: xenial-membership
+        Recipe: bionic-membership-ARM
         AmigoStage: PROD
       amiParameter: ImageId
       amiEncrypted: true
   frontend:
     type: autoscaling
-    dependencies: [ami]
+    dependencies: [cfn]
     parameters:
       bucket: subscriptions-dist


### PR DESCRIPTION
similar to https://github.com/guardian/membership-frontend/pull/1990

This updates the ubuntu version to be supported by AWS.
also makes the CFN auto deploy to make things more convenient.
Also switch to ARM t4g instance type to save money.

I have previewed the CFN changes in prod (and CODE) and there is nothing out of date other than the instance type
![image](https://user-images.githubusercontent.com/7304387/109498192-0c47b180-7a8b-11eb-97a3-83c996bc314c.png)

Tested in CODE and working OK (deploy and front page)