### PR TITLE
Update change password link in top pop-out menu

### DIFF
--- a/app/configuration/Links.scala
+++ b/app/configuration/Links.scala
@@ -34,7 +34,7 @@ object ProfileLinks {
   val commentActivity = Links(s"$identityUrl/user/id/", "Comment activity")
   val editProfile = Links(s"$identityUrl/public/edit", "Edit profile")
   val emailPreferences = Links(s"$identityUrl/email-prefs", "Email preferences")
-  val changePassword = Links(s"$identityUrl/password/change", "Change password")
+  val changePassword = Links(s"$identityUrl/reset", "Change password")
   val signOut = Links(s"$identityUrl/signout", "Sign out")
 
   val popupLinks = Seq(commentActivity, editProfile, emailPreferences, changePassword, signOut)


### PR DESCRIPTION
## What does this change?
This updates the change password link in the top pop-out menu to point to the correct password reset page. The page the link is currently pointing at will shortly be removed to reduce duplication and ensure we are adhering to security best practice.