### PR TITLE
Patch in necessary permissions for Wazuh

### DIFF
--- a/cloud-formation/subscriptions-app.cf.yaml
+++ b/cloud-formation/subscriptions-app.cf.yaml
@@ -270,6 +270,7 @@ Resources:
   WazuhSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
+      GroupDescription: Allow outbound traffic from wazuh agent to manager
       VpcId: !Ref 'VpcId'
       SecurityGroupEgress:
       - IpProtocol: tcp

--- a/cloud-formation/subscriptions-app.cf.yaml
+++ b/cloud-formation/subscriptions-app.cf.yaml
@@ -84,6 +84,7 @@ Resources:
       ImageId: !Ref 'ImageId'
       SecurityGroups:
       - !Ref 'InstanceSecurityGroup'
+      - !Ref 'WazuhSecurityGroup'
       InstanceType: t4g.small
       KeyName: !Ref 'KeyName'
       IamInstanceProfile: !Ref 'SubscriptionsAppInstanceProfile'
@@ -188,6 +189,21 @@ Resources:
             Resource: arn:aws:iam::021353022223:role/support-invoke-value-calculator
       ManagedPolicyArns:
       - !Sub arn:aws:iam::${AWS::AccountId}:policy/guardian-ec2-role-for-ssm
+  DescribeEC2Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: describe-ec2-policy
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Resource: "*"
+          Action:
+          - ec2:DescribeTags
+          - ec2:DescribeInstances
+          - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeAutoScalingInstances
+      Roles:
+      - !Ref SubscriptionsAppRole
   SubscriptionsAppInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -250,6 +266,15 @@ Resources:
       - IpProtocol: tcp
         FromPort: '443'
         ToPort: '443'
+        CidrIp: 0.0.0.0/0
+  WazuhSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref 'VpcId'
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        FromPort: 1514
+        ToPort: 1515
         CidrIp: 0.0.0.0/0
   FrontendELBDNSrecord:
     Type: AWS::Route53::RecordSet


### PR DESCRIPTION
## What does this change?

There's currently a major review of the guardian's security practices under the cyber security programme. One of the projects in this programme is to install a vulnerability scanner called Wazuh in guardian ec2 instances.

This patch enables Wazuh to work by

* Opening ports 1514 and 1515 for outbound traffic
* Giving permission to the instance to call describe-tags,
   so the agent can identify itself in a human readable way with 
   the wazuh server.


## How to test
Deploy to CODE and see if the wazuh agent successfully connects with the central server 

✅works in code

## How can we measure success?
Wazuh will start reporting vulnerabilities to infosec!

## Have we considered potential risks?
CFN could be wrong and cause downtime.
