### PR TITLE
Add route to disallow rules in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,5 +7,6 @@ Disallow: /management/manifest
 Disallow: /p/*
 Disallow: /patterns
 Disallow: /test-users
+Disallow: /collection/paper-digital
 
 Allow: /


### PR DESCRIPTION
## What does this change?

We want to prevent this route from being indexed by search engines.

Trello: https://trello.com/c/99gSG57p/191-update-robotstxt-on-subscribetheguardiancom