### PR TITLE
Fix review section on paper checkout

### DIFF
--- a/assets/javascripts/modules/checkout/reviewDetails.js
+++ b/assets/javascripts/modules/checkout/reviewDetails.js
@@ -26,14 +26,6 @@ define([
         }
     }
 
-    function getGiftDetails() {
-        return textUtils.mergeValues([
-            formEls.DELIVERY.$TITLE.val(),
-            formEls.DELIVERY.$FIRST_NAME.val(),
-            formEls.DELIVERY.$LAST_NAME.val()
-        ], ' ');
-    }
-
     function populateDetails() {
         formEls.$REVIEW_NAME.text(textUtils.mergeValues([
             formEls.$TITLE.val(),
@@ -58,7 +50,6 @@ define([
         var DELIVERY_COUNTRY_SELECT = formEls.DELIVERY.$COUNTRY_SELECT[0];
 
         formEls.$REVIEW_DELIVERY_ADDRESS.text(textUtils.mergeValues([
-            getGiftDetails(),
             formEls.DELIVERY.$ADDRESS1.val(),
             formEls.DELIVERY.$ADDRESS2.val(),
             formEls.DELIVERY.$TOWN.val(),


### PR DESCRIPTION
## What does this change?
This fixes a bug we found whilst testing the newspaper checkout for the Waitrose campaign which was causing the applied promo code to be prepended to the delivery address in the review section.

Strangely this was being called by the `getGiftDetails()` function which seemed to be just picking up the promo code and returning it as though it was a gift recipient. 

We are not selling gifts through this site any more and are about to turn it all off anyway so I've just removed the function rather than spending too much time trying to work out what's going on.