### PR TITLE
Update to version 1.5.6 of SBT

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.6


### PR DESCRIPTION
## What does this change?

Update to version 1.5.6 of SBT to get around the log4j vulnerability.
