### PR TITLE
Revert "stop using bintray for acquisition-event-producer"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,10 +37,10 @@ lazy val root = (project in file(".")).enablePlugins(
       "com.gu.memsub.Subscription.ProductRatePlanId"
   ))
 
-scalaVersion := "2.12.13"
+scalaVersion := "2.12.10"
 scalacOptions ++= Seq("-feature")
 
-val scalatestVersion = "3.1.1"
+val scalatestVersion = "3.0.4"
 val jacksonVersion = "2.10.0"
 
 libraryDependencies ++= Seq(
@@ -56,13 +56,13 @@ libraryDependencies ++= Seq(
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.4",
     "com.gu" %% "tip" % "0.1.1",
+    "com.gu" %% "acquisition-event-producer-play26" % "4.0.26",
     "com.github.nscala-time" %% "nscala-time" % "2.16.0",
     "io.sentry" % "sentry-logback" % "1.7.5",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
     "org.scalatest" %% "scalatest" % scalatestVersion % "test",
     "org.scalactic" %% "scalactic" % scalatestVersion % "test",
-    "org.scalatestplus" %% "selenium-3-141" % (scalatestVersion + ".0") % "test",
-    "org.seleniumhq.selenium" % "selenium-java" % "3.141.59" % "test",
+    "org.seleniumhq.selenium" % "selenium-java" % "3.7.1" % "test",
     "org.seleniumhq.selenium" % "htmlunit-driver" % "2.28.1" % "test",
     "io.github.bonigarcia" % "webdrivermanager" % "1.7.2" % "test",
     "com.gocardless" % "gocardless-pro" % "2.7.0",
@@ -95,8 +95,10 @@ javaOptions in Test += "-Dconfig.file=test/acceptance/conf/acceptance-test.conf"
 resolvers ++= Seq(
     "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases",
     "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-snapshots",
+    "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",
     Resolver.sonatypeRepo("releases"),
-    Resolver.sonatypeRepo("snapshots")
+    Resolver.sonatypeRepo("snapshots"),
+    Resolver.bintrayRepo("guardian", "ophan")
 )
 
 import com.typesafe.sbt.packager.archetypes.systemloader.ServerLoader.Systemd

--- a/test/acceptance/pages/Checkout.scala
+++ b/test/acceptance/pages/Checkout.scala
@@ -3,7 +3,7 @@ package acceptance.pages
 import acceptance.util.{Browser, Config, Driver, TestUser}
 import Config.baseUrl
 import org.openqa.selenium.By
-import org.scalatestplus.selenium.Page
+import org.scalatest.selenium.Page
 
 case class Checkout(testUser: TestUser, endpoint: String = "checkout") extends Page with Browser {
   val url = s"$baseUrl/$endpoint"

--- a/test/acceptance/pages/Signin.scala
+++ b/test/acceptance/pages/Signin.scala
@@ -2,7 +2,7 @@ package acceptance.pages
 
 import acceptance.util.{Config, TestUser, Browser}
 import Config.identityFrontendUrl
-import org.scalatestplus.selenium.Page
+import org.scalatest.selenium.Page
 
 class Signin(testUser: TestUser) extends Page with Browser {
   val url = s"${identityFrontendUrl}/signin"

--- a/test/acceptance/pages/ThankYou.scala
+++ b/test/acceptance/pages/ThankYou.scala
@@ -2,7 +2,7 @@ package acceptance.pages
 
 import acceptance.util.{TestUser, Browser, Config}
 import Config.baseUrl
-import org.scalatestplus.selenium.Page
+import org.scalatest.selenium.Page
 
 case class ThankYou(val testUser: TestUser) extends Page with Browser {
   override val url = s"$baseUrl/checkout/thank-you"

--- a/test/acceptance/pages/WeeklyPromo.scala
+++ b/test/acceptance/pages/WeeklyPromo.scala
@@ -3,7 +3,7 @@ package acceptance.pages
 import acceptance.util.Config.baseUrl
 import acceptance.util.{Browser, Config, TestUser}
 import org.openqa.selenium.{By, WebElement}
-import org.scalatestplus.selenium.Page
+import org.scalatest.selenium.Page
 
 case class WeeklyPromo(endpoint: String = "/p/WWM99X", country: String = "GB") extends Page with Browser {
 

--- a/test/acceptance/util/Browser.scala
+++ b/test/acceptance/util/Browser.scala
@@ -2,7 +2,7 @@ package acceptance.util
 
 import org.openqa.selenium.support.ui.{ExpectedCondition, ExpectedConditions, WebDriverWait}
 import org.openqa.selenium.By
-import org.scalatestplus.selenium.WebBrowser
+import org.scalatest.selenium.WebBrowser
 import scala.util.Try
 
 trait Browser extends WebBrowser {

--- a/test/acceptance/util/LoadablePage.scala
+++ b/test/acceptance/util/LoadablePage.scala
@@ -1,6 +1,6 @@
 package acceptance.util
 
-import org.scalatestplus.selenium.Page
+import org.scalatest.selenium.Page
 
 trait LoadablePage extends Page {
 


### PR DESCRIPTION
Reverts guardian/subscriptions-frontend#1329

instances are coming up but not passing the health check.
SSH doesn't work due to being in the vpc but not having a tunnel
I suspect the unmanaged jar isn't making it into the artifact, as it does seem to work ok locally.