### PR TITLE
reduce to two instances

### DIFF
--- a/cloud-formation/subscriptions-app.cf.yaml
+++ b/cloud-formation/subscriptions-app.cf.yaml
@@ -36,9 +36,9 @@ Mappings:
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-PROD
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-UAT
       SiteDomain: 'subscribe.theguardian.com.origin.subscriptions.guardianapis.com.'
-      MinInstances: '3'
-      MaxInstances: '6'
-      DesiredInstances: '3'
+      MinInstances: '2'
+      MaxInstances: '4'
+      DesiredInstances: '2'
       SSLCertificateId: '39488f8a-17f1-4154-b799-b6a132ef37e7'
       KinesisStreamArn: arn:aws:kinesis:eu-west-1:865473395570:stream/acquisitions-stream-PROD
     CODE:


### PR DESCRIPTION
We no longer need a high level of redundancy for subs in PROD.  This will save almost 100$ for the year.

Having a non multiple of 3 can slow down deploys due to rebalancing, but it's not the end of the world.