### PR TITLE
Newspaper promo landing page links for Feb 22 promotion

### DIFF
--- a/app/model/Subscriptions.scala
+++ b/app/model/Subscriptions.scala
@@ -17,6 +17,8 @@ object Subscriptions {
     paymentDetails: Option[Html] = None
   )
 
+  case class SubscriptionProductFooter(text: String, url: String)
+
   trait SubscriptionProduct {
     val id: String
     val title: String
@@ -25,6 +27,7 @@ object Subscriptions {
     val options: Seq[SubscriptionOption]
     val stepsHeading: String
     val steps: Seq[String]
+    val stepsFooter: SubscriptionProductFooter
     val insideM25: Boolean
     val isDiscounted: Boolean
     val catalogProduct: Product
@@ -42,6 +45,7 @@ object Subscriptions {
     override val insideM25 = true
     override val id = Delivery.name
     val stepsHeading = "This is how direct delivery works"
+    val stepsFooter  = SubscriptionProductFooter("Not within the M25? Click here for our voucher scheme", "https://sub.thegulocal.com/p/Waitrose#voucher")
     val steps = Seq(
       "Pick the perfect package for you",
       "Confirm your address is within the M25",
@@ -60,6 +64,7 @@ object Subscriptions {
     override val insideM25 = false
     override val id = Voucher.name
     val stepsHeading = "This is how the voucher scheme works"
+    val stepsFooter  = SubscriptionProductFooter("For Home Delivery within the M25 click here", "https://sub.thegulocal.com/p/Waitrose#delivery")
     val steps = Seq(
       "Pick the perfect package for you",
       "We'll post personalised vouchers for the newspapers in your package",

--- a/app/model/Subscriptions.scala
+++ b/app/model/Subscriptions.scala
@@ -45,7 +45,9 @@ object Subscriptions {
     override val insideM25 = true
     override val id = Delivery.name
     val stepsHeading = "This is how direct delivery works"
-    val stepsFooter  = SubscriptionProductFooter("Not within the M25? Click here for our voucher scheme", "https://sub.thegulocal.com/p/Waitrose#voucher")
+    val stepsFooter  = SubscriptionProductFooter(
+      "Not within the M25? Click here for our voucher scheme", "https://subscribe.theguardian.com/p/Waitrose#voucher"
+    )
     val steps = Seq(
       "Pick the perfect package for you",
       "Confirm your address is within the M25",
@@ -64,7 +66,9 @@ object Subscriptions {
     override val insideM25 = false
     override val id = Voucher.name
     val stepsHeading = "This is how the voucher scheme works"
-    val stepsFooter  = SubscriptionProductFooter("For Home Delivery within the M25 click here", "https://sub.thegulocal.com/p/Waitrose#delivery")
+    val stepsFooter  = SubscriptionProductFooter(
+      "For Home Delivery within the M25 click here", "https://subscribe.theguardian.com/p/Waitrose#delivery"
+    )
     val steps = Seq(
       "Pick the perfect package for you",
       "We'll post personalised vouchers for the newspapers in your package",

--- a/app/views/fragments/shipping/shipping.scala.html
+++ b/app/views/fragments/shipping/shipping.scala.html
@@ -1,5 +1,6 @@
 @import utils.Prices._
 @(subscription: model.Subscriptions.SubscriptionProduct)
+<a class="paper-promo__link" href="@subscription.stepsFooter.url">@subscription.stepsFooter.text</a>
 <section class="section-slice">
     <h2 class="page-heading">@subscription.stepsHeading</h2>
     <ol class="steps">
@@ -7,7 +8,6 @@
         <li class="steps__item">@step</li>
     }
     </ol>
-    <a class="u-link" href="@subscription.stepsFooter.url">@subscription.stepsFooter.text</a>
 </section>
 
 <section class="section-slice">

--- a/app/views/fragments/shipping/shipping.scala.html
+++ b/app/views/fragments/shipping/shipping.scala.html
@@ -7,6 +7,7 @@
         <li class="steps__item">@step</li>
     }
     </ol>
+    <a class="u-link" href="@subscription.stepsFooter.url">@subscription.stepsFooter.text</a>
 </section>
 
 <section class="section-slice">

--- a/app/views/promotion/newspaperLandingPage.scala.html
+++ b/app/views/promotion/newspaperLandingPage.scala.html
@@ -58,17 +58,7 @@
         @fragments.page.header(title)
 
         <section class="promotion-description">
-            @promotion.landingPage.description.fold {
-                <p>@promotion.description</p>
-            } { d =>
-                <div>@Html(md.render(d))</div>
-                <br/>
-            }
 
-            @promotion.asIncentive.map { p =>
-                <h4>Redemption instructions</h4>
-                <p>@p.promotionType.redemptionInstructions</p>
-            }
         </section>
 
         @for(product <- products) {

--- a/assets/stylesheets/modules/_packages.scss
+++ b/assets/stylesheets/modules/_packages.scss
@@ -154,6 +154,19 @@
 $step-size: 40px;
 $step-size-tablet: 60px;
 
+.paper-promo__link {
+    color: guss-colour(guardian-brand);
+    display: block;
+    @include font-size(18px, 22px);
+    text-decoration: underline;
+    padding-bottom: $gs-baseline;
+
+    @include mq(tablet) {
+        @include font-size(18px, 22px);
+        max-width: gs-span(10);
+    }
+}
+
 .steps {
     @extend .o-inline-list;
     @include mq(tablet) {

--- a/assets/stylesheets/modules/_page.scss
+++ b/assets/stylesheets/modules/_page.scss
@@ -52,10 +52,10 @@
 
 .page-header {
     padding-top: $gs-baseline/2;
-    margin-bottom: $gs-baseline*2;
+    margin-bottom: $gs-baseline;
 
     @include mq(tablet) {
-        margin-bottom: $gs-baseline*4;
+        margin-bottom: $gs-baseline*2;
     }
 }
 .page-header__title {


### PR DESCRIPTION
## What does this change?
This PR adds a link to the top of the newspaper promo landing page from home delivery to voucher and vice versa.

[**Trello card**](https://trello.com/c/L1vuw6e3/245-revive-paper-vouchers-sign-up-on-the-subscribe-platform-in-support-of-the-waitrose-campaign)

## Screenshots
<img width="780" alt="Screen Shot 2022-01-21 at 17 00 38" src="https://user-images.githubusercontent.com/181371/150766409-10c1c45e-59ce-4ae1-9dc0-ed3f056d8325.png">
<img width="780" alt="Screen Shot 2022-01-21 at 16 58 23" src="https://user-images.githubusercontent.com/181371/150766426-4a720cda-8878-4875-a092-241407535e74.png">
