### PR TITLE
Update the packshot image on the newspaper checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ public/images
 public/javascripts
 public/stylesheets
 .vscode/settings.json
+/.bsp

--- a/app/views/support/PlanOps.scala
+++ b/app/views/support/PlanOps.scala
@@ -65,7 +65,7 @@ object PlanOps {
         )
       case _ =>
         ResponsiveImageGroup(
-          availableImages = ResponsiveImageGenerator("ffef3e22c4546072b1f17b16751a8ad39297a8a2/0_0_1200_1308", Seq(459, 917, 1200)),
+          availableImages = ResponsiveImageGenerator("c3dbecb41fd1538d10379ec8fb557d54c1bdac10/0_0_459_500", Seq(459)),
           altText = Some("Stack of The Guardian newspapers")
         )
     }


### PR DESCRIPTION
## What does this change?
The packshot image on subscribe hasn't been updated for years so we're updating it for the Waitrose promotion.
<img width="375" alt="Screen Shot 2022-02-14 at 11 42 31" src="https://user-images.githubusercontent.com/181371/153858189-7026dc7c-3b7d-4928-808b-95a9788cd2ab.png">
