### PR TITLE
Remove Tip verification experiment

### DIFF
--- a/app/controllers/Checkout.scala
+++ b/app/controllers/Checkout.scala
@@ -17,7 +17,6 @@ import com.gu.memsub.subsv2.{CatalogPlan, PlansWithIntroductory}
 import com.gu.memsub.{Product, SupplierCode}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
-import com.gu.tip.Tip
 import com.gu.zuora.soap.models.errors._
 import com.typesafe.scalalogging.LazyLogging
 import configuration.Config.Identity.webAppProfileUrl
@@ -217,7 +216,6 @@ class Checkout(fBackendFactory: TouchpointBackends, authenticationService: Authe
       val eventualMaybeSubscription = tpBackend.subscriptionService.get[com.gu.memsub.subsv2.SubscriptionPlan.ContentSubscription](Name(subsName))
       eventualMaybeSubscription.map { maybeSub =>
         maybeSub.map { sub =>
-          if (tpBackend.environmentName == "PROD") Tip.verify()
           Ok(view.thankyou(sub, passwordForm, resolution, promoCode, promotion, startDate, edition, billingCountry))
         }.getOrElse {
           Redirect(routes.Homepage.index()).withNewSession

--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,6 @@ libraryDependencies ++= Seq(
     "com.gu" %% "play-googleauth" % "0.7.6",
     "com.gu" %% "identity-test-users" % "0.6",
     "com.gu" %% "content-authorisation-common" % "0.4",
-    "com.gu" %% "tip" % "0.1.1",
     "com.github.nscala-time" %% "nscala-time" % "2.16.0",
     "io.sentry" % "sentry-logback" % "1.7.5",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",


### PR DESCRIPTION
## What does this change?

Removes some experimental monitoring that was added in https://github.com/guardian/subscriptions-frontend/pull/901.

> Note that this requires us to add a GitHub access token to our private .conf file. For the purposes of testing out TiP, I suggest that we use my personal access token for this (temporarily).

Unfortunately this is currently still the case, so I'd like to remove this functionality and tidy things up!

## How to test

I've [deployed this to `CODE`](https://riffraff.gutools.co.uk/deployment/view/5a501b21-e587-4229-98c5-26fabea0b3e0) and confirmed that I can still buy a Digital Pack / reach the Thank You page.

## How can we measure success?

* We'll be able to delete a personal access token
* This repository will have less dependencies

## Have we considered potential risks?

Before deploying this change, I will also remove some private configuration related to TiP. This is a `PROD`-only operation, which takes place outside of version control, so it's a bit risky. After deploying I will buy something as a test user just to be on the safe side.

## To do

- [x] Remove private configuration