### PR TITLE
pull in the whole acquisition event producer

### DIFF
--- a/app/com.gu.acquisition/instances/ThriftEnumFormat.scala
+++ b/app/com.gu.acquisition/instances/ThriftEnumFormat.scala
@@ -1,0 +1,22 @@
+package com.gu.acquisition.instances
+
+import com.twitter.scrooge.ThriftEnum
+import play.api.libs.json._
+
+import scala.reflect.ClassTag
+
+private[instances] trait ThriftEnumFormat {
+
+  def thriftEnumReads[A <: ThriftEnum : ClassTag](valueOf: String => Option[A]): Reads[A] = Reads { json =>
+    json.validate[String].flatMap { raw =>
+      valueOf(raw.filter(_ != '_')).map(JsSuccess(_)).getOrElse {
+        JsError(s"Unable to read Thrift enum of type ${reflect.classTag[A].runtimeClass} from $raw")
+      }
+    }
+  }
+
+  def thriftEnumWrites[A <: ThriftEnum]: Writes[A] = Writes { enum =>
+    JsString(enum.originalName)
+  }
+}
+

--- a/app/com.gu.acquisition/instances/abTest.scala
+++ b/app/com.gu.acquisition/instances/abTest.scala
@@ -1,0 +1,26 @@
+package com.gu.acquisition.instances
+
+import com.gu.fezziwig.CirceScroogeMacros._
+import io.circe.{Decoder, Encoder}
+import ophan.thrift.event.AbTest
+import play.api.libs.json._
+
+trait AbTestInstances {
+  // Ignore IntelliJ - these imports are used!
+  import cats.syntax.either._
+
+  implicit val abTestDecoder: Decoder[AbTest] = decodeThriftStruct[AbTest]
+
+  implicit val abTestEncoder: Encoder[AbTest] = encodeThriftStruct[AbTest]
+
+  implicit val abTestReads: Reads[AbTest] = {
+    import play.api.libs.functional.syntax._
+    ((__ \ "name").read[String] and (__ \ "variant").read[String]) { (name, variant) =>
+      AbTest(name, variant)
+    }
+  }
+
+  implicit val abTestWrites: Writes[AbTest] = Writes { abTest =>
+    Json.obj("name" -> abTest.name, "variant" -> abTest.variant)
+  }
+}

--- a/app/com.gu.acquisition/instances/abTestInfo.scala
+++ b/app/com.gu.acquisition/instances/abTestInfo.scala
@@ -1,0 +1,14 @@
+package com.gu.acquisition.instances
+
+import com.gu.fezziwig.CirceScroogeMacros._
+import io.circe.{Decoder, Encoder}
+import ophan.thrift.event.AbTestInfo
+
+trait AbTestInfoInstances {
+  // Ignore IntelliJ - these imports are used!
+  import cats.syntax.either._
+
+  implicit val abTestInfoDecoder: Decoder[AbTestInfo] = decodeThriftStruct[AbTestInfo]
+
+  implicit val abTestInfoEncoder: Encoder[AbTestInfo] = encodeThriftStruct[AbTestInfo]
+}

--- a/app/com.gu.acquisition/instances/acquisition.scala
+++ b/app/com.gu.acquisition/instances/acquisition.scala
@@ -1,0 +1,14 @@
+package com.gu.acquisition.instances
+
+import com.gu.fezziwig.CirceScroogeMacros._
+import io.circe.{Decoder, Encoder}
+import ophan.thrift.event.Acquisition
+
+trait AcquisitionInstances {
+  // Ignore IntelliJ - these imports are used!
+  import cats.syntax.either._
+
+  implicit val acquisitionDecoder: Decoder[Acquisition] = decodeThriftStruct[Acquisition]
+
+  implicit val acquisitionEncoder: Encoder[Acquisition] = encodeThriftStruct[Acquisition]
+}

--- a/app/com.gu.acquisition/instances/acquisitionSource.scala
+++ b/app/com.gu.acquisition/instances/acquisitionSource.scala
@@ -1,0 +1,17 @@
+package com.gu.acquisition.instances
+
+import com.gu.fezziwig.CirceScroogeMacros._
+import io.circe.{Decoder, Encoder}
+import ophan.thrift.event.AcquisitionSource
+import play.api.libs.json.{Reads, Writes}
+
+trait AcquisitionSourceInstances extends ThriftEnumFormat {
+
+  implicit val acquisitionSourceDecoder: Decoder[AcquisitionSource] = decodeThriftEnum[AcquisitionSource]
+
+  implicit val acquisitionSourceEncoder: Encoder[AcquisitionSource] = encodeThriftEnum[AcquisitionSource]
+
+  implicit val acquisitionSourceReads: Reads[AcquisitionSource] = thriftEnumReads(AcquisitionSource.valueOf)
+
+  implicit val acquisitionSourceWrites: Writes[AcquisitionSource] = thriftEnumWrites[AcquisitionSource]
+}

--- a/app/com.gu.acquisition/instances/componentType.scala
+++ b/app/com.gu.acquisition/instances/componentType.scala
@@ -1,0 +1,17 @@
+package com.gu.acquisition.instances
+
+import com.gu.fezziwig.CirceScroogeMacros._
+import io.circe.{Decoder, Encoder}
+import ophan.thrift.componentEvent.ComponentType
+import play.api.libs.json.{Reads, Writes}
+
+trait ComponentTypeInstances extends ThriftEnumFormat {
+
+  implicit val componentTypeDecoder: Decoder[ComponentType] = decodeThriftEnum[ComponentType]
+
+  implicit val componentTypeEncoder: Encoder[ComponentType] = encodeThriftEnum[ComponentType]
+
+  implicit val componentTypeReads: Reads[ComponentType] = thriftEnumReads(ComponentType.valueOf)
+
+  implicit val componentTypeWrites: Writes[ComponentType] = thriftEnumWrites[ComponentType]
+}

--- a/app/com.gu.acquisition/instances/package.scala
+++ b/app/com.gu.acquisition/instances/package.scala
@@ -1,0 +1,22 @@
+package com.gu.acquisition
+
+package object instances {
+
+  object all extends AbTestInstances
+    with AbTestInfoInstances
+    with AcquisitionInstances
+    with AcquisitionSourceInstances
+    with ComponentTypeInstances
+    with PaymentFrequencyInstances
+    with PaymentProviderInstances
+    with QueryParameterInstances
+
+  object abTest extends AbTestInstances
+  object abTestInfo extends AbTestInfoInstances
+  object acquisition extends AcquisitionInstances
+  object acquisitionSource extends AcquisitionSourceInstances
+  object componentType extends ComponentTypeInstances
+  object paymentFrequency extends PaymentFrequencyInstances
+  object paymentProvider extends PaymentProviderInstances
+  object queryParamter extends QueryParameterInstances
+}

--- a/app/com.gu.acquisition/instances/paymentFrequency.scala
+++ b/app/com.gu.acquisition/instances/paymentFrequency.scala
@@ -1,0 +1,12 @@
+package com.gu.acquisition.instances
+
+import com.gu.fezziwig.CirceScroogeMacros._
+import io.circe.{Decoder, Encoder}
+import ophan.thrift.event.PaymentFrequency
+
+trait PaymentFrequencyInstances {
+
+  implicit val paymentFrequencyDecoder: Decoder[PaymentFrequency] = decodeThriftEnum[PaymentFrequency]
+
+  implicit val paymentFrequencyEncoder: Encoder[PaymentFrequency] = encodeThriftEnum[PaymentFrequency]
+}

--- a/app/com.gu.acquisition/instances/paymentProvider.scala
+++ b/app/com.gu.acquisition/instances/paymentProvider.scala
@@ -1,0 +1,12 @@
+package com.gu.acquisition.instances
+
+import com.gu.fezziwig.CirceScroogeMacros._
+import io.circe.{Decoder, Encoder}
+import ophan.thrift.event.PaymentProvider
+
+trait PaymentProviderInstances {
+
+  implicit val paymentProviderDecoder: Decoder[PaymentProvider] = decodeThriftEnum[PaymentProvider]
+
+  implicit val paymentProviderEncoder: Encoder[PaymentProvider] = encodeThriftEnum[PaymentProvider]
+}

--- a/app/com.gu.acquisition/instances/queryParameter.scala
+++ b/app/com.gu.acquisition/instances/queryParameter.scala
@@ -1,0 +1,26 @@
+package com.gu.acquisition.instances
+
+import com.gu.fezziwig.CirceScroogeMacros._
+import io.circe.{Decoder, Encoder}
+import ophan.thrift.event.QueryParameter
+import play.api.libs.json._
+
+trait QueryParameterInstances {
+  // Ignore IntelliJ - these imports are used!
+  import cats.syntax.either._
+
+  implicit val queryParameterDecoder: Decoder[QueryParameter] = decodeThriftStruct[QueryParameter]
+
+  implicit val queryParameterEncoder: Encoder[QueryParameter] = encodeThriftStruct[QueryParameter]
+
+  implicit val queryParameterReads: Reads[QueryParameter] = {
+    import play.api.libs.functional.syntax._
+    ((__ \ "name").read[String] and (__ \ "value").read[String]) { (name, value) =>
+      QueryParameter(name, value)
+    }
+  }
+
+  implicit val queryParameterWrites: Writes[QueryParameter] = Writes { queryParameter =>
+    Json.obj("name" -> queryParameter.name, "value" -> queryParameter.value)
+  }
+}

--- a/app/com.gu.acquisition/model/AcquisitionSubmission.scala
+++ b/app/com.gu.acquisition/model/AcquisitionSubmission.scala
@@ -1,0 +1,24 @@
+package com.gu.acquisition.model
+
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
+import ophan.thrift.event.Acquisition
+
+/**
+  * Encapsulates all the data required to submit an acquisition to Ophan.
+  */
+case class AcquisitionSubmission(ophanIds: OphanIds, gaData: GAData, acquisition: Acquisition)
+
+object AcquisitionSubmission {
+
+  // Type class allows an acquisition submission to passed directly to the submit() method
+  // of an Ophan service instance.
+  implicit val acquisitionSubmissionBuilder: AcquisitionSubmissionBuilder[AcquisitionSubmission] =
+    new AcquisitionSubmissionBuilder[AcquisitionSubmission] {
+
+      override def buildOphanIds(a: AcquisitionSubmission): Either[String, OphanIds] = Right(a.ophanIds)
+
+      override def buildGAData(a: AcquisitionSubmission): Either[String, GAData] = Right(a.gaData)
+
+      override def buildAcquisition(a: AcquisitionSubmission): Either[String, Acquisition] = Right(a.acquisition)
+    }
+}

--- a/app/com.gu.acquisition/model/ConversionCategory.scala
+++ b/app/com.gu.acquisition/model/ConversionCategory.scala
@@ -1,0 +1,23 @@
+package com.gu.acquisition.model
+
+private [acquisition] sealed trait ConversionCategory {
+  val name: String
+  val description: String
+}
+
+private [acquisition] object ConversionCategory {
+  case object PrintConversion extends ConversionCategory {
+    override val name = "PrintConversion"
+    override val description = "PrintSubscription"
+  }
+
+  case object DigitalConversion extends ConversionCategory {
+    override val name = "DigitalConversion"
+    override val description = "DigitalSubscription"
+  }
+
+  case object ContributionConversion extends ConversionCategory {
+    override val name = "ContributionConversion"
+    override val description = "Contribution"
+  }
+}

--- a/app/com.gu.acquisition/model/GAData.scala
+++ b/app/com.gu.acquisition/model/GAData.scala
@@ -1,0 +1,24 @@
+package com.gu.acquisition.model
+
+/**
+ * Describes the information that Google Analytics needs to track correctly
+ * @param hostname - Used to distinguish the site that this conversion comes from this helps with GA views
+ * @param clientId - The GA client id used to identify unique devices, can be retrieved from the _ga cookie
+ * @param clientIpAddress - Allows GA to to compute all the geo / network dimensions.
+ * @param clientUserAgent - Allows GA to compute the browser, platform, and mobile capabilities dimensions.
+ */
+case class GAData(
+  hostname: String,
+  clientId: String,
+  clientIpAddress: Option[String],
+  clientUserAgent: Option[String]
+)
+
+object GAData {
+
+  import io.circe._
+  import io.circe.generic.semiauto._
+
+  implicit val decoder: Decoder[GAData] = deriveDecoder
+  implicit val encoder: Encoder[GAData] = deriveEncoder
+}

--- a/app/com.gu.acquisition/model/OphanIds.scala
+++ b/app/com.gu.acquisition/model/OphanIds.scala
@@ -1,0 +1,21 @@
+package com.gu.acquisition.model
+
+import play.api.libs.json.{Reads, Writes, Json => PlayJson}
+
+/**
+  * Ids to be included in requests to Ophan.
+  */
+case class OphanIds(pageviewId: Option[String], visitId: Option[String], browserId: Option[String])
+
+object OphanIds {
+  import io.circe._
+  import io.circe.generic.semiauto._
+
+  implicit val decoder: Decoder[OphanIds] = deriveDecoder[OphanIds]
+
+  implicit val encoder: Encoder[OphanIds] = deriveEncoder[OphanIds]
+
+  implicit val reads: Reads[OphanIds] = PlayJson.reads[OphanIds]
+
+  implicit val writes: Writes[OphanIds] = PlayJson.writes[OphanIds]
+}

--- a/app/com.gu.acquisition/model/ReferrerAcquisitionData.scala
+++ b/app/com.gu.acquisition/model/ReferrerAcquisitionData.scala
@@ -1,0 +1,42 @@
+package com.gu.acquisition.model
+
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto._
+import ophan.thrift.componentEvent.ComponentType
+import ophan.thrift.event.{AbTest, AcquisitionSource, QueryParameter}
+import play.api.libs.json.{Reads, Writes, Json => PlayJson}
+
+/**
+  * Model for acquisition data passed by the referrer.
+  */
+case class ReferrerAcquisitionData(
+  campaignCode: Option[String],
+  referrerPageviewId: Option[String],
+  referrerUrl: Option[String],
+  componentId: Option[String],
+  componentType: Option[ComponentType],
+  source: Option[AcquisitionSource],
+  abTests: Option[Set[AbTest]],
+  queryParameters: Option[Set[QueryParameter]],
+  hostname: Option[String],
+  gaClientId: Option[String],
+  userAgent: Option[String],
+  ipAddress: Option[String]
+)
+
+object ReferrerAcquisitionData {
+  // Ignore IntelliJ - these imports are used!
+  import com.gu.acquisition.instances.abTest._
+  import com.gu.acquisition.instances.acquisitionSource._
+  import com.gu.acquisition.instances.componentType._
+  import com.gu.acquisition.instances.componentType._
+  import com.gu.acquisition.instances.queryParamter._
+
+  implicit val referrerAcquisitionDataDecoder: Decoder[ReferrerAcquisitionData] = deriveDecoder[ReferrerAcquisitionData]
+
+  implicit val referrerAcquisitionDataEncoder: Encoder[ReferrerAcquisitionData] = deriveEncoder[ReferrerAcquisitionData]
+
+  implicit val referrerAcquisitionDataReads: Reads[ReferrerAcquisitionData] = PlayJson.reads[ReferrerAcquisitionData]
+
+  implicit val referrerAcquisitionDataWrites: Writes[ReferrerAcquisitionData] = PlayJson.writes[ReferrerAcquisitionData]
+}

--- a/app/com.gu.acquisition/model/SyntheticPageviewId.scala
+++ b/app/com.gu.acquisition/model/SyntheticPageviewId.scala
@@ -1,0 +1,33 @@
+package com.gu.acquisition.model
+
+class SyntheticPageviewId(length: Int, suffix: String) {
+  import scala.util.Random
+  import java.lang.Long
+
+  private def base36(long: Long): String = Long.toString(long, 36)
+
+  /**
+    * Generate a pageview ID using the same logic (barring the suffix) used
+    * in tracker-js
+    *
+    * @see https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee#L3
+    */
+  def generate: String = {
+    val prefix: String = base36(System.currentTimeMillis)
+    val infix: String = Stream.continually(Random.nextInt(36))
+      .map(x => base36(x.toLong))
+      .take(length - prefix.length - suffix.length)
+      .mkString
+
+    s"$prefix$infix$suffix"
+  }
+}
+
+object SyntheticPageviewId {
+  val defaultLength = 20
+  val defaultSuffix = "AEP"
+
+  private val defaultInstance = new SyntheticPageviewId(defaultLength, defaultSuffix)
+
+  def generate: String = defaultInstance.generate
+}

--- a/app/com.gu.acquisition/model/errors/AnalyticsServiceError.scala
+++ b/app/com.gu.acquisition/model/errors/AnalyticsServiceError.scala
@@ -1,0 +1,29 @@
+package com.gu.acquisition.model.errors
+
+import java.io.IOException
+
+import okhttp3.{Request, Response}
+
+sealed trait AnalyticsServiceError extends Throwable
+
+object AnalyticsServiceError {
+
+  case class BuildError(message: String) extends AnalyticsServiceError {
+    override def getMessage: String = s"Acquisition submission build error: $message"
+  }
+
+  case class NetworkFailure(underlying: IOException) extends AnalyticsServiceError {
+    override def getMessage: String = s"Analytics network failure: ${underlying.getMessage}"
+  }
+
+  case class ResponseUnsuccessful(request: Request, failedResponse: Response) extends AnalyticsServiceError {
+    override def getMessage: String = {
+      s"HTTP request failed: ${failedResponse.code}"
+    }
+  }
+
+  case class KinesisError(e: Throwable) extends AnalyticsServiceError {
+    override def getMessage: String = s"Kinesis put error: $e"
+  }
+}
+

--- a/app/com.gu.acquisition/services/AcquisitionService.scala
+++ b/app/com.gu.acquisition/services/AcquisitionService.scala
@@ -1,0 +1,19 @@
+package com.gu.acquisition.services
+
+import cats.data.EitherT
+import com.gu.acquisition.model.AcquisitionSubmission
+import com.gu.acquisition.model.errors.AnalyticsServiceError
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
+import okhttp3.OkHttpClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait AcquisitionService {
+  def submit[A : AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext): EitherT[Future, List[AnalyticsServiceError], AcquisitionSubmission]
+}
+
+object AcquisitionService {
+
+  def prod(config: DefaultAcquisitionServiceConfig)(implicit client: OkHttpClient): DefaultAcquisitionService =
+    new DefaultAcquisitionService(config)
+}

--- a/app/com.gu.acquisition/services/AnalyticsService.scala
+++ b/app/com.gu.acquisition/services/AnalyticsService.scala
@@ -1,0 +1,12 @@
+package com.gu.acquisition.services
+
+import cats.data.EitherT
+import com.gu.acquisition.model.AcquisitionSubmission
+import com.gu.acquisition.model.errors.AnalyticsServiceError
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
+
+import scala.concurrent.{ExecutionContext, Future}
+
+private [acquisition] trait AnalyticsService {
+  def submit[A : AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext): EitherT[Future, AnalyticsServiceError, AcquisitionSubmission]
+}

--- a/app/com.gu.acquisition/services/DefaultAcquisitionService.scala
+++ b/app/com.gu.acquisition/services/DefaultAcquisitionService.scala
@@ -1,0 +1,49 @@
+package com.gu.acquisition.services
+
+import cats.data.EitherT
+import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.gu.acquisition.model.AcquisitionSubmission
+import com.gu.acquisition.model.errors.AnalyticsServiceError
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
+import okhttp3.{HttpUrl, OkHttpClient}
+
+import scala.concurrent.ExecutionContext
+
+sealed trait DefaultAcquisitionServiceConfig {
+  val kinesisStreamName: String
+  val ophanEndpoint: Option[HttpUrl]
+}
+
+//Credentials provider is only required by the kinesis client when running in ec2 or locally
+case class Ec2OrLocalConfig(credentialsProvider: AWSCredentialsProviderChain, kinesisStreamName: String, ophanEndpoint: Option[HttpUrl] = None) extends DefaultAcquisitionServiceConfig
+
+case class LambdaConfig(kinesisStreamName: String, ophanEndpoint: Option[HttpUrl] = None) extends DefaultAcquisitionServiceConfig
+
+class DefaultAcquisitionService(config: DefaultAcquisitionServiceConfig)(implicit client: OkHttpClient) extends AcquisitionService {
+  private val ophanService = new OphanService(config.ophanEndpoint)
+  private val gAService = new GAService()
+  private val kinesisService = new KinesisService(config)
+
+  override def submit[A: AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext) = {
+    val ov = ophanService.submit(a).value
+    val gv = gAService.submit(a).value
+    val kv = kinesisService.submit(a).value
+    val result = for {
+      o <- ov
+      g <- gv
+      k <- kv
+    } yield mergeEithers(List(o, g, k))
+    EitherT(result)
+  }
+
+  // Return the AcquisitionSubmission only if there are no errors, otherwise the full List[AnalyticsServiceError]
+  def mergeEithers(eithers: List[Either[AnalyticsServiceError, AcquisitionSubmission]]): Either[List[AnalyticsServiceError], AcquisitionSubmission] = {
+    val errors: List[AnalyticsServiceError] = eithers.flatMap(_.swap.toOption)
+    val submission: Option[AcquisitionSubmission] = eithers.collectFirst { case Right(s) => s }
+
+    (errors, submission) match {
+      case (Nil, Some(s)) => Right(s)
+      case _ => Left(errors)
+    }
+  }
+}

--- a/app/com.gu.acquisition/services/GAService.scala
+++ b/app/com.gu.acquisition/services/GAService.scala
@@ -1,0 +1,214 @@
+package com.gu.acquisition.services
+
+import java.util.UUID
+
+import cats.data.EitherT
+import cats.implicits._
+import com.gu.acquisition.model._
+import com.gu.acquisition.model.errors.AnalyticsServiceError.BuildError
+import com.gu.acquisition.services.HttpAnalyticsService.RequestData
+import com.gu.acquisition.services.GAService.clientIdPattern
+import com.gu.acquisitionsValueCalculatorClient.model.{AcquisitionModel, PrintOptionsModel}
+import com.gu.acquisitionsValueCalculatorClient.service.AnnualisedValueService
+import com.typesafe.scalalogging.LazyLogging
+import okhttp3._
+import ophan.thrift.event.PrintProduct.{GuardianWeekly, HomeDeliveryEveryday, HomeDeliveryEverydayPlus, HomeDeliverySaturday, HomeDeliverySaturdayPlus, HomeDeliverySixday, HomeDeliverySixdayPlus, HomeDeliverySunday, HomeDeliverySundayPlus, HomeDeliveryWeekend, HomeDeliveryWeekendPlus, VoucherEveryday, VoucherEverydayPlus, VoucherSaturday, VoucherSaturdayPlus, VoucherSixday, VoucherSixdayPlus, VoucherSunday, VoucherSundayPlus, VoucherWeekend, VoucherWeekendPlus}
+import ophan.thrift.event.Product.{Contribution, DigitalSubscription, PrintSubscription, RecurringContribution}
+import ophan.thrift.event.{AbTestInfo, Acquisition, PrintOptions, Product}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.matching.Regex
+
+private[services] object GAService {
+  val clientIdPattern: Regex = raw"GA\d\.\d\.(\d+\.\d+)".r
+}
+
+private[services] class GAService(implicit client: OkHttpClient)
+  extends HttpAnalyticsService with LazyLogging {
+
+  private val gaPropertyId: String = "UA-51507017-5"
+  private val endpoint: HttpUrl = HttpUrl.parse("https://www.google-analytics.com")
+
+  private[services] def buildBody(submission: AcquisitionSubmission)(implicit ec: ExecutionContext): EitherT[Future, BuildError, RequestBody] = EitherT {
+    getAnnualisedValue(submission.acquisition)
+      .fold(
+        error => {
+          logger.warn(s"Couldn't retrieve annualised value for this acquisition: $error")
+          buildPayload(submission, 0) // We still want to record the acquisition even if we can't get the AV
+        },
+        value => buildPayload(submission, value)
+      ).map {
+      maybePayload =>
+        maybePayload.map { payload =>
+          logger.debug(s"GA payload: $payload")
+          RequestBody.create(null, payload)
+        }
+    }
+  }
+
+  private def getAnnualisedValue(acquisition: Acquisition)(implicit ec: ExecutionContext) = {
+    val acquisitionModel = AcquisitionModel(acquisition.amount,
+      acquisition.product.originalName,
+      acquisition.currency,
+      acquisition.paymentFrequency.originalName,
+      acquisition.paymentProvider.map(_.toString),
+      acquisition.printOptions.map(printOptions => PrintOptionsModel(printOptions.product.originalName, printOptions.deliveryCountryCode))
+    )
+
+    EitherT(AnnualisedValueService.getAsyncAV(acquisitionModel, "ophan"))
+  }
+
+  private def getSuccessfulSubscriptionSignUpMetric(conversionCategory: ConversionCategory) =
+    conversionCategory match {
+      case _: ConversionCategory.ContributionConversion.type => ""
+      case _ => "1"
+    }
+
+  private[services] def buildPayload(submission: AcquisitionSubmission, annualisedValue: Double, transactionId: Option[String] = None): Either[BuildError, String] = {
+    import submission._
+    val tid = transactionId.getOrElse(UUID.randomUUID().toString)
+    val goExp = buildOptimizeTestsPayload(acquisition.abTests)
+
+    // clientId cannot be empty or the call will fail
+    sanitiseClientId(gaData.clientId).map {
+      clientId =>
+        val productName = getProductName(submission.acquisition)
+        val conversionCategory = getConversionCategory(submission.acquisition)
+        val productCheckout = getProductCheckout(submission.acquisition)
+        val body = Map(
+          "v" -> "1", //Version
+          "cid" -> clientId,
+          "tid" -> gaPropertyId,
+          "dh" -> gaData.hostname,
+          "uip" -> gaData.clientIpAddress.getOrElse(""), // IP Override
+          "ua" -> gaData.clientUserAgent.getOrElse(""), // User Agent Override
+
+          // Custom Dimensions
+          "cd12" -> acquisition.campaignCode.map(_.mkString(",")).getOrElse(""), // Campaign code
+          "cd16" -> buildABTestPayload(acquisition.abTests), //'Experience' custom dimension
+          "cd17" -> acquisition.paymentProvider.getOrElse(""), // Payment method
+          "cd19" -> acquisition.promoCode.getOrElse(""), // Promo code
+          "cd25" -> acquisition.labels.exists(_.contains("REUSED_EXISTING_PAYMENT_METHOD")), // usedExistingPaymentMethod
+          "cd26" -> acquisition.labels.exists(_.contains("gift-subscription")), // gift subscription
+          "cd27" -> productCheckout,
+          "cd30" -> acquisition.labels.exists(_.contains("corporate-subscription")), // corporate subscription
+
+          // Custom metrics
+          "cm10" -> getSuccessfulSubscriptionSignUpMetric(conversionCategory),
+
+          // Google Optimize Experiment Id
+          "xid" -> goExp.map(_._1).getOrElse(""),
+          "xvar" -> goExp.map(_._2).getOrElse(""),
+
+          // The GA conversion event
+          "t" -> "event",
+          "ec" -> conversionCategory.name, //Event Category
+          "ea" -> productName, //Event Action
+          "el" -> acquisition.paymentFrequency.name, //Event Label
+          "ev" -> acquisition.amount.toInt.toString, //Event Value is an Integer
+
+          // Enhanced Ecommerce tracking https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
+          "ti" -> tid,
+          "tcc" -> acquisition.promoCode.getOrElse(""), // Transaction coupon.
+          "pa" -> "purchase", //This is a purchase
+          "pr1nm" -> productName, // Product Name
+          "pr1ca" -> conversionCategory.description, // Product category
+          "pr1pr" -> annualisedValue, // Product Price - we are tracking the annualised value here as this is what goes into the revenue metric
+          "pr1qt" -> "1", // Product Quantity
+          "pr1cc" -> acquisition.promoCode.getOrElse(""), // Product coupon code.
+          "pr1cm15" -> acquisition.amount.toString, // Custom metric 15 - purchasePrice
+          "cu" -> acquisition.currency.toString // Currency
+        )
+
+        body
+          .filter { case (key, value) => value != "" }
+          .map { case (key, value) => s"$key=$value" }
+          .mkString("&")
+    }
+  }
+
+  private[services] def sanitiseClientId(maybeId: String): Either[BuildError, String] = {
+    maybeId match {
+      case clientIdPattern(id) => Right(id) // If we have a full _ga cookie string extract the client id
+      case "" => Left(BuildError("Client ID cannot be an empty string.\n" +
+        "To link server side with client side events you need to pass a valid clientId from the `_ga` cookie.\n" +
+        "Otherwise you can pass any non-empty string eg. `UUID.randomUUID().toString`\n" +
+        "More info here: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cid"))
+      case _ => Right(maybeId) // Otherwise assume that the caller has passed in the client id correctly
+    }
+  }
+
+  private[services] def getProductCheckout(acquisition: Acquisition) =
+    acquisition.product match {
+      case Contribution | RecurringContribution => Some("Contribution")
+      case DigitalSubscription => Some("DigitalPack")
+      case PrintSubscription => getProductCheckoutForPrint(acquisition.printOptions)
+      case default => None
+    }
+
+  private def getProductCheckoutForPrint(maybePrintOptions: Option[PrintOptions]) =
+    maybePrintOptions.map(
+      _.product match {
+        case VoucherEveryday | VoucherSaturday | VoucherSunday | VoucherSixday | VoucherWeekend |
+             HomeDeliveryEveryday | HomeDeliverySaturday | HomeDeliverySunday | HomeDeliverySixday | HomeDeliveryWeekend
+        => "Paper"
+        case VoucherEverydayPlus | VoucherSaturdayPlus | VoucherSundayPlus | VoucherSixdayPlus | VoucherWeekendPlus |
+             HomeDeliveryEverydayPlus | HomeDeliverySaturdayPlus | HomeDeliverySundayPlus | HomeDeliverySixdayPlus | HomeDeliveryWeekendPlus
+        => "PaperAndDigital"
+        case GuardianWeekly => "GuardianWeekly"
+      }
+    )
+
+  private[services] def getProductName(acquisition: Acquisition) =
+    acquisition.printOptions.map(_.product.name).getOrElse(acquisition.product.name)
+
+  private[services] def getConversionCategory(acquisition: Acquisition) =
+    acquisition.printOptions.map(p => ConversionCategory.PrintConversion)
+      .getOrElse(getDigitalConversionCategory(acquisition))
+
+  private[services] def getDigitalConversionCategory(acquisition: Acquisition) =
+    acquisition.product match {
+      case _: Product.RecurringContribution.type |
+           _: Product.Contribution.type => ConversionCategory.ContributionConversion
+      case _ => ConversionCategory.DigitalConversion
+    }
+
+  private[services] def buildOptimizeTestsPayload(maybeTests: Option[AbTestInfo]) = {
+    val optimizePrefix = "optimize$$"
+    maybeTests.map {
+      abTests =>
+        abTests.tests
+          .filter(test => test._1.startsWith(optimizePrefix))
+          .map(test => test._1.replace(optimizePrefix, "") -> test._2)
+          .toMap
+    }.map(tests => (tests.keys.mkString(","), tests.values.mkString(",")))
+
+  }
+
+  private[services] def buildABTestPayload(maybeTests: Option[AbTestInfo]) =
+    maybeTests.map {
+      abTests =>
+        abTests.tests
+          .map(test => s"${test._1}=${test._2}")
+          .mkString(",")
+    }.getOrElse("")
+
+
+  override def buildRequest(submission: AcquisitionSubmission)(implicit ec: ExecutionContext): EitherT[Future, BuildError, RequestData] = {
+
+    val url = endpoint.newBuilder()
+      .addPathSegment("collect")
+      .build()
+
+    buildBody(submission).map {
+      requestBody =>
+        val request = new Request.Builder()
+          .url(url)
+          .addHeader("User-Agent", submission.gaData.clientUserAgent.getOrElse(""))
+          .post(requestBody)
+          .build()
+
+        RequestData(request, submission)
+    }
+  }
+}

--- a/app/com.gu.acquisition/services/HttpAnalyticsService.scala
+++ b/app/com.gu.acquisition/services/HttpAnalyticsService.scala
@@ -1,0 +1,65 @@
+package com.gu.acquisition.services
+
+import java.io.IOException
+
+import cats.data.EitherT
+import com.gu.acquisition.model.AcquisitionSubmission
+import com.gu.acquisition.model.errors.AnalyticsServiceError
+import com.gu.acquisition.model.errors.AnalyticsServiceError.{BuildError, NetworkFailure, ResponseUnsuccessful}
+import com.gu.acquisition.services.HttpAnalyticsService.RequestData
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
+import okhttp3._
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.control.NonFatal
+
+private [acquisition] abstract class HttpAnalyticsService(implicit client: OkHttpClient) extends AnalyticsService {
+
+  protected def buildRequest(submission: AcquisitionSubmission)(implicit ec: ExecutionContext): EitherT[Future, BuildError, RequestData]
+
+  private def executeRequest(data: RequestData): EitherT[Future, AnalyticsServiceError, AcquisitionSubmission] = {
+
+    val p = Promise[Either[AnalyticsServiceError, AcquisitionSubmission]]
+
+    client.newCall(data.request).enqueue(new Callback {
+
+      override def onFailure(call: Call, e: IOException): Unit =
+        p.success(Left(NetworkFailure(e)))
+
+      private def close(response: Response): Unit =
+        try {
+          response.close()
+        } catch {
+          case NonFatal(_) =>
+        }
+
+      override def onResponse(call: Call, response: Response): Unit =
+        try {
+          if (response.isSuccessful) p.success(Right(data.submission))
+          else p.success(Left(ResponseUnsuccessful(data.request, response)))
+        } finally {
+          close(response)
+        }
+    })
+
+    EitherT(p.future)
+  }
+
+  def submit[A : AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext): EitherT[Future, AnalyticsServiceError, AcquisitionSubmission] = {
+
+    import AcquisitionSubmissionBuilder.ops._
+    import cats.instances.future._
+
+    for {
+      submission <- EitherT.fromEither(a.asAcquisitionSubmission)
+      request <- buildRequest(submission)
+      result <- executeRequest(request)
+    } yield result
+  }
+
+}
+
+object HttpAnalyticsService {
+
+  private[services] case class RequestData(request: Request, submission: AcquisitionSubmission)
+}

--- a/app/com.gu.acquisition/services/KinesisService.scala
+++ b/app/com.gu.acquisition/services/KinesisService.scala
@@ -1,0 +1,63 @@
+package com.gu.acquisition.services
+
+import java.nio.ByteBuffer
+
+import cats.data.EitherT
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.services.kinesis.AmazonKinesisAsyncClientBuilder
+import com.amazonaws.services.kinesis.model.{PutRecordRequest, PutRecordResult}
+import com.gu.acquisition.model.AcquisitionSubmission
+import com.gu.acquisition.model.errors.AnalyticsServiceError
+import com.gu.acquisition.model.errors.AnalyticsServiceError.KinesisError
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
+import com.gu.thrift.serializer.ThriftSerializer
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.control.NonFatal
+
+private [acquisition] class KinesisService(config: DefaultAcquisitionServiceConfig, region: String = "eu-west-1") extends AnalyticsService {
+
+  private val kinesisClient = {
+    val builder = AmazonKinesisAsyncClientBuilder.standard().withRegion(region)
+    config match {
+      case Ec2OrLocalConfig(provider, _, _) => builder.withCredentials(provider).build
+      case _: LambdaConfig => builder.build
+    }
+  }
+
+  private def putAcquisition(acquisitionSubmission: AcquisitionSubmission): EitherT[Future, AnalyticsServiceError, AcquisitionSubmission] = {
+    val promise = Promise[Either[AnalyticsServiceError, AcquisitionSubmission]]()
+
+    val request: PutRecordRequest = {
+      val buffer = ByteBuffer.wrap {
+        ThriftSerializer.serializeToBytes(acquisitionSubmission.acquisition, userCompressionType = None, thriftBufferInitialSize = None)
+      }
+
+      new PutRecordRequest()
+        .withStreamName(config.kinesisStreamName)
+        .withPartitionKey(acquisitionSubmission.acquisition.identityId.getOrElse(acquisitionSubmission.acquisition.amount.toString))
+        .withData(buffer)
+    }
+
+    kinesisClient.putRecordAsync(request, new AsyncHandler[PutRecordRequest, PutRecordResult] {
+      override def onError(exception: Exception): Unit = exception match {
+        case NonFatal(e) => promise.failure(KinesisError(e))
+        case fatal => promise.failure(fatal)
+      }
+
+      override def onSuccess(request: PutRecordRequest, result: PutRecordResult): Unit = promise.success(Right(acquisitionSubmission))
+    })
+
+    EitherT(promise.future)
+  }
+
+  def submit[A : AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext): EitherT[Future, AnalyticsServiceError, AcquisitionSubmission] = {
+    import AcquisitionSubmissionBuilder.ops._
+    import cats.instances.future._
+
+    for {
+      submission <- EitherT.fromEither(a.asAcquisitionSubmission)
+      result <- putAcquisition(submission)
+    } yield result
+  }
+}

--- a/app/com.gu.acquisition/services/MockAcquisitionService.scala
+++ b/app/com.gu.acquisition/services/MockAcquisitionService.scala
@@ -1,0 +1,26 @@
+package com.gu.acquisition.services
+
+import cats.data.EitherT
+import com.gu.acquisition.model.AcquisitionSubmission
+import com.gu.acquisition.model.errors.AnalyticsServiceError
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Build an acquisition submission, but don't actually send it to an Ophan endpoint.
+  * Useful for e.g. test users.
+  */
+object MockAcquisitionService extends AcquisitionService {
+
+  override def submit[A: AcquisitionSubmissionBuilder](a: A)(
+    implicit ec: ExecutionContext): EitherT[Future, List[AnalyticsServiceError], AcquisitionSubmission] = {
+
+    import cats.instances.future._
+    import cats.syntax.either._
+    import AcquisitionSubmissionBuilder.ops._
+
+    // Left map to lift the build error into a processing error.
+    a.asAcquisitionSubmission.toEitherT.leftMap(err => List(err))
+  }
+}

--- a/app/com.gu.acquisition/services/OphanService.scala
+++ b/app/com.gu.acquisition/services/OphanService.scala
@@ -1,0 +1,47 @@
+package com.gu.acquisition.services
+
+import cats.data.EitherT
+import cats.implicits._
+import com.gu.acquisition.model.errors.AnalyticsServiceError.BuildError
+import com.gu.acquisition.model.{AcquisitionSubmission, SyntheticPageviewId}
+import com.gu.acquisition.services.HttpAnalyticsService.RequestData
+import okhttp3._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Build an acquisition submission, and submit it to Ophan.
+  * Uses OkHttp for executing the Http request.
+  */
+private [acquisition] class OphanService(endpointOverride: Option[HttpUrl] = None)(implicit client: OkHttpClient)
+  extends HttpAnalyticsService {
+
+  private val endpoint: HttpUrl = endpointOverride getOrElse HttpUrl.parse("https://ophan.theguardian.com")
+
+  private def cookieValue(visitId: Option[String], browserId: Option[String]): String =
+    List(visitId.map(("vsid", _)), browserId.map(("bwid", _))).flatten
+      .map { case (name, value) => name + "=" + value }
+      .mkString(";")
+
+  override def buildRequest(submission: AcquisitionSubmission)(implicit ec: ExecutionContext): EitherT[Future, BuildError, RequestData] = {
+    import com.gu.acquisition.instances.acquisition._
+    import io.circe.syntax._
+    import submission._
+
+    val url = endpoint.newBuilder()
+      .addPathSegment("a.gif")
+      .addQueryParameter("viewId", ophanIds.pageviewId.getOrElse(SyntheticPageviewId.generate))
+      .addQueryParameter("acquisition" , acquisition.asJson.noSpaces)
+      .build()
+
+    val request = new Request.Builder()
+      .url(url)
+      .addHeader("Cookie", cookieValue(ophanIds.visitId, ophanIds.browserId))
+      .build()
+
+    EitherT.rightT[Future, BuildError](RequestData(request, submission))
+  }
+
+
+}
+

--- a/app/com.gu.acquisition/syntax/iterable.scala
+++ b/app/com.gu.acquisition/syntax/iterable.scala
@@ -1,0 +1,17 @@
+package com.gu.acquisition.syntax
+
+import com.gu.acquisition.typeclasses.AbTestConverter
+import ophan.thrift.event.AbTestInfo
+
+trait IterableSyntax {
+
+  implicit def iterableSyntax[A](as: Iterable[A]): IterableOps[A] = new IterableOps[A](as)
+}
+
+final class IterableOps[A](val as: Iterable[A]) extends AnyVal {
+
+  def asAbTestInfo(implicit converter: AbTestConverter[A]): AbTestInfo = {
+    import AbTestConverter.ops._
+    AbTestInfo(as.map(_.asAbTest).toSet)
+  }
+}

--- a/app/com.gu.acquisition/syntax/package.scala
+++ b/app/com.gu.acquisition/syntax/package.scala
@@ -1,0 +1,8 @@
+package com.gu.acquisition
+
+package object syntax {
+
+  object all extends IterableSyntax
+
+  object iterable extends IterableSyntax
+}

--- a/app/com.gu.acquisition/typeclasses/AbTestConverter.scala
+++ b/app/com.gu.acquisition/typeclasses/AbTestConverter.scala
@@ -1,0 +1,14 @@
+package com.gu.acquisition.typeclasses
+
+import ophan.thrift.event.AbTest
+import simulacrum.typeclass
+
+@typeclass trait AbTestConverter[A] {
+  def asAbTest(a: A): AbTest
+}
+
+object AbTestConverter {
+  def instance[A](f: A => AbTest): AbTestConverter[A] = new AbTestConverter[A] {
+    override def asAbTest(a: A): AbTest = f(a)
+  }
+}

--- a/app/com.gu.acquisition/typeclasses/AcquisitionSubmissionBuilder.scala
+++ b/app/com.gu.acquisition/typeclasses/AcquisitionSubmissionBuilder.scala
@@ -1,0 +1,27 @@
+package com.gu.acquisition.typeclasses
+
+import com.gu.acquisition.model.errors.AnalyticsServiceError.BuildError
+import com.gu.acquisition.model.{AcquisitionSubmission, GAData, OphanIds}
+import ophan.thrift.event.Acquisition
+import simulacrum.typeclass
+
+/**
+  * Type class for creating an acquisition submission from an arbitrary data type.
+  */
+@typeclass trait AcquisitionSubmissionBuilder[A] {
+
+  import cats.syntax.either._
+
+  def buildOphanIds(a: A): Either[String, OphanIds]
+
+  def buildAcquisition(a: A): Either[String, Acquisition]
+
+  def buildGAData(a: A): Either[String, GAData]
+
+  def asAcquisitionSubmission(a: A): Either[BuildError, AcquisitionSubmission] =
+    (for {
+      ophanIds <- buildOphanIds(a)
+      gaData <- buildGAData(a)
+      acquisition <- buildAcquisition(a)
+    } yield AcquisitionSubmission(ophanIds, gaData, acquisition)).leftMap(BuildError)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,25 @@ scalacOptions ++= Seq("-feature")
 val scalatestVersion = "3.0.4"
 val jacksonVersion = "2.10.0"
 
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full) // for simulacrum
+
+libraryDependencies ++= Seq(
+  "com.gu" %% "ophan-event-model" % "0.0.17" excludeAll ExclusionRule(organization = "com.typesafe.play"),
+  "com.gu" %% "fezziwig" % "1.3",
+  "com.typesafe.play" %% "play-json" % "2.7.4",
+  "io.circe" %% "circe-core" % "0.12.1",
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
+  "com.gu" %% "acquisitions-value-calculator-client" % "2.0.5",
+  "com.squareup.okhttp3" % "okhttp" % "3.9.0",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
+  "org.typelevel" %% "simulacrum" % "1.0.1",
+  "org.scalatest" %% "scalatest" % "3.1.1" % "test",
+  "org.scalactic" %% "scalactic" % "3.1.1",
+  "org.typelevel" %% "cats-core" % "2.1.1",
+  "com.amazonaws" % "aws-java-sdk-kinesis" % "1.11.465",
+  "com.gu" %% "thrift-serializer" % "4.0.3",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.5.1"
+)
 libraryDependencies ++= Seq(
     cache,
     ws,
@@ -56,7 +75,6 @@ libraryDependencies ++= Seq(
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.4",
     "com.gu" %% "tip" % "0.1.1",
-    "com.gu" %% "acquisition-event-producer-play26" % "4.0.26",
     "com.github.nscala-time" %% "nscala-time" % "2.16.0",
     "io.sentry" % "sentry-logback" % "1.7.5",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",

--- a/build.sbt
+++ b/build.sbt
@@ -55,8 +55,6 @@ libraryDependencies ++= Seq(
   "com.squareup.okhttp3" % "okhttp" % "3.9.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
   "org.typelevel" %% "simulacrum" % "1.0.1",
-  "org.scalatest" %% "scalatest" % "3.1.1" % "test",
-  "org.scalactic" %% "scalactic" % "3.1.1",
   "org.typelevel" %% "cats-core" % "2.1.1",
   "com.amazonaws" % "aws-java-sdk-kinesis" % "1.11.465",
   "com.gu" %% "thrift-serializer" % "4.0.3",


### PR DESCRIPTION
We've had quite a few goes at adding the acquisition event producer jar as an unmanaged dependency (due to the bintray switchoff) however this causes the instances to cycle as the dynamodb2 classes are somehow not found.

Since we have no reall hypothesis on why this is happening, this is a copy and paste job to resolve this.