### PR TITLE
Allow SSH via SSM

### DIFF
--- a/cloud-formation/subscriptions-app.cf.yaml
+++ b/cloud-formation/subscriptions-app.cf.yaml
@@ -187,8 +187,18 @@ Resources:
           - Effect: Allow
             Action: sts:AssumeRole
             Resource: arn:aws:iam::021353022223:role/support-invoke-value-calculator
-      ManagedPolicyArns:
-      - !Sub arn:aws:iam::${AWS::AccountId}:policy/guardian-ec2-role-for-ssm
+      - PolicyName: SSMTunnel
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - ssm:UpdateInstanceInformation
+                - ssmmessages:CreateControlChannel
+                - ssmmessages:CreateDataChannel
+                - ssmmessages:OpenControlChannel
+                - ssmmessages:OpenDataChannel
+              Resource: '*'
   DescribeEC2Policy:
     Type: AWS::IAM::Policy
     Properties:

--- a/cloud-formation/subscriptions-app.cf.yaml
+++ b/cloud-formation/subscriptions-app.cf.yaml
@@ -193,7 +193,16 @@ Resources:
           Statement:
             - Effect: Allow
               Action:
+                - ec2messages:AcknowledgeMessage
+                - ec2messages:DeleteMessage
+                - ec2messages:FailMessage
+                - ec2messages:GetEndpoint
+                - ec2messages:GetMessages
+                - ec2messages:SendReply
                 - ssm:UpdateInstanceInformation
+                - ssm:ListInstanceAssociations
+                - ssm:DescribeInstanceProperties
+                - ssm:DescribeDocumentParameters
                 - ssmmessages:CreateControlChannel
                 - ssmmessages:CreateDataChannel
                 - ssmmessages:OpenControlChannel


### PR DESCRIPTION
This PR allows SSH via SSM.  As per the instructions as I have updated in https://github.com/guardian/ssm-scala/pull/132

This is needed because the instances don't come up when I merged this pr: https://github.com/guardian/subscriptions-frontend/pull/1329
I need to have a look at what's going on.