### PR TITLE
Remove resolver for bintray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,6 @@ javaOptions in Test += "-Dconfig.file=test/acceptance/conf/acceptance-test.conf"
 resolvers ++= Seq(
     "Guardian Github Releases" at "https://guardian.github.io/maven/repo-releases",
     "Guardian Github Snapshots" at "https://guardian.github.io/maven/repo-snapshots",
-    "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",
     Resolver.sonatypeRepo("releases"),
     Resolver.sonatypeRepo("snapshots"),
     Resolver.bintrayRepo("guardian", "ophan")


### PR DESCRIPTION
## What does this change?
It turns out that the bintray resolver was unnecessary in this project because all the dependencies are already available on Maven Central. 

Tested and working on CODE